### PR TITLE
feat: cordis-group + cordis-loader (loader port phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "cordis-group"
+version = "0.0.1"
+dependencies = [
+ "cordis-rs",
+]
+
+[[package]]
 name = "cordis-include"
 version = "0.0.2"
 dependencies = [
@@ -18,6 +25,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+]
+
+[[package]]
+name = "cordis-loader"
+version = "0.0.1"
+dependencies = [
+ "cordis-group",
+ "cordis-include",
+ "cordis-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/dshbox/cordis-rs"
 
 [workspace.dependencies]
 cordis-rs = { version = "0.4.1", path = "crates/cordis" }
+cordis-group = { version = "0.0.1", path = "crates/cordis-group" }
+cordis-include = { version = "0.0.2", path = "crates/cordis-include" }
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/TODO.md
+++ b/TODO.md
@@ -19,21 +19,24 @@ test-only nit).
   more loudly or removing.
 - `Value` (and thus `Config`) has no `PartialEq`/`Display`; plugin config
   comparison in `update_value` relies on `Arc` pointer identity (`ptr_eq`).
-  Two structurally equal configs are treated as different allocations. Fine
-  today; revisit if config diffing is ever exposed.
+  Two structurally equal configs are treated as different allocations.
+  Resolution (2026-08-17): keep as-is. The loader stack passes
+  `cordis_include::Node` as config, which carries structural `PartialEq`,
+  so entry-level config diffing never depends on `Value` identity.
 
 ## Behavior gaps (parity questions)
 
 - `ReflectService::set_value` replaces a service value without advancing its
   generation or notifying injecting fibers (documented since the review).
-  Upstream cordis may re-evaluate dependents on set; verify against 4.x and
-  decide whether to notify automatically.
-- `Fiber::await_idle` blocks on the transition mutex and documents a
-  same-thread deadlock hazard. A try-based variant (`idle()` returning bool)
-  would give lifecycle callbacks a safe probe.
+  Resolution (2026-08-17): verified against upstream 4.x
+  (`vendor/cordis/src/reflect.ts`, `ReflectService.set`): upstream also only
+  assigns `impl.value = value` with no re-evaluation. Keep the current
+  semantics and the manual `notify()` escape hatch; the loader wraps
+  entry-level `inject` into plugin `Inject` declarations, so service
+  add/remove already reconciles dependents through the core fiber machinery.
 
 ## Test hygiene
 
-- `src/effect.rs` tests use bare `.lock().unwrap()` (lines ~270, ~276)
-  instead of the poison-tolerant `utils::lock` used everywhere else.
-  Test-only; align for consistency.
+- ~~`src/effect.rs` tests use bare `.lock().unwrap()` (lines ~270, ~276)
+  instead of the poison-tolerant `utils::lock` used everywhere else.~~
+  Fixed 2026-08-17 alongside the `Fiber::idle` addition.

--- a/crates/cordis-group/Cargo.toml
+++ b/crates/cordis-group/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cordis-group"
+version = "0.0.1"
+description = "Nested plugin groups with cascading disable for the cordis-rs plugin framework"
+keywords = ["cordis", "plugin", "group", "lifecycle"]
+categories = ["rust-patterns"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cordis-rs.workspace = true

--- a/crates/cordis-group/src/lib.rs
+++ b/crates/cordis-group/src/lib.rs
@@ -1,0 +1,49 @@
+//! Nested plugin groups with cascading disable for
+//! [cordis-rs](https://crates.io/crates/cordis-rs).
+//!
+//! A group is an entry with a `group` array in the config file (see
+//! `cordis-include`). At runtime the loader starts each group entry as a
+//! [`Group`] fiber and starts the child entries *beneath that fiber's
+//! context*: disposing the group fiber cascades to the whole subtree, and a
+//! `disabled` flag anywhere on the ancestor chain keeps the subtree from
+//! starting at all (the include tree's `enabled()` walk).
+//!
+//! The plugin itself is deliberately a no-op nesting marker — upstream
+//! cordis' `plugin-group` is similarly tiny. All orchestration lives in
+//! `cordis-loader`, which registers [`GROUP_NAME`] in its builtin registry.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use cordis::utils::BoxFuture;
+use cordis::{Config, Context, Plugin, PluginHandle, PluginOutput, Result};
+
+/// Entry name that marks a group (`name: group` in the config file).
+pub const GROUP_NAME: &str = "group";
+
+/// Nesting marker plugin for group entries.
+///
+/// Starting a group produces an active fiber whose context scopes the
+/// subtree's fibers and effects; the loader is the intended driver.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Group;
+
+impl Group {
+    /// A fresh handle around a [`Group`] plugin.
+    ///
+    /// Each call yields a distinct [`cordis::PluginKey`] identity, matching
+    /// one handle per entry.
+    pub fn handle() -> PluginHandle {
+        PluginHandle::new(Group)
+    }
+}
+
+impl Plugin for Group {
+    fn name(&self) -> &str {
+        GROUP_NAME
+    }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async { Ok(PluginOutput::default()) })
+    }
+}

--- a/crates/cordis-group/tests/group.rs
+++ b/crates/cordis-group/tests/group.rs
@@ -1,0 +1,42 @@
+//! Group fiber nesting: children started under the group's context die with
+//! it — the model the loader relies on.
+
+use cordis::{Context, FiberState, Inject, PluginOutput, plugin_sync};
+use cordis_group::{GROUP_NAME, Group};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn group_plugin_starts_active_under_its_registered_name() {
+    let root = Context::new();
+    let fiber = root.plugin_default(Group::handle());
+    fiber.try_wait().unwrap();
+    assert_eq!(fiber.name(), GROUP_NAME);
+    assert_eq!(fiber.state(), FiberState::Active);
+}
+
+#[test]
+fn children_started_under_the_group_context_cascade_on_dispose() {
+    let root = Context::new();
+    let group = root.plugin_default(Group::handle());
+    group.try_wait().unwrap();
+
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let group_ctx = group.context().expect("group context");
+    let child = group_ctx.plugin_default(plugin_sync::<(), _>("child", Inject::default(), {
+        let stopped = stopped.clone();
+        move |ctx, _| {
+            let stopped = stopped.clone();
+            ctx.fiber()?.effect("stop", move || {
+                stopped.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })?;
+            Ok(PluginOutput::none())
+        }
+    }));
+    child.try_wait().unwrap();
+
+    group.dispose().unwrap();
+    assert_eq!(child.state(), FiberState::Disposed);
+    assert_eq!(stopped.load(Ordering::SeqCst), 1);
+}

--- a/crates/cordis-include/src/options.rs
+++ b/crates/cordis-include/src/options.rs
@@ -73,4 +73,14 @@ impl EntryOptions {
         self.disabled = disabled;
         self
     }
+
+    /// Declare services that must be active before this entry starts.
+    pub fn with_inject<I, S>(mut self, inject: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.inject = inject.into_iter().map(Into::into).collect();
+        self
+    }
 }

--- a/crates/cordis-include/src/tree.rs
+++ b/crates/cordis-include/src/tree.rs
@@ -205,6 +205,9 @@ impl EntryTree {
             .map(|child| (child.id().to_string(), child.clone()))
             .collect();
         let mut reserved = self.ids();
+        // The entry's own id is identity, not a duplicate; reuse and
+        // subtree ids are already excluded above.
+        reserved.remove(entry.id());
         for key in pool.keys() {
             reserved.remove(key);
         }

--- a/crates/cordis-loader/Cargo.toml
+++ b/crates/cordis-loader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cordis-loader"
+version = "0.0.1"
+description = "Config-file driven plugin loader for the cordis-rs plugin framework"
+keywords = ["cordis", "plugin", "loader", "config", "lifecycle"]
+categories = ["config", "rust-patterns"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+# Hot reload of the entry file through cordis-include's watcher.
+watch = ["cordis-include/watch"]
+
+[dependencies]
+cordis-group.workspace = true
+cordis-include.workspace = true
+cordis-rs.workspace = true

--- a/crates/cordis-loader/src/error.rs
+++ b/crates/cordis-loader/src/error.rs
@@ -1,0 +1,48 @@
+//! Error type combining core and include failures.
+
+use cordis::CordisError;
+use cordis_include::IncludeError;
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Result alias used throughout `cordis-loader`.
+pub type Result<T> = std::result::Result<T, LoaderError>;
+
+/// Errors produced while loading entries and driving fibers.
+#[derive(Debug)]
+pub enum LoaderError {
+    /// A core lifecycle or registry operation failed.
+    Cordis(CordisError),
+    /// The entry tree or config file layer failed.
+    Include(IncludeError),
+}
+
+impl fmt::Display for LoaderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cordis(error) => write!(f, "{error}"),
+            Self::Include(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl StdError for LoaderError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Cordis(error) => Some(error),
+            Self::Include(error) => Some(error),
+        }
+    }
+}
+
+impl From<CordisError> for LoaderError {
+    fn from(error: CordisError) -> Self {
+        Self::Cordis(error)
+    }
+}
+
+impl From<IncludeError> for LoaderError {
+    fn from(error: IncludeError) -> Self {
+        Self::Include(error)
+    }
+}

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -1,0 +1,77 @@
+//! Config-file driven plugin loader for
+//! [cordis-rs](https://crates.io/crates/cordis-rs).
+//!
+//! This crate is the assembly half of porting upstream Cordis' loader: it
+//! connects `cordis-include`'s entry trees to cordis fibers. Everything a
+//! config-driven cordis application needs is re-exported here — depend on
+//! `cordis-loader` alone.
+//!
+//! # How it works
+//!
+//! - **Static registry** ([`PluginRegistry`]) replaces upstream's dynamic
+//!   `import(name)`: register plugins at startup, entries resolve by name.
+//!   The `group` builtin is pre-registered.
+//! - **Startup**: [`Loader::open`] reads the entry file (writing
+//!   `initial` when missing), builds the [`EntryTree`], and starts every
+//!   enabled entry — group entries as `cordis_group::Group` fibers, children
+//!   beneath their parent group's context, so disposing a group cascades.
+//! - **Config**: entries carry a `cordis_include::Node` config (never `()`);
+//!   loader plugins read it via `config.downcast::<Node>()`. `${{ env.X }}`
+//!   templates expand at hand-off time; the file keeps the raw text.
+//! - **Reload** ([`Loader::reload`], wired to the `watch` feature):
+//!   re-read the file, diff the tree, and reconcile fibers — created entries
+//!   start, removed subtrees stop, moved entries restart under their new
+//!   parent, config-only changes patch in place via `Fiber::update_value`.
+//! - **Inject**: an entry's `inject` list is merged into the plugin's own
+//!   declaration, so the core fiber machinery reconciles entries when
+//!   services come and go — "hot-swapped service restarts its dependents"
+//!   for free.
+//! - **Self-kill vs. removal**: a fiber that reaches `Disposed` outside
+//!   loader operation was killed by its own plugin; the loader persists
+//!   `disabled: true` for that entry. Removing an entry from the file just
+//!   stops it.
+//! - **Write-back**: [`Loader::update_config`] is the runtime entry point —
+//!   it updates the fiber *and* persists the config. Reloads never echo
+//!   back (file-level suspend).
+//!
+//! # Example
+//!
+//! ```
+//! use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+//!
+//! let root = cordis::Context::new();
+//! let mut registry = PluginRegistry::new();
+//! // registry.register_plugin(my_plugin);  // your plugins, by name
+//! let config = LoaderConfig::new("cordis.yml").with_registry(registry);
+//! let loader = Loader::open(&root, config)?;
+//! # assert!(loader.tree().entries().is_empty());
+//! # Ok::<(), cordis_loader::LoaderError>(())
+//! ```
+//!
+//! Register the plugins first (the `group` builtin is pre-registered), then
+//! open; plugins registered later via [`Loader::register_plugin`] are picked
+//! up by the next [`Loader::reload`].
+//!
+//! # Not in scope yet
+//!
+//! The `import` entry kind (mounting a sub-file), isolate/service
+//! migration, the `loader/entry-init`-style event family, and debounced
+//! merged writes are future work.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod loader;
+pub mod registry;
+
+pub use cordis_group::Group;
+pub use cordis_include::{Document, Entry, EntryOptions, EntryTree, LoaderFile, Node};
+pub use error::{LoaderError, Result};
+pub use loader::{Loader, LoaderConfig, LoaderHandle};
+pub use registry::PluginRegistry;
+
+/// Lock a mutex tolerantly, treating a poisoned lock as unlocked.
+pub(crate) fn lock<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -1,0 +1,462 @@
+//! The loader: entry tree ⇄ fiber lifecycle, file reloads, write-back.
+
+use crate::error::{LoaderError, Result};
+use crate::lock;
+use crate::registry::{PluginRegistry, WithInject};
+use cordis::{Config, Context, EffectHandle, EventOptions, Fiber, FiberState, PluginHandle};
+use cordis_include::{Entry, EntryOptions, EntryTree, LoaderFile, Node, PluginResolver, TreeDiff};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, Weak};
+
+/// Where the loader reads and writes its entry file.
+#[derive(Clone, Default)]
+pub struct LoaderConfig {
+    /// Path to the entry config file (`.yml`/`.yaml`/`.json`).
+    pub filename: PathBuf,
+    /// Document written on first run when the file does not exist yet.
+    pub initial: Option<cordis_include::Document>,
+    /// Plugin registry used to resolve entry names; defaults to a fresh
+    /// [`PluginRegistry`] with only the `group` builtin.
+    pub registry: Option<PluginRegistry>,
+}
+
+impl LoaderConfig {
+    /// Configure a loader around `filename`.
+    pub fn new(filename: impl Into<PathBuf>) -> Self {
+        Self {
+            filename: filename.into(),
+            initial: None,
+            registry: None,
+        }
+    }
+
+    /// Provide the document written when the file is missing.
+    pub fn with_initial(mut self, initial: cordis_include::Document) -> Self {
+        self.initial = Some(initial);
+        self
+    }
+
+    /// Provide the plugin registry entries resolve against.
+    pub fn with_registry(mut self, registry: PluginRegistry) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+}
+
+/// Bookkeeping guarded by the loader's state lock.
+struct LoaderState {
+    /// fiber uid -> entry, for status-event routing and lookups.
+    entries: HashMap<u64, Entry>,
+    /// Non-zero while the loader itself drives fibers; self-kill detection
+    /// ignores fibers disposed in that window.
+    operating: u16,
+    /// Last background error (reload callback, self-kill persistence).
+    last_error: Option<String>,
+    /// Keeps the internal listeners and the `loader` service registered.
+    _keep_alive: Vec<EffectHandle>,
+}
+
+/// Cheap cloneable loader handle.
+#[derive(Clone)]
+pub struct Loader {
+    pub(crate) inner: Arc<LoaderInner>,
+}
+
+pub(crate) struct LoaderInner {
+    root: Context,
+    file: LoaderFile,
+    tree: EntryTree,
+    registry: Mutex<PluginRegistry>,
+    state: Mutex<LoaderState>,
+}
+
+/// Weak service handle injected as `loader`, avoiding a reference cycle
+/// between the root context and the loader.
+///
+/// Recover the loader with [`LoaderHandle::upgrade`].
+pub struct LoaderHandle {
+    inner: Weak<LoaderInner>,
+}
+
+impl LoaderHandle {
+    /// Upgrade to a strong loader reference, if still alive.
+    pub fn upgrade(&self) -> Option<Loader> {
+        self.inner.upgrade().map(|inner| Loader { inner })
+    }
+}
+
+impl Loader {
+    /// Open (creating if needed) the entry file, load the tree, and start
+    /// every enabled entry.
+    ///
+    /// Entries that fail to resolve or start do not abort the open; the
+    /// error is recorded and retrievable via [`Loader::last_error`], and the
+    /// offending entry simply has no (or a failed) fiber.
+    pub fn open(root: &Context, config: LoaderConfig) -> Result<Loader> {
+        let file = LoaderFile::open(&config.filename)?;
+        if !file.path().exists() {
+            if let Some(initial) = &config.initial {
+                file.write(initial)?;
+            }
+        }
+        let tree = EntryTree::new();
+        tree.update(file.read()?.entries)?;
+        let inner = Arc::new(LoaderInner {
+            root: root.clone(),
+            file,
+            tree,
+            registry: Mutex::new(config.registry.unwrap_or_default()),
+            state: Mutex::new(LoaderState {
+                entries: HashMap::new(),
+                operating: 0,
+                last_error: None,
+                _keep_alive: Vec::new(),
+            }),
+        });
+
+        // The status listener routes plugin-initiated disposals (self-kill)
+        // back into the config file as `disabled: true`.
+        let weak = Arc::downgrade(&inner);
+        let status = root.events().on(
+            "internal/status",
+            move |event| {
+                if let Some(inner) = weak.upgrade() {
+                    handle_status(&inner, &event)?;
+                }
+                Ok(None)
+            },
+            EventOptions {
+                global: true,
+                ..EventOptions::default()
+            },
+        )?;
+        let service = root.provide_arc(
+            "loader",
+            Arc::new(LoaderHandle {
+                inner: Arc::downgrade(&inner),
+            }),
+        )?;
+        lock(&inner.state)._keep_alive = vec![status, service];
+
+        let loader = Loader { inner };
+        loader.start_all();
+        Ok(loader)
+    }
+
+    /// The root context the loader operates on.
+    pub fn context(&self) -> &Context {
+        &self.inner.root
+    }
+
+    /// The entry tree.
+    pub fn tree(&self) -> &EntryTree {
+        &self.inner.tree
+    }
+
+    /// The entry config file.
+    pub fn file(&self) -> &LoaderFile {
+        &self.inner.file
+    }
+
+    /// The plugin registry (a clone of the current state); populate it via
+    /// [`LoaderConfig::with_registry`] before open, or
+    /// [`Loader::register_plugin`] later.
+    pub fn registry(&self) -> PluginRegistry {
+        lock(&self.inner.registry).clone()
+    }
+
+    /// Register one plugin instance by its own name; picked up by the next
+    /// reload (or immediately for not-yet-started entries).
+    pub fn register_plugin<P: cordis::Plugin>(&self, plugin: P) {
+        lock(&self.inner.registry).register_plugin(plugin);
+    }
+
+    /// Register a handle factory under a name.
+    pub fn register<F>(&self, name: impl Into<String>, factory: F)
+    where
+        F: Fn() -> PluginHandle + Send + Sync + 'static,
+    {
+        lock(&self.inner.registry).register(name, factory);
+    }
+
+    /// The last background error recorded by the loader, if any.
+    pub fn last_error(&self) -> Option<String> {
+        lock(&self.inner.state).last_error.clone()
+    }
+
+    /// The entry whose fiber is `fiber`, if the loader started it.
+    pub fn locate(&self, fiber: &Fiber) -> Option<Entry> {
+        let state = lock(&self.inner.state);
+        if let Some(uid) = fiber.uid() {
+            return state.entries.get(&uid).cloned();
+        }
+        state
+            .entries
+            .values()
+            .find(|entry| entry.fiber().is_some_and(|started| started.ptr_eq(fiber)))
+            .cloned()
+    }
+
+    /// Start every enabled, unstarted entry, parents before children.
+    fn start_all(&self) {
+        for entry in self.inner.tree.entries() {
+            if let Err(error) = start_entry(&self.inner, &entry) {
+                self.record_error(error);
+            }
+        }
+    }
+
+    /// Re-read the entry file and apply the difference to the fibers.
+    ///
+    /// Created entries start (parents first), removed subtrees stop, moved
+    /// entries restart under their new parent, updated entries are patched
+    /// in place when only config changed and restarted otherwise. While the
+    /// reload runs, the file is suspended, so the patches it causes are not
+    /// written back; generated ids are persisted afterwards.
+    pub fn reload(&self) -> Result<TreeDiff> {
+        let inner = &self.inner;
+        let _suspend = inner.file.suspend();
+        let document = inner.file.read()?;
+        let diff = inner.tree.update(document.entries)?;
+
+        for entry in &diff.removed {
+            if let Err(error) = stop_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
+        for entry in &diff.moved {
+            if let Err(error) = stop_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
+        for entry in &diff.updated {
+            if let Err(error) = patch_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
+        for entry in &diff.created {
+            if let Err(error) = start_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
+        drop(_suspend);
+
+        // Entries created without explicit ids had one generated; persist
+        // it so the next reload can match them.
+        if !diff.created.is_empty() {
+            write_back(inner)?;
+        }
+        Ok(diff)
+    }
+
+    /// Change one entry's config at runtime: the fiber is updated (and
+    /// restarted when active) and the new config is persisted to the file.
+    pub fn update_config(&self, id: &str, config: Node) -> Result<()> {
+        let inner = &self.inner;
+        let entry = inner.tree.resolve(id).ok_or_else(|| {
+            LoaderError::Include(cordis_include::IncludeError::EntryNotFound { id: id.to_owned() })
+        })?;
+        if let Some(fiber) = entry.fiber() {
+            fiber.update_value(Config::new(config.clone()))?;
+        }
+        let mut options = entry_options_with_children(&entry);
+        options.config = Some(config);
+        inner
+            .tree
+            .update_entry(&entry.path(), options, None, None)?;
+        write_back(inner)
+    }
+
+    /// Stop every entry and clear the fiber map. The root context itself
+    /// stays usable.
+    pub fn dispose(&self) -> Result<()> {
+        let inner = &self.inner;
+        for entry in inner.tree.top_level() {
+            if let Err(error) = stop_entry(inner, &entry) {
+                self.record_error(error);
+            }
+        }
+        Ok(())
+    }
+
+    /// Watch the entry file for external changes and reload on them
+    /// (`watch` feature). Reload errors are recorded in
+    /// [`Loader::last_error`].
+    #[cfg(feature = "watch")]
+    pub fn watch(&self) -> Result<cordis_include::FileWatcher> {
+        let loader = self.clone();
+        self.inner
+            .file
+            .watch(move || {
+                if let Err(error) = loader.reload() {
+                    loader.record_error(error);
+                }
+            })
+            .map_err(LoaderError::Include)
+    }
+
+    fn record_error(&self, error: LoaderError) {
+        lock(&self.inner.state).last_error = Some(error.to_string());
+    }
+}
+
+/// Increment `operating` for the lifetime of the guard, so disposals driven
+/// by the loader itself are not mistaken for self-kill.
+struct OperatingGuard<'a> {
+    state: &'a Mutex<LoaderState>,
+}
+
+impl<'a> OperatingGuard<'a> {
+    fn new(state: &'a Mutex<LoaderState>) -> Self {
+        lock(state).operating += 1;
+        Self { state }
+    }
+}
+
+impl Drop for OperatingGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = lock(self.state);
+        state.operating = state.operating.saturating_sub(1);
+    }
+}
+
+/// Start one entry's fiber beneath its parent group's context.
+fn start_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
+    if !entry.enabled() || entry.fiber().is_some() {
+        return Ok(());
+    }
+    let name = entry.name();
+    let handle: PluginHandle = lock(&inner.registry)
+        .resolve(&name)
+        .map_err(LoaderError::Cordis)?;
+    let inject = entry.options().inject;
+    let handle = WithInject::wrap(handle, inject);
+    let config = entry.resolved_config()?.unwrap_or(Node::Null);
+    let parent_ctx = entry
+        .parent()
+        .and_then(|parent| parent.fiber())
+        .and_then(|fiber| fiber.context())
+        .unwrap_or_else(|| inner.root.clone());
+    let fiber = parent_ctx.plugin(handle, config);
+    entry.set_fiber(Some(fiber.clone()));
+    if let Some(uid) = fiber.uid() {
+        lock(&inner.state).entries.insert(uid, entry.clone());
+    }
+    Ok(())
+}
+
+/// Stop one entry's fiber (children first for bookkeeping; disposal of a
+/// group cascades regardless).
+fn stop_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
+    for child in entry.children() {
+        stop_entry(inner, &child)?;
+    }
+    let Some(fiber) = entry.fiber() else {
+        return Ok(());
+    };
+    entry.set_fiber(None);
+    if let Some(uid) = fiber.uid() {
+        lock(&inner.state).entries.remove(&uid);
+    }
+    let _guard = OperatingGuard::new(&inner.state);
+    fiber.dispose().map_err(LoaderError::Cordis)
+}
+
+/// Apply an options change to a live entry: restart when the plugin identity
+/// changed (name, inject) or the enabled flag flipped; patch the config in
+/// place otherwise.
+fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
+    if !entry.enabled() {
+        return stop_entry(inner, entry);
+    }
+    let Some(fiber) = entry.fiber() else {
+        return start_entry(inner, entry);
+    };
+    let options = entry.options();
+    let inject_changed =
+        fiber.inject().names().collect::<Vec<_>>() != options.inject.iter().collect::<Vec<_>>();
+    if fiber.name() != options.name || inject_changed {
+        stop_entry(inner, entry)?;
+        return start_entry(inner, entry);
+    }
+    let new_config = entry.resolved_config()?.unwrap_or(Node::Null);
+    let current = fiber
+        .config()
+        .downcast::<Node>()
+        .ok()
+        .map(|node| (*node).clone());
+    if current.as_ref() != Some(&new_config) {
+        fiber.update_value(Config::new(new_config))?;
+    }
+    Ok(())
+}
+
+/// Serialize an entry together with its live subtree (used by update paths
+/// that must not disturb children).
+fn entry_options_with_children(entry: &Entry) -> EntryOptions {
+    let mut options = entry.options();
+    options.group = entry
+        .children()
+        .iter()
+        .map(entry_options_with_children)
+        .collect();
+    options
+}
+
+/// Persist the current tree, preserving unknown top-level file keys.
+fn write_back(inner: &LoaderInner) -> Result<()> {
+    let mut document = inner.file.read()?;
+    document.entries = inner.tree.serialize();
+    inner.file.write(&document)?;
+    Ok(())
+}
+
+/// Route `internal/status` disposals: a fiber that reached `Disposed`
+/// outside loader operation was killed by its own plugin, so record
+/// `disabled: true` in the tree and persist it.
+fn handle_status(inner: &LoaderInner, event: &cordis::Event) -> cordis::EventResult {
+    let Some(fiber) = event.arg::<Fiber>(0).ok().flatten() else {
+        return Ok(None);
+    };
+    if fiber.state() != FiberState::Disposed {
+        return Ok(None);
+    }
+    if lock(&inner.state).operating > 0 {
+        return Ok(None);
+    }
+    let Some(entry) = lock(&inner.state)
+        .entries
+        .values()
+        .find(|entry| entry.fiber().is_some_and(|started| started.ptr_eq(&fiber)))
+        .cloned()
+    else {
+        return Ok(None);
+    };
+    if let Err(error) = persist_self_dispose(inner, &entry) {
+        lock(&inner.state).last_error = Some(error.to_string());
+    }
+    Ok(None)
+}
+
+/// A plugin disposed itself: unmap the entry and persist `disabled: true`.
+fn persist_self_dispose(inner: &LoaderInner, entry: &Entry) -> Result<()> {
+    {
+        let mut state = lock(&inner.state);
+        let key = state
+            .entries
+            .iter()
+            .find(|(_, mapped)| Entry::ptr_eq(mapped, entry))
+            .map(|(uid, _)| *uid);
+        if let Some(uid) = key {
+            state.entries.remove(&uid);
+        }
+    }
+    entry.set_fiber(None);
+    let mut options = entry_options_with_children(entry);
+    options.disabled = true;
+    inner
+        .tree
+        .update_entry(&entry.path(), options, None, None)?;
+    write_back(inner)
+}

--- a/crates/cordis-loader/src/registry.rs
+++ b/crates/cordis-loader/src/registry.rs
@@ -1,0 +1,128 @@
+//! Static plugin registry — the Rust replacement for upstream's dynamic
+//! `import(name)`.
+
+use cordis::utils::BoxFuture;
+use cordis::{Config, Context, Inject, Plugin, PluginHandle, PluginOutput, Result};
+use cordis_group::Group;
+use cordis_include::resolver::unknown_plugin;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A factory producing fresh plugin handles.
+type Factory = Arc<dyn Fn() -> PluginHandle + Send + Sync>;
+
+/// Name-to-factory plugin registry, populated at build or startup time.
+///
+/// Resolving the same name twice yields distinct [`PluginHandle`]s (and
+/// thus distinct [`cordis::PluginKey`] identities), mirroring one plugin
+/// instance per entry. The registry pre-registers [`cordis_group`]'s
+/// `group` marker.
+#[derive(Clone, Default)]
+pub struct PluginRegistry {
+    factories: HashMap<String, Factory>,
+}
+
+impl PluginRegistry {
+    /// An empty registry with the `group` builtin registered.
+    pub fn new() -> Self {
+        let mut registry = Self::default();
+        registry.register("group", Group::handle);
+        registry
+    }
+
+    /// Register a handle factory under `name`.
+    pub fn register<F>(&mut self, name: impl Into<String>, factory: F)
+    where
+        F: Fn() -> PluginHandle + Send + Sync + 'static,
+    {
+        self.factories.insert(name.into(), Arc::new(factory));
+    }
+
+    /// Register one plugin instance under its own name; every resolve then
+    /// wraps a shared clone of it in a fresh handle.
+    pub fn register_plugin<P: Plugin>(&mut self, plugin: P) {
+        let name = plugin.name().to_owned();
+        let shared = Arc::new(plugin);
+        self.register(name, move || {
+            PluginHandle::new(SharedPlugin(shared.clone()))
+        });
+    }
+
+    /// Registered names, unordered.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.factories.keys().map(String::as_str)
+    }
+}
+
+impl cordis_include::PluginResolver for PluginRegistry {
+    fn resolve(&self, name: &str) -> Result<PluginHandle> {
+        match self.factories.get(name) {
+            Some(factory) => Ok(factory()),
+            None => Err(unknown_plugin(name)),
+        }
+    }
+}
+
+/// Wraps one shared plugin instance so clones produce distinct handles.
+struct SharedPlugin<P>(Arc<P>);
+
+impl<P: Plugin> Plugin for SharedPlugin<P> {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn inject(&self) -> &Inject {
+        self.0.inject()
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        self.0.validate_config(config)
+    }
+
+    fn apply(&self, ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        self.0.apply(ctx, config)
+    }
+}
+
+/// Wraps a resolved plugin, merging an entry's `inject` declaration into the
+/// plugin's own dependencies.
+///
+/// With this in place, the core fiber machinery already reconciles entries
+/// when an injected service goes away or comes back — no loader-side batch
+/// refresh needed.
+pub(crate) struct WithInject {
+    handle: PluginHandle,
+    inject: Inject,
+}
+
+impl WithInject {
+    /// Wrap `handle` unless `inject` is empty (nothing to add).
+    pub fn wrap(handle: PluginHandle, inject: Vec<String>) -> PluginHandle {
+        if inject.is_empty() {
+            handle
+        } else {
+            PluginHandle::new(WithInject {
+                handle,
+                inject: Inject::new(inject),
+            })
+        }
+    }
+}
+
+impl Plugin for WithInject {
+    fn name(&self) -> &str {
+        self.handle.name()
+    }
+
+    fn inject(&self) -> &Inject {
+        &self.inject
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        self.handle.plugin().validate_config(config)
+    }
+
+    fn apply(&self, ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        self.handle.plugin().apply(ctx, config)
+    }
+}

--- a/crates/cordis-loader/tests/loader.rs
+++ b/crates/cordis-loader/tests/loader.rs
@@ -1,0 +1,311 @@
+//! Loader end-to-end behavior over real temp files.
+
+use cordis::{Context, Fiber, FiberState, Inject, PluginHandle, PluginOutput, plugin_sync};
+use cordis_include::{Document, EntryOptions, Node, PluginResolver};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn temp_path(stem: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("cordis-loader-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("cordis.yml")
+}
+
+fn cleanup(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}
+
+/// A plugin that records starts and reads a `port` from its Node config.
+fn counting_plugin(name: &'static str, starts: Arc<AtomicUsize>) -> PluginHandle {
+    plugin_sync::<Node, _>(name, Inject::default(), move |_ctx, config| {
+        starts.fetch_add(1, Ordering::SeqCst);
+        let _port = config["port"].as_i64();
+        Ok(PluginOutput::none())
+    })
+}
+
+#[test]
+fn open_starts_enabled_entries_and_skips_disabled_ones() {
+    let path = temp_path("open");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", {
+        let starts = starts.clone();
+        move || counting_plugin("worker", starts.clone())
+    });
+    let initial = Document::with_entries(vec![
+        EntryOptions::new("worker")
+            .with_id("w1")
+            .with_config(Node::from_iter([("port".to_string(), 8080.into())])),
+        EntryOptions::new("worker")
+            .with_id("w2")
+            .with_disabled(true),
+    ]);
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(initial),
+    )
+    .unwrap();
+
+    let w1 = loader.tree().resolve("w1").unwrap();
+    let fiber = w1.fiber().unwrap();
+    fiber.try_wait().unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    assert!(loader.tree().resolve("w2").unwrap().fiber().is_none());
+    assert!(loader.last_error().is_none());
+
+    // The initial document was persisted with the generated state intact.
+    let reread = loader.file().read().unwrap();
+    assert!(
+        reread
+            .entries
+            .iter()
+            .any(|options| options.id.as_deref() == Some("w1"))
+    );
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn reload_reconciles_created_removed_updated_and_moved() {
+    let path = temp_path("reload");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", {
+        let starts = starts.clone();
+        move || counting_plugin("worker", starts.clone())
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("keep"),
+                EntryOptions::new("worker").with_id("drop"),
+            ])),
+    )
+    .unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+
+    // External edit: "keep" gets a new port, "drop" disappears, "new"
+    // appears inside a group that itself is new.
+    std::fs::write(
+        &path,
+        "entries:\n  - id: keep\n    name: worker\n    config:\n      port: 9090\n  - id: grp\n    name: group\n    group:\n      - id: new\n        name: worker\n",
+    )
+    .unwrap();
+    let diff = loader.reload().unwrap();
+    assert!(diff.created.iter().any(|e| e.id() == "grp"));
+    assert!(diff.created.iter().any(|e| e.id() == "new"));
+    assert!(diff.updated.iter().any(|e| e.id() == "keep"));
+    assert!(diff.removed.iter().any(|e| e.id() == "drop"));
+
+    // Config-only change patched the fiber without a restart: starts went
+    // 2 -> 3 (update_value restarts "keep"), and the new entries started.
+    assert_eq!(starts.load(Ordering::SeqCst), 4);
+    let keep = loader.tree().resolve("keep").unwrap();
+    let config = keep.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(config["port"].as_i64(), Some(9090));
+    assert!(loader.tree().resolve("drop").is_none());
+    assert!(loader.tree().resolve("grp:new").unwrap().fiber().is_some());
+
+    // Removing the group cascades to its child.
+    std::fs::write(&path, "entries:\n  - id: keep\n    name: worker\n").unwrap();
+    loader.reload().unwrap();
+    assert!(loader.tree().resolve("grp").is_none());
+    let child_gone = loader
+        .tree()
+        .entries()
+        .iter()
+        .all(|entry| entry.id() != "new" || entry.fiber().is_none());
+    assert!(child_gone);
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn self_disposed_plugin_is_disabled_in_the_file() {
+    let path = temp_path("selfkill");
+    let victim_fiber: Arc<Mutex<Option<Fiber>>> = Arc::new(Mutex::new(None));
+    let mut registry = PluginRegistry::new();
+    registry.register("victim", {
+        let victim_fiber = victim_fiber.clone();
+        move || {
+            let victim_fiber = victim_fiber.clone();
+            plugin_sync::<Node, _>("victim", Inject::default(), move |ctx, _config| {
+                *victim_fiber.lock().unwrap() = Some(ctx.fiber()?);
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("victim").with_id("v1"),
+            ])),
+    )
+    .unwrap();
+    let entry = loader.tree().resolve("v1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+
+    // The plugin tears itself down outside the loader.
+    victim_fiber
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap()
+        .dispose()
+        .unwrap();
+
+    assert!(entry.fiber().is_none());
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("disabled: true"), "{text}");
+    // Loader-driven disposals must NOT be misclassified: stop the loader and
+    // confirm no further rewrite happened beyond the persisted state.
+    let before = std::fs::read_to_string(&path).unwrap();
+    loader.dispose().unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+    cleanup(&path);
+}
+
+#[test]
+fn entry_level_inject_waits_for_the_service() {
+    let path = temp_path("inject");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("consumer", {
+        let starts = starts.clone();
+        move || {
+            let starts = starts.clone();
+            plugin_sync::<Node, _>("consumer", Inject::default(), move |ctx, _config| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                let _service = ctx.require::<u32>("svc")?;
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("consumer")
+                    .with_id("c1")
+                    .with_inject(["svc"]),
+            ])),
+    )
+    .unwrap();
+    let entry = loader.tree().resolve("c1").unwrap();
+    assert_eq!(entry.fiber().unwrap().state(), FiberState::Pending);
+
+    // Service appears: the entry activates through the core machinery.
+    let _svc = root.provide("svc", 7_u32).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if entry.fiber().unwrap().state() == FiberState::Active {
+            break;
+        }
+        assert!(Instant::now() < deadline, "entry never became active");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+    // Service goes away: the entry demotes to Pending again.
+    _svc.dispose().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if entry.fiber().unwrap().state() == FiberState::Pending {
+            break;
+        }
+        assert!(Instant::now() < deadline, "entry never returned to pending");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn update_config_restarts_the_fiber_and_persists() {
+    let path = temp_path("update");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", {
+        let starts = starts.clone();
+        move || counting_plugin("worker", starts.clone())
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker")
+                    .with_id("w1")
+                    .with_config(Node::from_iter([("port".to_string(), 1.into())])),
+            ])),
+    )
+    .unwrap();
+    loader
+        .tree()
+        .resolve("w1")
+        .unwrap()
+        .fiber()
+        .unwrap()
+        .try_wait()
+        .unwrap();
+
+    let new_config = Node::from_iter([("port".to_string(), 2.into())]);
+    loader.update_config("w1", new_config).unwrap();
+
+    let entry = loader.tree().resolve("w1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+    let config = entry.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(config["port"].as_i64(), Some(2));
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("port: 2"), "{text}");
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn registry_resolves_distinct_identities_and_rejects_unknown_names() {
+    let registry = PluginRegistry::new();
+    let group = registry.resolve("group").unwrap();
+    let group_again = registry.resolve("group").unwrap();
+    assert_ne!(group.key(), group_again.key());
+    assert!(registry.resolve("nope").is_err());
+}
+
+#[test]
+fn loader_is_exposed_as_a_weak_service() {
+    let path = temp_path("service");
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path).with_initial(Document::default()),
+    )
+    .unwrap();
+    let handle = root
+        .require::<cordis_loader::LoaderHandle>("loader")
+        .unwrap();
+    assert!(handle.upgrade().is_some());
+    drop(loader);
+    assert!(handle.upgrade().is_none());
+    cleanup(&path);
+}

--- a/crates/cordis/src/effect.rs
+++ b/crates/cordis/src/effect.rs
@@ -267,14 +267,14 @@ mod tests {
                 Weak::new(),
                 "child",
                 AsyncDisposer::from_sync(move || {
-                    runs.lock().unwrap().push(id);
+                    lock(&runs).push(id);
                     Ok(())
                 }),
             );
             parent.adopt(child).unwrap();
         }
         block_on(parent.dispose()).unwrap();
-        assert_eq!(*runs.lock().unwrap(), vec![3, 2]);
+        assert_eq!(*lock(&runs), vec![3, 2]);
     }
 
     /// Regression: adopt checked `disposed` outside the children lock, so a

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -559,6 +559,20 @@ impl Fiber {
         }
     }
 
+    /// Whether no lifecycle transition is in progress on this fiber.
+    ///
+    /// The non-blocking counterpart of [`await_idle`](Self::await_idle):
+    /// lifecycle callbacks and plugin `apply` run on the fiber's own thread
+    /// with the transition mutex held, so they can probe `idle()` safely but
+    /// must never block on `await_idle`. This is a pure probe — it does not
+    /// drain the dirty flag or trigger a reconcile.
+    pub fn idle(&self) -> bool {
+        matches!(
+            self.inner.transition.try_lock(),
+            Ok(_) | Err(std::sync::TryLockError::Poisoned(_))
+        )
+    }
+
     /// Async equivalent of [`try_wait`](Self::try_wait): also never suspends.
     pub async fn await_ready(&self) -> Result<Fiber> {
         self.try_wait()
@@ -708,6 +722,24 @@ mod tests {
     use crate::{Inject, PluginOutput};
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn idle_reflects_and_probes_transitions() {
+        let root = Context::new();
+        let observed = Arc::new(std::sync::Mutex::new(Vec::<bool>::new()));
+        let fiber = root.plugin_default(plugin_sync::<(), _>("probe", Inject::default(), {
+            let observed = observed.clone();
+            move |ctx, _| {
+                // apply() runs inside the fiber's own transition: the probe
+                // must report busy where await_idle would deadlock.
+                lock(&observed).push(ctx.fiber()?.idle());
+                Ok(PluginOutput::none())
+            }
+        }));
+        fiber.try_wait().unwrap();
+        assert_eq!(*lock(&observed), vec![false]);
+        assert!(fiber.idle());
+    }
 
     /// Regression: a notification landing between refresh()'s final
     /// `dirty.swap(false)` and the transition lock release used to be lost —

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -159,6 +159,15 @@ impl Fiber {
         self.inner.uid_value()
     }
 
+    /// Whether both handles refer to the same fiber instance.
+    ///
+    /// Unlike comparing [`uid`](Self::uid), this stays valid after disposal
+    /// (uids are cleared then), which is what "which entry owned this
+    /// fiber?" lookups need.
+    pub fn ptr_eq(&self, other: &Fiber) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     /// Current lifecycle state.
     pub fn state(&self) -> FiberState {
         lock(&self.inner.data).state

--- a/crates/cordis/src/registry.rs
+++ b/crates/cordis/src/registry.rs
@@ -231,7 +231,12 @@ impl PluginHandle {
         self.plugin.name()
     }
 
-    pub(crate) fn plugin(&self) -> &Arc<dyn Plugin> {
+    /// Return the wrapped dynamically dispatched plugin.
+    ///
+    /// Intended for delegation wrappers (adding inject declarations,
+    /// intercepting validate/apply) that forward to the inner plugin while
+    /// keeping their own [`PluginHandle`] identity.
+    pub fn plugin(&self) -> &Arc<dyn Plugin> {
         &self.plugin
     }
 }


### PR DESCRIPTION
## What

Phase 2 of the loader port — core enablers plus the two runtime crates. After this, only `cordis-cli` remains from the planned four-crate layout.

### Core (cordis-rs)
- `Fiber::idle()`: non-blocking probe for the `await_idle` deadlock hazard (verified inside `apply` where the transition mutex is held)
- `Fiber::ptr_eq`: identity comparison that stays valid after disposal (uids are cleared then)
- `PluginHandle::plugin()` made public for delegation wrappers
- TODO.md: `set_value` no-notify verified as upstream-4.x behavior (vendored `reflect.ts` only assigns `impl.value`); `Value` pointer-equality decision recorded (loader diffs `Node` structurally)

### cordis-include fixes
- `update_entry` no longer rejects the entry's own id as a duplicate
- `EntryOptions::with_inject` builder

### cordis-group (new)
No-op nesting marker plugin; children started beneath the group fiber's context die with it (cascade verified by test).

### cordis-loader (new)
- **PluginRegistry**: static `import(name)` replacement, distinct handle identity per resolve, `group` builtin
- **State machine**: open → start enabled entries; reload → suspended full diff (created start / removed stop / moved restart / config-only patch via `Fiber::update_value`); generated ids persisted
- **Self-kill**: fibers disposed outside loader operation persist `disabled: true`; loader-driven stops masked by an operating guard
- **Inject**: entry-level inject merged into plugin `Inject` — service hot-swap reconciles entries through core, no batch refresh needed
- **update_config**: runtime config change (fiber update + persistence); loader itself exposed as a weak `loader` service
- `watch` feature wires `LoaderFile::watch` → `reload`

One real bug was caught and fixed along the way (a same-thread mutex re-lock in the operating guard's drop). Not yet ported: `import` entries, isolate, the `loader/entry-*` event family, debounced writes.

## Verification

Full gate under pinned 1.85: fmt, clippy `-D warnings` (incl. local 1.96 for new lints), 16 test targets, `cargo doc -D warnings`, bilingual README doctests.