### PR TITLE
feat: import entries — cross-file nested config

### DIFF
--- a/crates/cordis-include/src/error.rs
+++ b/crates/cordis-include/src/error.rs
@@ -71,6 +71,12 @@ pub enum IncludeError {
         /// The underlying watcher error.
         source: Box<dyn StdError + Send + Sync>,
     },
+    /// Free-form message from layers composing multiple files (import
+    /// cycles, unreadable sub-files).
+    Message {
+        /// The message.
+        message: String,
+    },
 }
 
 impl fmt::Display for IncludeError {
@@ -107,6 +113,7 @@ impl fmt::Display for IncludeError {
             Self::NotInTree => write!(f, "entry does not belong to this tree"),
             Self::Cycle => write!(f, "cannot move an entry into its own subtree"),
             Self::Watch { source } => write!(f, "file watcher error: {source}"),
+            Self::Message { message } => write!(f, "{message}"),
         }
     }
 }

--- a/crates/cordis-include/src/lib.rs
+++ b/crates/cordis-include/src/lib.rs
@@ -85,9 +85,9 @@ pub use entry::{Entry, EntrySuspendGuard};
 pub use error::{IncludeError, Result};
 pub use file::{Document, FileFormat, FileSuspendGuard, LoaderFile};
 pub use node::{Node, NodeMap};
-pub use options::EntryOptions;
+pub use options::{EntryOptions, IMPORT_NAME};
 pub use resolver::PluginResolver;
-pub use tree::{EntryTree, TreeDiff};
+pub use tree::{EntryTree, RemovedEntry, TreeDiff};
 #[cfg(feature = "watch")]
 pub use watch::FileWatcher;
 

--- a/crates/cordis-include/src/options.rs
+++ b/crates/cordis-include/src/options.rs
@@ -8,6 +8,10 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+/// Entry name that mounts another config file as a subtree
+/// (`name: import` with `config: { url: "…" }`).
+pub const IMPORT_NAME: &str = "import";
+
 /// One entry in a config file: a plugin instance plus its group position.
 ///
 /// The declared field order is the serialization order (`id` and `name`
@@ -72,6 +76,15 @@ impl EntryOptions {
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
+    }
+
+    /// The url this import entry mounts, when the entry is an import
+    /// (`name: import` with a string `config.url`).
+    pub fn import_url(&self) -> Option<&str> {
+        if self.name != IMPORT_NAME {
+            return None;
+        }
+        self.config.as_ref()?.as_object()?.get("url")?.as_str()
     }
 
     /// Declare services that must be active before this entry starts.

--- a/crates/cordis-include/src/tree.rs
+++ b/crates/cordis-include/src/tree.rs
@@ -6,6 +6,17 @@ use crate::options::EntryOptions;
 use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// An entry whose id vanished from the new data, together with the
+/// composite path it had while attached (detached entries would otherwise
+/// report a bare id).
+#[derive(Debug, Clone)]
+pub struct RemovedEntry {
+    /// The detached entry, subtree intact.
+    pub entry: Entry,
+    /// The composite path the entry had before the update.
+    pub path: String,
+}
+
 /// What changed in one [`EntryTree::update`] pass.
 ///
 /// The loader consumes this to start/stop/patch fibers without touching
@@ -19,7 +30,7 @@ pub struct TreeDiff {
     /// Entries that moved to a different parent.
     pub moved: Vec<Entry>,
     /// Entries whose ids vanished from the new data (whole subtrees).
-    pub removed: Vec<Entry>,
+    pub removed: Vec<RemovedEntry>,
 }
 
 impl TreeDiff {
@@ -250,6 +261,13 @@ impl EntryTree {
         // duplicates within the incoming data are rejected.
         validate_subtree(&entries, &HashSet::new(), &mut HashSet::new())?;
 
+        // Snapshot composite paths while every entry is still attached, so
+        // removals can report where they lived.
+        let paths: HashMap<String, String> = self
+            .entries()
+            .iter()
+            .map(|entry| (entry.id().to_string(), entry.path()))
+            .collect();
         // Index every existing entry by id so matches work across groups.
         let mut pool: HashMap<String, Entry> = self
             .entries()
@@ -260,7 +278,13 @@ impl EntryTree {
         let mut diff = TreeDiff::default();
         let children = sync_children(&self.root, entries, &mut pool, &reserved, &mut diff);
         self.root.set_children(children);
-        diff.removed = pool.into_values().collect();
+        diff.removed = pool
+            .into_values()
+            .map(|entry| RemovedEntry {
+                path: paths.get(entry.id()).cloned().unwrap_or_default(),
+                entry,
+            })
+            .collect();
         Ok(diff)
     }
 

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -63,6 +63,31 @@ let _ = std::fs::remove_file(&path);
 # }
 ```
 
+## Imports
+
+An entry with `name: import` and `config: { url: "…" }` mounts another
+config file as its subtree — same diff machinery, same id reuse:
+
+```yaml
+# main.yml
+entries:
+  - id: extra
+    name: import
+    config:
+      url: extra.yml
+```
+
+```yaml
+# extra.yml — entries become children of `extra`
+entries:
+  - id: adapter
+    name: adapter-http
+```
+
+Reloads compose all involved files into one tree diff; write-back always
+routes mounted entries back to the file they came from (generated ids
+included). Import cycles are reported via `last_error()` and skipped.
+
 ## What the state machine does
 
 - **open** — read (or create) the entry file, build the tree, start every

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -52,11 +52,20 @@
 //! open; plugins registered later via [`Loader::register_plugin`] are picked
 //! up by the next [`Loader::reload`].
 //!
+//! # Imports
+//!
+//! An entry with `name: import` and `config: { url: "…" }` mounts another
+//! config file as its subtree. Reloads compose every involved file into
+//! one tree (so diffs and id reuse work across files), while write-back
+//! decomposes: mounted children are persisted to the file they came from,
+//! never to the importing file. Import cycles are reported through
+//! [`Loader::last_error`] instead of recursing. With the `watch` feature,
+//! import files are watched like the main file.
+//!
 //! # Not in scope yet
 //!
-//! The `import` entry kind (mounting a sub-file), isolate/service
-//! migration, the `loader/entry-init`-style event family, and debounced
-//! merged writes are future work.
+//! Isolate/service migration, the `loader/entry-init`-style event family,
+//! and debounced merged writes are future work.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -5,8 +5,8 @@ use crate::lock;
 use crate::registry::{PluginRegistry, WithInject};
 use cordis::{Config, Context, EffectHandle, EventOptions, Fiber, FiberState, PluginHandle};
 use cordis_include::{Entry, EntryOptions, EntryTree, LoaderFile, Node, PluginResolver, TreeDiff};
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
 
 /// Where the loader reads and writes its entry file.
@@ -69,6 +69,14 @@ pub(crate) struct LoaderInner {
     tree: EntryTree,
     registry: Mutex<PluginRegistry>,
     state: Mutex<LoaderState>,
+    /// Canonical path -> file of every import currently mounted.
+    imports: Mutex<HashMap<PathBuf, LoaderFile>>,
+    /// Paths already armed by [`Loader::watch`] (watch feature).
+    #[cfg(feature = "watch")]
+    watched: Mutex<HashSet<PathBuf>>,
+    /// Import-file watchers kept alive for hot reload (watch feature).
+    #[cfg(feature = "watch")]
+    watchers: Mutex<Vec<cordis_include::FileWatcher>>,
 }
 
 /// Weak service handle injected as `loader`, avoiding a reference cycle
@@ -100,12 +108,10 @@ impl Loader {
                 file.write(initial)?;
             }
         }
-        let tree = EntryTree::new();
-        tree.update(file.read()?.entries)?;
         let inner = Arc::new(LoaderInner {
             root: root.clone(),
             file,
-            tree,
+            tree: EntryTree::new(),
             registry: Mutex::new(config.registry.unwrap_or_default()),
             state: Mutex::new(LoaderState {
                 entries: HashMap::new(),
@@ -113,7 +119,25 @@ impl Loader {
                 last_error: None,
                 _keep_alive: Vec::new(),
             }),
+            imports: Mutex::new(HashMap::new()),
+            #[cfg(feature = "watch")]
+            watched: Mutex::new(HashSet::new()),
+            #[cfg(feature = "watch")]
+            watchers: Mutex::new(Vec::new()),
         });
+        let mut errors = Vec::new();
+        let (composed, _dirty) = compose(
+            &inner.file,
+            &mut lock(&inner.imports),
+            &mut HashSet::new(),
+            &mut errors,
+        );
+        for error in errors {
+            lock(&inner.state).last_error = Some(error);
+        }
+        inner.tree.update(composed)?;
+        // Generated ids from the initial load are persisted lazily, on the
+        // first explicit write-back.
 
         // The status listener routes plugin-initiated disposals (self-kill)
         // back into the config file as `disabled: true`.
@@ -216,12 +240,20 @@ impl Loader {
     /// written back; generated ids are persisted afterwards.
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
-        let _suspend = inner.file.suspend();
-        let document = inner.file.read()?;
-        let diff = inner.tree.update(document.entries)?;
+        let mut imports = HashMap::new();
+        let mut errors = Vec::new();
+        let (composed, dirty) =
+            compose(&inner.file, &mut imports, &mut HashSet::new(), &mut errors);
+        for error in errors {
+            self.record_error(LoaderError::Include(
+                cordis_include::IncludeError::Message { message: error },
+            ));
+        }
+        let diff = inner.tree.update(composed)?;
+        *lock(&inner.imports) = imports;
 
-        for entry in &diff.removed {
-            if let Err(error) = stop_entry(inner, entry) {
+        for removed in &diff.removed {
+            if let Err(error) = stop_entry(inner, &removed.entry) {
                 self.record_error(error);
             }
         }
@@ -240,13 +272,14 @@ impl Loader {
                 self.record_error(error);
             }
         }
-        drop(_suspend);
 
         // Entries created without explicit ids had one generated; persist
-        // it so the next reload can match them.
-        if !diff.created.is_empty() {
+        // it to the file that owns them so the next reload can match them.
+        if dirty {
             write_back(inner)?;
         }
+        #[cfg(feature = "watch")]
+        self.arm_import_watchers();
         Ok(diff)
     }
 
@@ -286,14 +319,43 @@ impl Loader {
     #[cfg(feature = "watch")]
     pub fn watch(&self) -> Result<cordis_include::FileWatcher> {
         let loader = self.clone();
-        self.inner
+        let watcher = self
+            .inner
             .file
             .watch(move || {
                 if let Err(error) = loader.reload() {
                     loader.record_error(error);
                 }
             })
-            .map_err(LoaderError::Include)
+            .map_err(LoaderError::Include)?;
+        let main_path = std::fs::canonicalize(self.inner.file.path())
+            .unwrap_or_else(|_| self.inner.file.path().to_path_buf());
+        lock(&self.inner.watched).insert(main_path);
+        self.arm_import_watchers();
+        Ok(watcher)
+    }
+
+    /// Watch import files that appeared since the last arming; their
+    /// watchers live for the loader's lifetime (`watch` feature).
+    #[cfg(feature = "watch")]
+    fn arm_import_watchers(&self) {
+        for (path, file) in lock(&self.inner.imports).clone() {
+            if lock(&self.inner.watched).contains(&path) {
+                continue;
+            }
+            let loader = self.clone();
+            match file.watch(move || {
+                if let Err(error) = loader.reload() {
+                    loader.record_error(error);
+                }
+            }) {
+                Ok(watcher) => {
+                    lock(&self.inner.watched).insert(path);
+                    lock(&self.inner.watchers).push(watcher);
+                }
+                Err(error) => self.record_error(LoaderError::Include(error)),
+            }
+        }
     }
 
     fn record_error(&self, error: LoaderError) {
@@ -404,12 +466,122 @@ fn entry_options_with_children(entry: &Entry) -> EntryOptions {
     options
 }
 
-/// Persist the current tree, preserving unknown top-level file keys.
+/// Persist the current tree across every involved file, preserving
+/// unknown top-level keys. Import subtrees are stripped from their parent
+/// file and written to the file they came from.
 fn write_back(inner: &LoaderInner) -> Result<()> {
-    let mut document = inner.file.read()?;
-    document.entries = inner.tree.serialize();
-    inner.file.write(&document)?;
+    let mut jobs: Vec<(LoaderFile, Vec<EntryOptions>)> = vec![(
+        inner.file.clone(),
+        inner
+            .tree
+            .top_level()
+            .iter()
+            .map(to_stripped_options)
+            .collect(),
+    )];
+    for entry in inner.tree.entries() {
+        if entry.options().import_url().is_some() {
+            if let Some(file) = lock(&inner.imports).get(&import_canonical(inner, &entry)) {
+                let children = entry.children().iter().map(to_stripped_options).collect();
+                jobs.push((file.clone(), children));
+            }
+        }
+    }
+    for (file, entries) in jobs {
+        let mut document = file.read()?;
+        document.entries = entries;
+        file.write(&document)?;
+    }
     Ok(())
+}
+
+/// The entry's full options with import descendants cut off: an import
+/// entry keeps its own fields but drops the children mounted from its
+/// file, at any depth.
+fn to_stripped_options(entry: &Entry) -> EntryOptions {
+    fn strip(options: &mut EntryOptions) {
+        if options.import_url().is_some() {
+            // Everything below an import comes from its own file.
+            options.group.clear();
+            return;
+        }
+        options.group.retain(|child| child.import_url().is_none());
+        for child in &mut options.group {
+            strip(child);
+        }
+    }
+    let mut options = entry_options_with_children(entry);
+    strip(&mut options);
+    options
+}
+
+/// Resolve an import url against the directory of the file that contains
+/// the import entry.
+fn import_path(base_file: &LoaderFile, url: &str) -> PathBuf {
+    let direct = Path::new(url);
+    if direct.is_absolute() {
+        return direct.to_path_buf();
+    }
+    match base_file.path().parent() {
+        Some(parent) => parent.join(url),
+        None => direct.to_path_buf(),
+    }
+}
+
+/// The canonical path under which an import entry's file is registered.
+fn import_canonical(inner: &LoaderInner, entry: &Entry) -> PathBuf {
+    let url = entry.options().import_url().unwrap_or_default().to_owned();
+    let path = import_path(&inner.file, &url);
+    std::fs::canonicalize(&path).unwrap_or(path)
+}
+
+/// Read `file` and recursively mount import subtrees: every `import`
+/// entry's `group` becomes the entries of the file its `url` names, so one
+/// `EntryTree::update` diffs across all files uniformly. Returns the
+/// composed top-level entries and whether any file carried entries without
+/// ids (whose generated ids need persisting).
+fn compose(
+    file: &LoaderFile,
+    imports: &mut HashMap<PathBuf, LoaderFile>,
+    active: &mut HashSet<PathBuf>,
+    errors: &mut Vec<String>,
+) -> (Vec<EntryOptions>, bool) {
+    let document = match file.read() {
+        Ok(document) => document,
+        Err(error) => {
+            errors.push(format!("cannot read {}: {error}", file.path().display()));
+            return (Vec::new(), false);
+        }
+    };
+    let mut entries = Vec::with_capacity(document.entries.len());
+    let mut dirty = document.entries.iter().any(|options| options.id.is_none());
+    for mut options in document.entries {
+        if let Some(url) = options.import_url().map(str::to_owned) {
+            let path = import_path(file, &url);
+            let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if !active.insert(canonical.clone()) {
+                errors.push(format!("import cycle detected at {}", path.display()));
+                // Drop the cyclic reference: keeping a copy of the entry
+                // would duplicate its id inside the composed tree.
+                continue;
+            }
+            match LoaderFile::open(&path) {
+                Ok(sub_file) => {
+                    let (sub_entries, sub_dirty) = compose(&sub_file, imports, active, errors);
+                    dirty |= sub_dirty;
+                    options.group = sub_entries;
+                    imports.insert(canonical, sub_file);
+                }
+                Err(error) => errors.push(format!(
+                    "cannot open import {} ({}: {error})",
+                    path.display(),
+                    file.path().display()
+                )),
+            }
+        }
+        entries.push(options);
+    }
+    (entries, dirty)
 }
 
 /// Route `internal/status` disposals: a fiber that reached `Disposed`

--- a/crates/cordis-loader/src/registry.rs
+++ b/crates/cordis-loader/src/registry.rs
@@ -4,6 +4,7 @@
 use cordis::utils::BoxFuture;
 use cordis::{Config, Context, Inject, Plugin, PluginHandle, PluginOutput, Result};
 use cordis_group::Group;
+use cordis_include::IMPORT_NAME;
 use cordis_include::resolver::unknown_plugin;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,10 +24,11 @@ pub struct PluginRegistry {
 }
 
 impl PluginRegistry {
-    /// An empty registry with the `group` builtin registered.
+    /// An empty registry with the `group` and `import` builtins registered.
     pub fn new() -> Self {
         let mut registry = Self::default();
         registry.register("group", Group::handle);
+        registry.register(IMPORT_NAME, || PluginHandle::new(Import));
         registry
     }
 
@@ -60,6 +62,20 @@ impl cordis_include::PluginResolver for PluginRegistry {
             Some(factory) => Ok(factory()),
             None => Err(unknown_plugin(name)),
         }
+    }
+}
+
+/// Nesting marker for import entries, whose children the loader mounts
+/// from the referenced file at compose time.
+pub(crate) struct Import;
+
+impl Plugin for Import {
+    fn name(&self) -> &str {
+        IMPORT_NAME
+    }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async { Ok(PluginOutput::default()) })
     }
 }
 

--- a/crates/cordis-loader/tests/import.rs
+++ b/crates/cordis-loader/tests/import.rs
@@ -1,0 +1,261 @@
+//! Import entries: sub-files mounted as subtrees, reloaded and persisted
+//! through the compose/decompose routing.
+
+use cordis::{Context, Inject, plugin_sync};
+use cordis_include::Node;
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("cordis-import-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn worker_registry(starts: Arc<AtomicUsize>) -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", move || {
+        let starts = starts.clone();
+        plugin_sync::<Node, _>("worker", Inject::default(), move |_ctx, config| {
+            starts.fetch_add(1, Ordering::SeqCst);
+            let _port = config["port"].as_i64();
+            Ok(cordis::PluginOutput::none())
+        })
+    });
+    registry
+}
+
+#[test]
+fn import_mounts_sub_file_entries_as_a_subtree() {
+    let dir = temp_dir("mount");
+    let main = dir.join("main.yml");
+    let sub = dir.join("extra.yml");
+    std::fs::write(
+        &main,
+        "entries:\n  - id: imp\n    name: import\n    config:\n      url: extra.yml\n",
+    )
+    .unwrap();
+    std::fs::write(&sub, "entries:\n  - id: w1\n    name: worker\n").unwrap();
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(worker_registry(starts.clone())),
+    )
+    .unwrap();
+
+    let import = loader.tree().resolve("imp").unwrap();
+    import.fiber().unwrap().try_wait().unwrap(); // import marker is active
+    let child = loader.tree().resolve("imp:w1").unwrap();
+    child.fiber().unwrap().try_wait().unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    assert_eq!(import.name(), "import");
+
+    // Children run under the import fiber's context: disposing the import
+    // cascades (here through a loader-driven group stop).
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn import_sub_file_reload_diffs_only_its_children() {
+    let dir = temp_dir("reload");
+    let main = dir.join("main.yml");
+    let sub = dir.join("extra.yml");
+    std::fs::write(
+        &main,
+        "entries:\n  - id: imp\n    name: import\n    config:\n      url: extra.yml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &sub,
+        "entries:\n  - id: keep\n    name: worker\n  - id: gone\n    name: worker\n",
+    )
+    .unwrap();
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(worker_registry(starts.clone())),
+    )
+    .unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+
+    // External edit of the SUB file: remove one entry, patch the other.
+    std::fs::write(
+        &sub,
+        "entries:\n  - id: keep\n    name: worker\n    config:\n      port: 7\n",
+    )
+    .unwrap();
+    let diff = loader.reload().unwrap();
+    assert!(diff.updated.iter().any(|e| e.path() == "imp:keep"));
+    assert!(diff.removed.iter().any(|e| e.path == "imp:gone"));
+    assert!(diff.created.is_empty());
+
+    let keep = loader.tree().resolve("imp:keep").unwrap();
+    let config = keep.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(config["port"].as_i64(), Some(7));
+    assert!(loader.tree().resolve("imp:gone").is_none());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn generated_ids_persist_to_the_sub_file_not_the_main_file() {
+    let dir = temp_dir("ids");
+    let main = dir.join("main.yml");
+    let sub = dir.join("extra.yml");
+    std::fs::write(
+        &main,
+        "entries:\n  - id: imp\n    name: import\n    config:\n      url: extra.yml\n",
+    )
+    .unwrap();
+    std::fs::write(&sub, "entries:\n  - name: worker\n").unwrap(); // no id
+
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(worker_registry(Arc::new(AtomicUsize::new(0)))),
+    )
+    .unwrap();
+    std::fs::write(&sub, "entries:\n  - name: worker\n").unwrap(); // touch the sub file
+    loader.reload().unwrap();
+
+    let sub_text = std::fs::read_to_string(&sub).unwrap();
+    let main_text = std::fs::read_to_string(&main).unwrap();
+    assert!(
+        sub_text.contains("id:"),
+        "generated id persisted to sub file: {sub_text}"
+    );
+    assert!(
+        !sub_text.contains("import"),
+        "sub file stays flat: {sub_text}"
+    );
+    assert!(
+        main_text.contains("url: extra.yml"),
+        "main file untouched structurally: {main_text}"
+    );
+    assert!(
+        !main_text.contains("name: worker"),
+        "mounted children never leak into main: {main_text}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn import_cycles_are_reported_without_recursing_forever() {
+    let dir = temp_dir("cycle");
+    let a = dir.join("a.yml");
+    let b = dir.join("b.yml");
+    std::fs::write(
+        &a,
+        "entries:\n  - id: ia\n    name: import\n    config:\n      url: b.yml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &b,
+        "entries:\n  - id: ib\n    name: import\n    config:\n      url: a.yml\n",
+    )
+    .unwrap();
+
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&a).with_registry(worker_registry(Arc::new(AtomicUsize::new(0)))),
+    )
+    .unwrap();
+    assert!(
+        loader.last_error().unwrap().contains("cycle"),
+        "cycle recorded: {:?}",
+        loader.last_error()
+    );
+    // Both import entries still exist as (childless) markers.
+    assert!(loader.tree().resolve("ia").is_some());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn update_config_on_a_mounted_entry_writes_the_sub_file() {
+    let dir = temp_dir("update");
+    let main = dir.join("main.yml");
+    let sub = dir.join("extra.yml");
+    std::fs::write(
+        &main,
+        "entries:\n  - id: imp\n    name: import\n    config:\n      url: extra.yml\n",
+    )
+    .unwrap();
+    std::fs::write(&sub, "entries:\n  - id: w1\n    name: worker\n").unwrap();
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(worker_registry(starts.clone())),
+    )
+    .unwrap();
+    loader
+        .tree()
+        .resolve("imp:w1")
+        .unwrap()
+        .fiber()
+        .unwrap()
+        .try_wait()
+        .unwrap();
+
+    loader
+        .update_config(
+            "imp:w1",
+            [("port".to_string(), Node::Int(42))].into_iter().collect(),
+        )
+        .unwrap();
+
+    let sub_text = std::fs::read_to_string(&sub).unwrap();
+    let main_text = std::fs::read_to_string(&main).unwrap();
+    assert!(
+        sub_text.contains("port: 42"),
+        "config persisted to the owning sub file: {sub_text}"
+    );
+    assert!(
+        !main_text.contains("port: 42"),
+        "main file does not absorb mounted entries: {main_text}"
+    );
+    let entry = loader.tree().resolve("imp:w1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 2); // patched, not re-created
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn disabled_import_cascades_to_mounted_children() {
+    let dir = temp_dir("disable");
+    let main = dir.join("main.yml");
+    let sub = dir.join("extra.yml");
+    std::fs::write(&main, "entries:\n  - id: imp\n    name: import\n    disabled: true\n    config:\n      url: extra.yml\n").unwrap();
+    std::fs::write(&sub, "entries:\n  - id: w1\n    name: worker\n").unwrap();
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(worker_registry(starts.clone())),
+    )
+    .unwrap();
+    let import = loader.tree().resolve("imp").unwrap();
+    let child = loader.tree().resolve("imp:w1").unwrap();
+    assert!(import.fiber().is_none(), "disabled import never starts");
+    assert!(
+        child.fiber().is_none(),
+        "cascade keeps children from starting"
+    );
+    assert_eq!(starts.load(Ordering::SeqCst), 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cordis-loader/tests/loader.rs
+++ b/crates/cordis-loader/tests/loader.rs
@@ -109,7 +109,7 @@ fn reload_reconciles_created_removed_updated_and_moved() {
     assert!(diff.created.iter().any(|e| e.id() == "grp"));
     assert!(diff.created.iter().any(|e| e.id() == "new"));
     assert!(diff.updated.iter().any(|e| e.id() == "keep"));
-    assert!(diff.removed.iter().any(|e| e.id() == "drop"));
+    assert!(diff.removed.iter().any(|e| e.entry.id() == "drop"));
 
     // Config-only change patched the fiber without a restart: starts went
     // 2 -> 3 (update_value restarts "keep"), and the new entries started.


### PR DESCRIPTION
## What

Implements the `import` entry kind from the port plan: an entry with `name: import` and `config: { url: "…" }` mounts another config file as its subtree.

**Architecture — compose on load, decompose on write:**
- Reloads **compose** all involved files (recursively) into one options tree, so a single `EntryTree::update` diffs across files uniformly: id reuse, moves, config patches, subtree removals all work unchanged, including nested imports.
- Write-back **decomposes**: mounted children persist to the file they came from — generated ids, `update_config`, and self-kill `disabled: true` included — never leaking into the importing file (all covered by tests).
- Import **cycles** are detected via canonical-path stack; the cyclic reference is dropped and reported through `last_error()` instead of duplicating ids or recursing.
- The `import` builtin (nesting marker, like `group`) is pre-registered; mounted children run under the import fiber's context so disposal cascades. `disabled` on the import cascades to the whole mounted subtree.
- `watch` arms watchers for import files as they appear, each firing a full recompose-reload.

**Include API changes** (0.0.x): `IMPORT_NAME` + `EntryOptions::import_url()`, `IncludeError::Message`, and `TreeDiff::removed` now carries `RemovedEntry { entry, path }` with the pre-detachment composite path.

## Verification

Full pinned-1.85 gate: fmt, clippy `-D warnings`, 21 test targets (6 new import e2e tests), `cargo doc -D warnings`, all five README doctests.