### PR TITLE
docs: crate READMEs + feat: cordis-cli (loader port complete)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,25 @@ jobs:
           rustdoc --test README.zh-CN.md --edition 2024
           -L dependency=target/debug/deps
           --extern cordis=target/debug/libcordis.rlib
+
+      - name: Test cordis-include README examples
+        run: >-
+          rustdoc --test crates/cordis-include/README.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_include=target/debug/libcordis_include.rlib
+
+      - name: Test cordis-group README examples
+        run: >-
+          rustdoc --test crates/cordis-group/README.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_group=target/debug/libcordis_group.rlib
+
+      - name: Test cordis-loader README examples
+        run: >-
+          rustdoc --test crates/cordis-loader/README.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_include=target/debug/libcordis_include.rlib
+          --extern cordis_loader=target/debug/libcordis_loader.rlib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cordis-cli"
+version = "0.0.1"
+dependencies = [
+ "cordis-loader",
+ "cordis-rs",
+ "ctrlc",
+]
+
+[[package]]
 name = "cordis-group"
 version = "0.0.2"
 dependencies = [
@@ -39,6 +69,29 @@ dependencies = [
 [[package]]
 name = "cordis-rs"
 version = "0.4.2"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "equivalent"
@@ -150,6 +203,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +240,21 @@ checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ license = "MIT"
 repository = "https://github.com/dshbox/cordis-rs"
 
 [workspace.dependencies]
-cordis-rs = { version = "0.4.2", path = "crates/cordis" }
+cordis-cli = { version = "0.0.1", path = "crates/cordis-cli" }
 cordis-group = { version = "0.0.2", path = "crates/cordis-group" }
 cordis-include = { version = "0.0.3", path = "crates/cordis-include" }
+cordis-loader = { version = "0.0.2", path = "crates/cordis-loader" }
+cordis-rs = { version = "0.4.2", path = "crates/cordis" }
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -315,9 +315,21 @@ Two consequences of the eager model: `Fiber::try_wait()` reports the settled sta
 
 A panic in a plugin `apply`, disposer, or event listener propagates to the caller of the lifecycle operation that triggered it. Internal mutexes recover from poisoning, and a fiber interrupted mid-transition stays in `Loading`/`Unloading` — with already-registered effects still owned — until the next lifecycle event or `dispose` settles it. `Context` and `Fiber` do not implement `UnwindSafe` because their trait objects cannot prove it; when a plugin must not take down its caller, isolate it with `std::panic::catch_unwind(std::panic::AssertUnwindSafe(...))`.
 
+## Ecosystem
+
+The core crate stays dependency-free; the loader stack lives in sibling
+crates that build on it:
+
+| Crate | Purpose |
+| --- | --- |
+| [`cordis-include`](../crates/cordis-include) | Config entry trees, YAML/JSON loader files, `${{ env.NAME }}` interpolation |
+| [`cordis-group`](../crates/cordis-group) | Group plugin: nested entries with cascading disable |
+| [`cordis-loader`](../crates/cordis-loader) | Plugin registry + entry↔fiber state machine, file hot reload |
+| [`cordis-cli`](../crates/cordis-cli) | `cordis run` executable: daemon/worker, signals, dotenv |
+
 ## Project layout
 
-The source mirrors the upstream package:
+The core crate source mirrors the upstream package:
 
 ```text
 src/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -315,9 +315,20 @@ TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采�
 
 插件 `apply`、disposer 或事件监听器中的 panic 会传播给触发生命周期操作的调用方。内部互斥锁会从 poisoning 中恢复；在迁移途中被打断的 fiber 会停留在 `Loading`/`Unloading` 状态（已注册的 effect 仍归其所有），直到下一次生命周期事件或 `dispose` 使其稳定。`Context` 和 `Fiber` 未实现 `UnwindSafe`（其内部的 trait object 无法证明该性质）；当某个插件不允许拖垮调用方时，请在调用处用 `std::panic::catch_unwind(std::panic::AssertUnwindSafe(...))` 进行隔离。
 
+## 生态
+
+核心 crate 保持零依赖；loader 栈位于其上的兄弟 crate 中：
+
+| Crate | 用途 |
+| --- | --- |
+| [`cordis-include`](../crates/cordis-include) | 配置条目树、YAML/JSON 配置文件、`${{ env.NAME }}` 插值 |
+| [`cordis-group`](../crates/cordis-group) | 分组插件：嵌套条目与级联禁用 |
+| [`cordis-loader`](../crates/cordis-loader) | 插件注册表 + 条目↔fiber 状态机、配置热重载 |
+| [`cordis-cli`](../crates/cordis-cli) | `cordis run` 可执行入口：daemon/worker、信号、dotenv |
+
 ## 项目结构
 
-源码结构与上游 package 对应：
+核心 crate 源码结构与上游 package 对应：
 
 ```text
 src/

--- a/crates/cordis-cli/Cargo.toml
+++ b/crates/cordis-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cordis-cli"
+version = "0.0.1"
+description = "Command line runner (daemon/worker) for the cordis-rs plugin framework"
+keywords = ["cordis", "cli", "runner", "daemon", "loader"]
+categories = ["command-line-utilities"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[[bin]]
+name = "cordis"
+path = "src/main.rs"
+
+[dependencies]
+cordis-loader = { workspace = true, features = ["watch"] }
+cordis-rs.workspace = true
+ctrlc = { version = "3", features = ["termination"] }

--- a/crates/cordis-cli/README.md
+++ b/crates/cordis-cli/README.md
@@ -1,0 +1,42 @@
+# cordis-cli
+
+Command-line runner for the [cordis-rs](https://crates.io/crates/cordis-rs)
+plugin framework: `cordis run <config.yml>`.
+
+Builds on [cordis-loader](https://crates.io/crates/cordis-loader) to give a
+config-driven cordis application a process model:
+
+```console
+$ cordis run cordis.yml
+cordis: worker ready (2 entries, config: cordis.yml)
+```
+
+- **daemon / worker** — `cordis run` supervises a worker subprocess that
+  boots the loader. The worker exits with code `51` to request a hot
+  restart and `52` to quit; only `51` respawns.
+- **signals** — `SIGINT` / `SIGTERM` dispose the root context gracefully
+  and exit `52`, so Ctrl+C stops the whole application cleanly.
+- **dotenv** — `.env` and `.env.local` are loaded from the working
+  directory at startup (existing environment variables always win), and
+  `${{ env.NAME }}` templates in the config expand from there.
+- **hot reload** — the entry file is watched (debounced); external edits
+  reconcile fibers through the loader's diff machinery.
+
+Plugins stop or restart the process through the `worker` service:
+
+```rust
+# use cordis::Context;
+# fn main() -> cordis::Result<()> {
+let handle = ctx.require::<cordis_cli::worker::WorkerHandle>("worker")?;
+handle.restart(); // full worker reload (exit 51)
+# Ok(())
+# }
+```
+
+## Scope
+
+The stock binary registers only the built-in `group` plugin; entries with
+other names are recorded in the loader's `last_error()` and skipped.
+Embedding applications register their own plugins via
+[`cordis_loader::PluginRegistry`](https://docs.rs/cordis-loader) or fork
+this runner; dynamic library loading (`dynamic` feature) is future work.

--- a/crates/cordis-cli/src/dotenv.rs
+++ b/crates/cordis-cli/src/dotenv.rs
@@ -1,0 +1,96 @@
+//! Minimal `.env` loading — `KEY=VALUE` lines, no interpolation.
+
+use std::path::Path;
+
+/// Load `.env` and then `.env.local` from `dir`, without overriding
+/// variables that are already set in the environment.
+pub fn load(dir: &Path) {
+    for name in [".env", ".env.local"] {
+        let path = dir.join(name);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (key, value) in parse(&text) {
+            if std::env::var_os(&key).is_none() {
+                set_if_absent(&key, &value);
+            }
+        }
+    }
+}
+
+/// SAFETY: the CLI sets the environment exactly once during single-threaded
+/// startup, before any worker threads exist, so no other thread can be
+/// reading `std::env` concurrently.
+#[allow(unsafe_code)]
+fn set_if_absent(key: &str, value: &str) {
+    unsafe { std::env::set_var(key, value) };
+}
+
+/// Parse dotenv text into key/value pairs. Supports comments, blank lines,
+/// an optional `export ` prefix, and single- or double-quoted values.
+/// Malformed lines are skipped.
+pub fn parse(text: &str) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line).trim_start();
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() || key.contains(char::is_whitespace) {
+            continue;
+        }
+        pairs.push((key.to_owned(), unquote(value.trim())));
+    }
+    pairs
+}
+
+/// Strip one layer of matching quotes; `#` starts a comment in unquoted
+/// values.
+fn unquote(value: &str) -> String {
+    let value = if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+            .split_once('#')
+            .map_or(value, |(head, _)| head.trim_end())
+    };
+    value.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_comments_quotes_and_exports() {
+        let text = r#"
+# comment
+PLAIN=value
+export EXPORTED=1
+QUOTED="a # b"
+SINGLE='c'
+TRAILING=x   # trailing comment
+EMPTY=
+malformed-line
+"#;
+        assert_eq!(
+            parse(text),
+            vec![
+                ("PLAIN".to_owned(), "value".to_owned()),
+                ("EXPORTED".to_owned(), "1".to_owned()),
+                ("QUOTED".to_owned(), "a # b".to_owned()),
+                ("SINGLE".to_owned(), "c".to_owned()),
+                ("TRAILING".to_owned(), "x".to_owned()),
+                ("EMPTY".to_owned(), String::new()),
+            ]
+        );
+    }
+}

--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -1,0 +1,210 @@
+//! Command-line runner for the [cordis-rs](https://crates.io/crates/cordis-rs)
+//! plugin framework: `cordis run <config.yml>`.
+//!
+//! The process model follows upstream Cordis' NodeLoader: `cordis run`
+//! supervises a worker subprocess running the loader. The worker exits
+//! with code `51` to request a hot restart and `52` to quit; `SIGINT` /
+//! `SIGTERM` dispose the root context gracefully and exit `52`. `.env` and
+//! `.env.local` are loaded (without overriding existing variables) before
+//! the worker boots, and the entry file is watched for hot reload.
+//!
+//! Plugins reach the process controls through the `worker` service
+//! ([`worker::WorkerHandle`]): `restart()` maps to a full worker reload,
+//! and `shutdown()` stops the whole application.
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod dotenv;
+pub mod worker;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// What the supervisor does after a worker exits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Spawn a fresh worker (hot restart).
+    Restart,
+    /// Stop supervising.
+    Stop,
+}
+
+/// Decide whether to restart the worker after it exited with `exit_code`.
+///
+/// Only exit code [`worker::EXIT_RESTART`] (51) restarts, and never once
+/// the daemon itself received a shutdown signal.
+pub fn supervisor_action(exit_code: Option<i32>, shutdown: bool) -> Action {
+    if shutdown || exit_code != Some(worker::EXIT_RESTART) {
+        Action::Stop
+    } else {
+        Action::Restart
+    }
+}
+
+/// Parsed command line.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Options {
+    /// Entry config file.
+    pub config: PathBuf,
+    /// Run as the daemon's worker process instead of supervising.
+    pub worker: bool,
+}
+
+/// Parse `cordis` arguments (after the binary name).
+pub fn parse_args(args: &[String]) -> Result<Options, String> {
+    let Some(command) = args.first() else {
+        return Err(usage());
+    };
+    if command != "run" {
+        return Err(format!("unknown command `{command}`\n\n{}", usage()));
+    }
+    let mut config = None;
+    let mut worker = false;
+    for arg in &args[1..] {
+        match arg.as_str() {
+            "--worker" | "-w" => worker = true,
+            "--help" | "-h" => return Err(usage()),
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag `{other}`\n\n{}", usage()));
+            }
+            other => {
+                if config.replace(PathBuf::from(other)).is_some() {
+                    return Err(format!(
+                        "unexpected extra argument `{other}`\n\n{}",
+                        usage()
+                    ));
+                }
+            }
+        }
+    }
+    match config {
+        Some(config) => Ok(Options { config, worker }),
+        None => Err(format!("missing config file\n\n{}", usage())),
+    }
+}
+
+fn usage() -> String {
+    "usage: cordis run <config.yml> [--worker]
+
+  run        start the loader from an entry config file
+  --worker   internal: run as the daemon's worker process
+
+Worker exit codes: 51 = hot restart, 52 = quit."
+        .to_owned()
+}
+
+/// Entry point used by the `cordis` binary: parse arguments, load dotenv,
+/// then supervise or run as the worker.
+pub fn run<I, S>(args: I) -> i32
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let args: Vec<String> = args.into_iter().map(Into::into).collect();
+    let options = match parse_args(&args) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{message}");
+            return 2;
+        }
+    };
+    if let Ok(dir) = std::env::current_dir() {
+        dotenv::load(&dir);
+    }
+    if options.worker {
+        worker::run(&options.config);
+    }
+    supervise(&options.config)
+}
+
+/// Supervise worker subprocesses until they quit or a signal arrives.
+fn supervise(config: &std::path::Path) -> i32 {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let signal_flag = Arc::clone(&shutdown);
+    if ctrlc::set_handler(move || {
+        eprintln!("cordis: shutdown requested");
+        signal_flag.store(true, Ordering::SeqCst);
+    })
+    .is_err()
+    {
+        eprintln!("cordis: could not install signal handlers");
+    }
+
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(error) => {
+            eprintln!("cordis: cannot resolve own executable: {error}");
+            return 1;
+        }
+    };
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        let child = std::process::Command::new(&exe)
+            .arg("run")
+            .arg(config)
+            .arg("--worker")
+            .spawn();
+        let mut child = match child {
+            Ok(child) => child,
+            Err(error) => {
+                eprintln!("cordis: cannot spawn worker: {error}");
+                return 1;
+            }
+        };
+        let exit_code = child.wait().ok().and_then(|status| status.code());
+        if supervisor_action(exit_code, shutdown.load(Ordering::SeqCst)) == Action::Stop {
+            break;
+        }
+        eprintln!("cordis: worker requested restart, respawning");
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn parses_run_command_and_flags() {
+        assert_eq!(
+            parse_args(&args(&["run", "cordis.yml"])).unwrap(),
+            Options {
+                config: "cordis.yml".into(),
+                worker: false
+            }
+        );
+        assert_eq!(
+            parse_args(&args(&["run", "cordis.yml", "--worker"])).unwrap(),
+            Options {
+                config: "cordis.yml".into(),
+                worker: true
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_unknown_arguments() {
+        assert!(parse_args(&args(&[])).is_err());
+        assert!(parse_args(&args(&["start", "cordis.yml"])).is_err());
+        assert!(parse_args(&args(&["run"])).is_err());
+        assert!(parse_args(&args(&["run", "a.yml", "b.yml"])).is_err());
+        assert!(parse_args(&args(&["run", "a.yml", "--nope"])).is_err());
+    }
+
+    #[test]
+    fn only_code_51_restarts_and_never_after_shutdown() {
+        assert_eq!(supervisor_action(Some(51), false), Action::Restart);
+        assert_eq!(supervisor_action(Some(51), true), Action::Stop);
+        assert_eq!(supervisor_action(Some(52), false), Action::Stop);
+        assert_eq!(supervisor_action(Some(0), false), Action::Stop);
+        assert_eq!(supervisor_action(None, false), Action::Stop);
+    }
+}

--- a/crates/cordis-cli/src/main.rs
+++ b/crates/cordis-cli/src/main.rs
@@ -1,0 +1,9 @@
+//! The `cordis` binary: see [`cordis_cli`] for the actual implementation.
+
+fn main() {
+    let args: Vec<String> = std::env::args_os()
+        .skip(1)
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    std::process::exit(cordis_cli::run(args));
+}

--- a/crates/cordis-cli/src/worker.rs
+++ b/crates/cordis-cli/src/worker.rs
@@ -1,0 +1,104 @@
+//! Worker runtime: boot the loader, watch the config, exit on signals.
+
+use cordis::Context;
+use cordis_loader::{Loader, LoaderConfig};
+use std::path::Path;
+use std::sync::Arc;
+
+/// Exit code asking the daemon for a hot restart.
+pub const EXIT_RESTART: i32 = 51;
+/// Exit code telling the daemon to quit without restarting.
+pub const EXIT_QUIT: i32 = 52;
+
+/// Handle exposed as the `worker` service so plugins can stop or restart
+/// the process (upstream's `ctx.loader.exit` / full-reload protocol).
+pub struct WorkerHandle {
+    inner: Arc<WorkerInner>,
+}
+
+impl WorkerHandle {
+    /// Hot restart: dispose everything and ask the daemon for a new worker.
+    pub fn restart(&self) -> ! {
+        self.inner.teardown();
+        std::process::exit(EXIT_RESTART);
+    }
+
+    /// Quit: dispose everything and tell the daemon not to restart.
+    pub fn shutdown(&self) -> ! {
+        self.inner.teardown();
+        std::process::exit(EXIT_QUIT);
+    }
+}
+
+/// Everything the worker owns; shared with the signal handler.
+struct WorkerInner {
+    root: Context,
+    loader: Option<Loader>,
+}
+
+impl WorkerInner {
+    fn teardown(&self) {
+        if let Some(loader) = &self.loader {
+            let _ = loader.dispose();
+        }
+        let _ = self.root.fiber().and_then(|fiber| fiber.dispose());
+    }
+}
+
+/// Run the worker process: load dotenv, boot the loader, watch the entry
+/// file, and block until a signal (or a `worker` service call) exits the
+/// process. Never returns.
+pub fn run(config_path: &Path) -> ! {
+    let root = Context::new();
+    let loader = match Loader::open(&root, LoaderConfig::new(config_path)) {
+        Ok(loader) => loader,
+        Err(error) => {
+            eprintln!(
+                "cordis: failed to start from {}: {error}",
+                config_path.display()
+            );
+            std::process::exit(EXIT_QUIT);
+        }
+    };
+    let inner = Arc::new(WorkerInner {
+        root: root.clone(),
+        loader: Some(loader.clone()),
+    });
+
+    let handle = Arc::new(WorkerHandle {
+        inner: Arc::clone(&inner),
+    });
+    if let Err(error) = root.provide_arc("worker", handle) {
+        eprintln!("cordis: could not expose the worker service: {error}");
+    }
+
+    let signal_inner = Arc::clone(&inner);
+    if ctrlc::set_handler(move || {
+        eprintln!("cordis: signal received, shutting down");
+        signal_inner.teardown();
+        std::process::exit(EXIT_QUIT);
+    })
+    .is_err()
+    {
+        eprintln!("cordis: could not install signal handlers");
+    }
+
+    match loader.watch() {
+        Ok(_watcher) => {}
+        Err(error) => eprintln!(
+            "cordis: config hot reload disabled ({error}); restart manually to apply changes"
+        ),
+    }
+
+    eprintln!(
+        "cordis: worker ready ({} entries, config: {})",
+        loader.tree().entries().len(),
+        config_path.display()
+    );
+
+    // The worker's work happens on fiber threads and watcher callbacks;
+    // park until a signal or service call ends the process.
+    loop {
+        std::thread::park();
+    }
+}

--- a/crates/cordis-cli/tests/cli.rs
+++ b/crates/cordis-cli/tests/cli.rs
@@ -1,0 +1,98 @@
+//! End-to-end run of the `cordis` binary (Unix: uses the kill utility).
+
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cordis-cli-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn kill(child: &std::process::Child, signal: &str) {
+    let _ = Command::new("kill")
+        .args([signal, &child.id().to_string()])
+        .status();
+}
+
+#[test]
+fn run_boots_the_loader_and_sigterm_exits_gracefully() {
+    let dir = temp_dir("sigterm");
+    let config = dir.join("cordis.yml");
+    std::fs::write(&config, "entries:\n  - id: g\n    name: group\n").unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("run")
+        .arg(&config)
+        .process_group(0)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn cordis binary");
+
+    // Give the daemon and its worker a moment to boot.
+    std::thread::sleep(Duration::from_millis(800));
+    if let Ok(Some(status)) = child.try_wait() {
+        panic!("cordis exited early with {status}");
+    }
+
+    // Signal the whole process group, like a terminal Ctrl+C would. The
+    // `--` separator keeps the negative pgid from being parsed as a flag.
+    let _ = Command::new("kill")
+        .args(["-TERM", "--", &format!("-{}", child.id())])
+        .status();
+    let output = child.wait_with_output().expect("wait for cordis");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("worker ready"), "stderr: {stderr}");
+    assert!(stderr.contains("shutting down"), "stderr: {stderr}");
+    assert_eq!(output.status.code(), Some(0), "daemon should exit 0");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_config_boots_an_empty_loader() {
+    let dir = temp_dir("missing");
+    let config = dir.join("does-not-exist.yml");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .args(["run", "--worker"])
+        .arg(&config)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn cordis worker");
+
+    std::thread::sleep(Duration::from_millis(800));
+    let early = child
+        .try_wait()
+        .expect("poll child")
+        .map(|status| panic!("worker exited early with {status}"));
+    assert!(early.is_none(), "worker stays parked on an empty config");
+
+    kill(&child, "-KILL");
+    let output = child.wait_with_output().expect("reap worker");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("worker ready (0 entries"),
+        "stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn unknown_arguments_fail_fast() {
+    let output = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("frobnicate")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown command"), "stderr: {stderr}");
+}

--- a/crates/cordis-group/Cargo.toml
+++ b/crates/cordis-group/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "README.md"
 
 [dependencies]
 cordis-rs.workspace = true

--- a/crates/cordis-group/README.md
+++ b/crates/cordis-group/README.md
@@ -1,0 +1,49 @@
+# cordis-group
+
+Nested plugin groups with cascading disable for the
+[cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
+
+A group is an entry with a `group` array in the config file. At runtime the
+loader starts each group as a [`Group`] fiber and starts the child entries
+*beneath that fiber's context*: disposing the group cascades to the whole
+subtree, and a `disabled` flag anywhere on the ancestor chain keeps the
+subtree from starting at all.
+
+```yaml
+entries:
+  - id: staging
+    name: group
+    disabled: true      # cascades to every child
+    group:
+      - name: adapter-http
+```
+
+## Example
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput, FiberState};
+use cordis_group::Group;
+# fn main() -> cordis::Result<()> {
+let root = cordis::Context::new();
+let group = root.plugin_default(Group::handle());
+group.try_wait()?;
+
+// Children started under the group's context die with it.
+let group_ctx = group.context().unwrap();
+let child = group_ctx.plugin_default(plugin_sync::<(), _>(
+    "child", Inject::default(), |_, _| Ok(PluginOutput::none()),
+));
+child.try_wait()?;
+
+group.dispose()?;
+assert_eq!(child.state(), FiberState::Disposed);
+# Ok(())
+# }
+```
+
+The plugin itself is a no-op nesting marker — all orchestration (walking
+the entry tree, starting children under the right context, patching config)
+lives in [`cordis-loader`](https://crates.io/crates/cordis-loader), which
+pre-registers the `group` name in its plugin registry.
+
+[`Group`]: https://docs.rs/cordis-group/latest/cordis_group/struct.Group.html

--- a/crates/cordis-include/Cargo.toml
+++ b/crates/cordis-include/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -1,0 +1,73 @@
+# cordis-include
+
+Config entry trees and YAML/JSON loader files for the
+[cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
+
+This crate is the data half of porting upstream Cordis' loader: it maps
+between config files on disk and an in-memory tree of entries, preserving
+object key order for diff-friendly files, expanding `${{ env.NAME }}`
+templates, and providing the suspend guards that break the
+write → watch → write feedback loop.
+
+```text
+┌─ cordis-loader   assembly: plugin registry + fiber state machine
+├─ cordis-group    group plugin (nesting marker)
+├─ cordis-include  ← this crate: entry trees + config files
+└─ cordis-rs       core runtime (zero dependencies)
+```
+
+## Example
+
+```rust
+use cordis_include::{Entry, EntryOptions, EntryTree, Node};
+# fn main() -> cordis_include::Result<()> {
+let tree = EntryTree::new();
+
+// Load a set of entries (from a file, or built by hand).
+let diff = tree.update(vec![
+    EntryOptions::new("group").with_id("srv").with_group(vec![
+        EntryOptions::new("adapter-http").with_config(
+            [("port".to_string(), Node::Int(8080))].into_iter().collect(),
+        ),
+    ]),
+])?;
+assert_eq!(diff.created.len(), 2);
+
+// A full reload matches entries by id across groups: existing entry
+// objects are reused (same pointer), so callers can keep their handles.
+let kept = tree.resolve("srv").unwrap();
+tree.update(vec![EntryOptions::new("group").with_id("srv")])?;
+assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
+# Ok(())
+# }
+```
+
+Files round-trip through [`LoaderFile`] with atomic `.tmp` + rename writes,
+readonly detection, and unknown top-level keys preserved:
+
+```yaml
+entries:
+  - id: srv
+    name: group
+    group:
+      - name: adapter-http
+        config:
+          port: 8080
+          host: ${{ env.HOST }}
+```
+
+## Feature flags
+
+- **`watch`** — debounced file watching through [`notify`](https://crates.io/crates/notify).
+  Events observed while the file is suspended (our own writes, or reloads in
+  progress) do not fire the callback.
+
+## Scope
+
+This crate deliberately knows nothing about *where plugins come from* and
+never starts or stops fibers: [`cordis-loader`](https://crates.io/crates/cordis-loader)
+implements the [`PluginResolver`] contract defined here and drives the
+lifecycle.
+
+[`LoaderFile`]: https://docs.rs/cordis-include/latest/cordis_include/struct.LoaderFile.html
+[`PluginResolver`]: https://docs.rs/cordis-include/latest/cordis_include/trait.PluginResolver.html

--- a/crates/cordis-loader/Cargo.toml
+++ b/crates/cordis-loader/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -1,0 +1,92 @@
+# cordis-loader
+
+Config-file driven plugin loader for the
+[cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
+
+This crate is the assembly half of porting upstream Cordis' loader: it
+connects [cordis-include](https://crates.io/crates/cordis-include) entry
+trees to cordis fibers and re-exports everything needed on top
+(`cordis-include`, `cordis-group`), so applications depend on this crate
+alone.
+
+```text
+┌─ cordis-loader   ← this crate: plugin registry + fiber state machine
+├─ cordis-group    group plugin (nesting marker)
+├─ cordis-include  entry trees + config files
+└─ cordis-rs       core runtime (zero dependencies)
+```
+
+## Example
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+
+# fn main() -> cordis_loader::Result<()> {
+// Register plugins by name (upstream's dynamic import() replacement).
+// The factory yields a fresh handle per entry.
+let mut registry = PluginRegistry::new();
+registry.register("greeter", || {
+    plugin_sync::<Node, _>(
+        "greeter",
+        Inject::default(),
+        |_ctx, config| {
+            let port = config["port"].as_i64().unwrap_or(80);
+            println!("greeter on port {port}");
+            Ok(PluginOutput::none())
+        },
+    )
+});
+
+let path = std::env::temp_dir().join(format!("cordis-loader-readme-{}.yml", std::process::id()));
+let initial = Document::with_entries(vec![
+    EntryOptions::new("greeter")
+        .with_id("greet")
+        .with_config([("port".to_string(), Node::Int(8080))].into_iter().collect()),
+]);
+
+let root = cordis::Context::new();
+let loader = Loader::open(
+    &root,
+    LoaderConfig::new(&path).with_registry(registry).with_initial(initial),
+)?;
+
+let entry = loader.tree().resolve("greet").unwrap();
+entry.fiber().unwrap().try_wait()?;      // started from the file
+loader.update_config("greet", [("port".to_string(), Node::Int(9090))].into_iter().collect())?;
+entry.fiber().unwrap().try_wait()?;      // restarted with the new config
+
+loader.dispose()?;
+let _ = std::fs::remove_file(&path);
+# Ok(())
+# }
+```
+
+## What the state machine does
+
+- **open** — read (or create) the entry file, build the tree, start every
+  enabled entry; group children start beneath their group fiber's context,
+  so disposing a group cascades.
+- **reload** — re-read the file under a suspend guard and reconcile:
+  created entries start, removed subtrees stop, moved entries restart
+  under their new parent, config-only changes patch in place. Generated
+  ids are persisted afterwards so the next reload matches them.
+- **self-kill** — a fiber that reaches `Disposed` outside loader operation
+  was killed by its own plugin; the loader persists `disabled: true` for
+  that entry. Removing an entry from the file just stops it.
+- **inject** — an entry's `inject` list is merged into the plugin's own
+  declaration, so services going away or coming back reconciles entries
+  through the core machinery.
+- **update_config** — the runtime entry point for changing config: updates
+  the fiber and persists to the file.
+
+## Feature flags
+
+- **`watch`** — hot reload: wires `LoaderFile`'s debounced watcher to
+  [`Loader::reload`]. Reload errors are recorded in `last_error()`.
+
+The [`cordis-cli`](https://crates.io/crates/cordis-cli) runner builds its
+`cordis run` command on top of this crate.
+
+[`Loader::reload`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.reload


### PR DESCRIPTION
## What

Closes out the four-crate layout from the port plan.

### READMEs (docs commit)
- `cordis-include` / `cordis-group` / `cordis-loader` each ship a README (rendered on crates.io via the `readme` manifest field) with **runnable examples** — CI gained three `rustdoc --test` steps for them, alongside the existing root-README tests
- Root READMEs (en/zh) gain an ecosystem table pointing at the four crates

### cordis-cli (feat commit)
`cordis run <config.yml>`:
- **daemon/worker** supervision with the upstream exit-code protocol: worker exits 51 → hot restart, 52 → quit; only 51 respawns, never after the daemon was itself signaled
- **SIGINT/SIGTERM** → graceful root dispose, exit 52 (e2e-tested with a real process-group signal)
- **dotenv**: `.env` + `.env.local` at startup, existing vars win, hand-rolled parser (comments / export / quotes)
- **hot reload** via `cordis-loader/watch`
- **`worker` service** (`WorkerHandle::restart/shutdown`) for plugin-driven process control

The stock binary registers only the `group` builtin — real plugins come from embedding the registry or the future `dynamic` feature (documented in the README).

Debugging detour worth noting: the e2e "hang" turned out to be `kill -TERM -<pgid>` swallowing the negative pgid as a flag — the test now passes `--`.

## Verification

Full pinned-1.85 gate: fmt, clippy `-D warnings`, 20 test targets, `cargo doc -D warnings`, root READMEs ×2 and crate READMEs ×3 as doctests.