### PR TITLE
feat: loader event family + debounced write-backs

### DIFF
--- a/crates/cordis-include/src/file.rs
+++ b/crates/cordis-include/src/file.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::time::{Duration, Instant};
 
 /// The serialization format of a [`LoaderFile`], picked from its extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +48,27 @@ struct FileInner {
     path: PathBuf,
     format: FileFormat,
     suspend: Mutex<usize>,
+    deferred: Mutex<DeferredState>,
+    deferred_signal: Condvar,
+    flusher: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+/// State of the coalescing writer behind [`LoaderFile::write_deferred`].
+#[derive(Default)]
+struct DeferredState {
+    /// Latest queued document and its flush deadline.
+    pending: Option<(Document, Instant)>,
+    /// Monotonic counters so [`LoaderFile::flush_deferred`] can await a
+    /// specific queue state.
+    queued: u64,
+    flushed: u64,
+    /// A flush is currently running outside the lock.
+    writing: bool,
+    /// The owning file is gone; the flusher exits.
+    closed: bool,
+    /// The last flush error, surfaced through
+    /// [`LoaderFile::last_deferred_error`].
+    last_error: Option<String>,
 }
 
 /// A handle to one config file on disk.
@@ -86,6 +108,9 @@ impl LoaderFile {
                 path,
                 format,
                 suspend: Mutex::new(0),
+                deferred: Mutex::new(DeferredState::default()),
+                deferred_signal: Condvar::new(),
+                flusher: Mutex::new(None),
             }),
         })
     }
@@ -153,47 +178,65 @@ impl LoaderFile {
     /// Serialize the document and replace the file atomically (write to a
     /// sibling `.tmp` file, fsync, rename). A no-op while suspended.
     pub fn write(&self, document: &Document) -> Result<()> {
-        if self.is_suspended() {
-            return Ok(());
-        }
-        if let Ok(metadata) = fs::metadata(&self.inner.path) {
-            if metadata.permissions().readonly() {
-                return Err(IncludeError::ReadOnly {
-                    path: self.inner.path.clone(),
-                });
-            }
-        }
-        let content = match self.inner.format {
-            FileFormat::Yaml => {
-                serde_yaml_ng::to_string(document).map_err(|error| IncludeError::Parse {
-                    format: "yaml",
-                    source: Box::new(error),
-                })?
-            }
-            FileFormat::Json => {
-                let mut text = serde_json::to_string_pretty(document).map_err(|error| {
-                    IncludeError::Parse {
-                        format: "json",
-                        source: Box::new(error),
-                    }
-                })?;
-                text.push('\n');
-                text
-            }
-        };
-        if let Some(parent) = self.inner.path.parent() {
-            if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent)?;
-            }
-        }
-        let tmp = self.tmp_path();
+        write_document(&self.inner, document)
+    }
+
+    /// Schedule a coalesced write: rapid calls replace the pending document
+    /// (latest wins), and the physical write happens once `delay` has passed
+    /// without a newer call. A suspension active at flush time postpones the
+    /// write until it lifts. Errors surface through
+    /// [`LoaderFile::last_deferred_error`] and never propagate to callers.
+    ///
+    /// If the flusher thread cannot be spawned, the write happens
+    /// synchronously instead.
+    pub fn write_deferred(&self, document: Document, delay: Duration) {
         {
-            let mut file = fs::File::create(&tmp)?;
-            file.write_all(content.as_bytes())?;
-            file.sync_all()?;
+            let mut flusher = crate::lock(&self.inner.flusher);
+            if flusher.is_none() {
+                let weak = Arc::downgrade(&self.inner);
+                match std::thread::Builder::new()
+                    .name(format!("cordis-flush-{}", self.inner.path.display()))
+                    .spawn(move || flusher_loop(weak))
+                {
+                    Ok(thread) => *flusher = Some(thread),
+                    Err(_) => {
+                        drop(flusher);
+                        let _ = self.write(&document);
+                        return;
+                    }
+                }
+            }
         }
-        fs::rename(&tmp, &self.inner.path)?;
-        Ok(())
+        {
+            let mut state = crate::lock(&self.inner.deferred);
+            state.pending = Some((document, Instant::now() + delay));
+            state.queued += 1;
+        }
+        self.inner.deferred_signal.notify_all();
+    }
+
+    /// Block until every [`LoaderFile::write_deferred`] call made before
+    /// this one has been flushed (or skipped by suspension lifting and a
+    /// later flush).
+    pub fn flush_deferred(&self) {
+        let mut state = crate::lock(&self.inner.deferred);
+        let target = state.queued;
+        while state.flushed < target || state.writing || state.pending.is_some() {
+            let (guard, _) = self
+                .inner
+                .deferred_signal
+                .wait_timeout(state, Duration::from_millis(100))
+                .unwrap_or_else(|error| error.into_inner());
+            state = guard;
+            if state.flushed >= target && !state.writing && state.pending.is_none() {
+                return;
+            }
+        }
+    }
+
+    /// The last deferred-write error, if the flusher failed.
+    pub fn last_deferred_error(&self) -> Option<String> {
+        crate::lock(&self.inner.deferred).last_error.clone()
     }
 
     /// Increment the suspend counter, returning a guard whose drop resumes
@@ -211,15 +254,154 @@ impl LoaderFile {
     pub fn is_suspended(&self) -> bool {
         *lock(&self.inner.suspend) > 0
     }
+}
 
-    fn tmp_path(&self) -> PathBuf {
-        let file_name = self
-            .inner
-            .path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        self.inner.path.with_file_name(format!("{file_name}.tmp"))
+/// Serialize `document` and atomically replace the file behind `inner`.
+/// A no-op while the file is suspended.
+fn write_document(inner: &FileInner, document: &Document) -> Result<()> {
+    if *crate::lock(&inner.suspend) > 0 {
+        return Ok(());
+    }
+    if let Ok(metadata) = fs::metadata(&inner.path) {
+        if metadata.permissions().readonly() {
+            return Err(IncludeError::ReadOnly {
+                path: inner.path.clone(),
+            });
+        }
+    }
+    let content = match inner.format {
+        FileFormat::Yaml => {
+            serde_yaml_ng::to_string(document).map_err(|error| IncludeError::Parse {
+                format: "yaml",
+                source: Box::new(error),
+            })?
+        }
+        FileFormat::Json => {
+            let mut text =
+                serde_json::to_string_pretty(document).map_err(|error| IncludeError::Parse {
+                    format: "json",
+                    source: Box::new(error),
+                })?;
+            text.push('\n');
+            text
+        }
+    };
+    if let Some(parent) = inner.path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let file_name = inner
+        .path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let tmp = inner.path.with_file_name(format!("{file_name}.tmp"));
+    {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+    }
+    fs::rename(&tmp, &inner.path)?;
+    Ok(())
+}
+
+/// The flusher thread: holds only a weak reference so it dies with the last
+/// handle, and loops until the state is closed.
+fn flusher_loop(weak: Weak<FileInner>) {
+    const SUSPEND_RETRY: Duration = Duration::from_millis(50);
+    while let Some(inner) = weak.upgrade() {
+        let state = crate::lock(&inner.deferred);
+        if state.closed {
+            return;
+        }
+        let deadline = match state.pending.as_ref() {
+            Some((_, deadline)) => *deadline,
+            None => {
+                let waited = inner
+                    .deferred_signal
+                    .wait(state)
+                    .unwrap_or_else(|error| error.into_inner());
+                drop(waited);
+                continue;
+            }
+        };
+        drop(state);
+        let now = Instant::now();
+        if now < deadline {
+            // Park until the deadline (or a newer document/close) and
+            // re-decide with fresh state.
+            let state = crate::lock(&inner.deferred);
+            let (guard, _) = inner
+                .deferred_signal
+                .wait_timeout(state, deadline - now)
+                .unwrap_or_else(|error| error.into_inner());
+            drop(guard);
+            continue;
+        }
+        let mut state = crate::lock(&inner.deferred);
+        if state.closed {
+            return;
+        }
+        let Some((document, deadline)) = state.pending.take() else {
+            continue;
+        };
+        if Instant::now() < deadline {
+            state.pending = Some((document, deadline));
+            drop(state);
+            continue;
+        }
+        let queued_at_take = state.queued;
+        state.writing = true;
+        drop(state);
+
+        let suspended = *crate::lock(&inner.suspend) > 0;
+        if suspended {
+            let mut state = crate::lock(&inner.deferred);
+            state.pending = Some((document, Instant::now() + SUSPEND_RETRY));
+            state.writing = false;
+            drop(state);
+            inner.deferred_signal.notify_all();
+            continue;
+        }
+        let result = write_document(&inner, &document);
+        let mut state = crate::lock(&inner.deferred);
+        state.writing = false;
+        state.flushed = state.flushed.max(queued_at_take);
+        if let Err(error) = result {
+            state.last_error = Some(error.to_string());
+        }
+        drop(state);
+        inner.deferred_signal.notify_all();
+    }
+}
+
+impl Drop for FileInner {
+    fn drop(&mut self) {
+        {
+            let mut state = crate::lock(&self.deferred);
+            state.closed = true;
+        }
+        self.deferred_signal.notify_all();
+        if let Some(thread) = self
+            .flusher
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take()
+        {
+            let _ = thread.join();
+        }
+        // Anything still pending (e.g. suspended at close time) is written
+        // synchronously so the last state is not lost.
+        if let Some((document, _)) = self
+            .deferred
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .pending
+            .take()
+        {
+            let _ = write_document(self, &document);
+        }
     }
 }
 

--- a/crates/cordis-include/tests/file.rs
+++ b/crates/cordis-include/tests/file.rs
@@ -2,6 +2,7 @@
 
 use cordis_include::{Document, EntryOptions, EntryTree, IncludeError, LoaderFile, Node};
 use std::path::PathBuf;
+use std::time::Duration;
 
 fn temp_path(stem: &str, ext: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
@@ -244,5 +245,45 @@ fn parse_errors_surface_the_format() {
         file.read(),
         Err(IncludeError::Parse { format: "yaml", .. })
     ));
+    cleanup(&path);
+}
+
+#[test]
+fn deferred_writes_coalesce_latest_wins() {
+    let path = temp_path("deferred", "yml");
+    cleanup(&path);
+    let file = LoaderFile::open(&path).unwrap();
+    let stale = Document::with_entries(vec![EntryOptions::new("a")]);
+    let latest = Document::with_entries(vec![EntryOptions::new("b"), EntryOptions::new("c")]);
+
+    file.write_deferred(stale, Duration::from_millis(300));
+    std::thread::sleep(Duration::from_millis(50));
+    // The second call replaces the pending document and resets the deadline.
+    file.write_deferred(latest.clone(), Duration::from_millis(300));
+    file.flush_deferred();
+
+    assert_eq!(file.read().unwrap(), latest);
+    assert!(file.last_deferred_error().is_none());
+    cleanup(&path);
+}
+
+#[test]
+fn deferred_writes_wait_for_suspension_to_lift() {
+    let path = temp_path("deferred-suspend", "yml");
+    cleanup(&path);
+    let file = LoaderFile::open(&path).unwrap();
+    let document = Document::with_entries(vec![EntryOptions::new("a")]);
+
+    let guard = file.suspend();
+    file.write_deferred(document.clone(), Duration::from_millis(50));
+    let flushing = file.clone();
+    let flusher = std::thread::spawn(move || flushing.flush_deferred());
+
+    // While suspended nothing lands; the flusher is parked behind the guard.
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(!path.exists(), "suspension defers the physical write");
+    drop(guard);
+    flusher.join().unwrap();
+    assert_eq!(file.read().unwrap(), document);
     cleanup(&path);
 }

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -106,6 +106,25 @@ included). Import cycles are reported via `last_error()` and skipped.
 - **update_config** — the runtime entry point for changing config: updates
   the fiber and persists to the file.
 
+## Events and write coalescing
+
+The loader emits `loader/entry-init`, `loader/before-patch`,
+`loader/after-patch`, `loader/partial-dispose`, and
+`loader/config-update` on the root context's event bus — every listener
+gets the affected entry, `config-update` also the new config node. Write
+debouncing coalesces rapid write-backs:
+
+```rust
+# use cordis_loader::{Loader, LoaderConfig};
+# use std::time::Duration;
+# let root = cordis::Context::new();
+# let config = LoaderConfig::new("cordis.yml").with_write_debounce(Duration::from_millis(300));
+let loader = Loader::open(&root, config)?;
+// loader.update_config(...) calls now merge into one disk write
+// after 300ms of quiet; loader.file().flush_deferred() waits it out.
+# Ok::<(), cordis_loader::LoaderError>(())
+```
+
 ## Feature flags
 
 - **`watch`** — hot reload: wires `LoaderFile`'s debounced watcher to

--- a/crates/cordis-loader/src/events.rs
+++ b/crates/cordis-loader/src/events.rs
@@ -1,0 +1,24 @@
+//! Names of the events the loader emits on the root context's event bus.
+//!
+//! All listeners receive the affected [`Entry`](crate::Entry) as the first
+//! argument; `config-update` additionally carries the new
+//! [`Node`](crate::Node) config as the second. Listener failures are
+//! recorded through [`Loader::last_error`](crate::Loader::last_error) and
+//! never abort the state machine — keep listeners light, they run inside
+//! loader transitions.
+
+/// Emitted after an entry's fiber was created and mapped.
+pub const ENTRY_INIT: &str = "loader/entry-init";
+
+/// Emitted before a config-only patch is applied to a live fiber.
+pub const BEFORE_PATCH: &str = "loader/before-patch";
+
+/// Emitted after a config-only patch was applied.
+pub const AFTER_PATCH: &str = "loader/after-patch";
+
+/// Emitted after a self-disposed plugin was persisted as `disabled: true`.
+pub const PARTIAL_DISPOSE: &str = "loader/partial-dispose";
+
+/// Emitted after [`update_config`](crate::Loader::update_config) changed
+/// and persisted an entry's config.
+pub const CONFIG_UPDATE: &str = "loader/config-update";

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -62,15 +62,24 @@
 //! [`Loader::last_error`] instead of recursing. With the `watch` feature,
 //! import files are watched like the main file.
 //!
+//! # Events and write coalescing
+//!
+//! Lifecycle transitions are observable through the [`events`] module's
+//! event names on the root context's bus; listener failures are recorded,
+//! never propagated. Write-backs can be debounced via
+//! [`LoaderConfig::with_write_debounce`] or
+//! [`Loader::set_write_debounce`]: rapid successive writes coalesce into
+//! one physical write after the quiet window.
+//!
 //! # Not in scope yet
 //!
-//! Isolate/service migration, the `loader/entry-init`-style event family,
-//! and debounced merged writes are future work.
+//! Isolate/service migration and dynamic library plugins are future work.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 pub mod error;
+pub mod events;
 pub mod loader;
 pub mod registry;
 

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -3,11 +3,12 @@
 use crate::error::{LoaderError, Result};
 use crate::lock;
 use crate::registry::{PluginRegistry, WithInject};
-use cordis::{Config, Context, EffectHandle, EventOptions, Fiber, FiberState, PluginHandle};
+use cordis::{Config, Context, EffectHandle, EventOptions, Fiber, FiberState, PluginHandle, Value};
 use cordis_include::{Entry, EntryOptions, EntryTree, LoaderFile, Node, PluginResolver, TreeDiff};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
 
 /// Where the loader reads and writes its entry file.
 #[derive(Clone, Default)]
@@ -19,6 +20,9 @@ pub struct LoaderConfig {
     /// Plugin registry used to resolve entry names; defaults to a fresh
     /// [`PluginRegistry`] with only the `group` builtin.
     pub registry: Option<PluginRegistry>,
+    /// Debounce window for coalesced config writes; `None` (default)
+    /// persists every write synchronously.
+    pub write_debounce: Option<Duration>,
 }
 
 impl LoaderConfig {
@@ -28,6 +32,7 @@ impl LoaderConfig {
             filename: filename.into(),
             initial: None,
             registry: None,
+            write_debounce: None,
         }
     }
 
@@ -40,6 +45,13 @@ impl LoaderConfig {
     /// Provide the plugin registry entries resolve against.
     pub fn with_registry(mut self, registry: PluginRegistry) -> Self {
         self.registry = Some(registry);
+        self
+    }
+
+    /// Coalesce config writes: rapid write-backs merge and land once after
+    /// this much quiet time.
+    pub fn with_write_debounce(mut self, delay: Duration) -> Self {
+        self.write_debounce = Some(delay);
         self
     }
 }
@@ -77,6 +89,8 @@ pub(crate) struct LoaderInner {
     /// Import-file watchers kept alive for hot reload (watch feature).
     #[cfg(feature = "watch")]
     watchers: Mutex<Vec<cordis_include::FileWatcher>>,
+    /// Debounce window for coalesced writes; `None` writes synchronously.
+    write_debounce: Mutex<Option<Duration>>,
 }
 
 /// Weak service handle injected as `loader`, avoiding a reference cycle
@@ -124,6 +138,7 @@ impl Loader {
             watched: Mutex::new(HashSet::new()),
             #[cfg(feature = "watch")]
             watchers: Mutex::new(Vec::new()),
+            write_debounce: Mutex::new(config.write_debounce),
         });
         let mut errors = Vec::new();
         let (composed, _dirty) = compose(
@@ -207,6 +222,12 @@ impl Loader {
     /// The last background error recorded by the loader, if any.
     pub fn last_error(&self) -> Option<String> {
         lock(&self.inner.state).last_error.clone()
+    }
+
+    /// Set (or clear, with `None`) the debounce window for coalesced
+    /// config writes.
+    pub fn set_write_debounce(&self, delay: Option<Duration>) {
+        *lock(&self.inner.write_debounce) = delay;
     }
 
     /// The entry whose fiber is `fiber`, if the loader started it.
@@ -294,11 +315,17 @@ impl Loader {
             fiber.update_value(Config::new(config.clone()))?;
         }
         let mut options = entry_options_with_children(&entry);
-        options.config = Some(config);
+        options.config = Some(config.clone());
         inner
             .tree
             .update_entry(&entry.path(), options, None, None)?;
-        write_back(inner)
+        write_back(inner)?;
+        emit(
+            inner,
+            crate::events::CONFIG_UPDATE,
+            vec![Value::new(entry), Value::new(config)],
+        );
+        Ok(())
     }
 
     /// Stop every entry and clear the fiber map. The root context itself
@@ -383,6 +410,14 @@ impl Drop for OperatingGuard<'_> {
     }
 }
 
+/// Emit a loader event; listener failures are recorded, never propagated
+/// into the state machine.
+fn emit(inner: &LoaderInner, name: &str, args: Vec<Value>) {
+    if let Err(error) = inner.root.events().emit(name, args) {
+        lock(&inner.state).last_error = Some(format!("{name} listener failed: {error}"));
+    }
+}
+
 /// Start one entry's fiber beneath its parent group's context.
 fn start_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     if !entry.enabled() || entry.fiber().is_some() {
@@ -405,6 +440,11 @@ fn start_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     if let Some(uid) = fiber.uid() {
         lock(&inner.state).entries.insert(uid, entry.clone());
     }
+    emit(
+        inner,
+        crate::events::ENTRY_INIT,
+        vec![Value::new(entry.clone())],
+    );
     Ok(())
 }
 
@@ -449,7 +489,17 @@ fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
         .ok()
         .map(|node| (*node).clone());
     if current.as_ref() != Some(&new_config) {
+        emit(
+            inner,
+            crate::events::BEFORE_PATCH,
+            vec![Value::new(entry.clone())],
+        );
         fiber.update_value(Config::new(new_config))?;
+        emit(
+            inner,
+            crate::events::AFTER_PATCH,
+            vec![Value::new(entry.clone())],
+        );
     }
     Ok(())
 }
@@ -487,10 +537,14 @@ fn write_back(inner: &LoaderInner) -> Result<()> {
             }
         }
     }
+    let debounce = *lock(&inner.write_debounce);
     for (file, entries) in jobs {
         let mut document = file.read()?;
         document.entries = entries;
-        file.write(&document)?;
+        match debounce {
+            Some(delay) => file.write_deferred(document, delay),
+            None => file.write(&document)?,
+        }
     }
     Ok(())
 }
@@ -630,5 +684,11 @@ fn persist_self_dispose(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     inner
         .tree
         .update_entry(&entry.path(), options, None, None)?;
-    write_back(inner)
+    write_back(inner)?;
+    emit(
+        inner,
+        crate::events::PARTIAL_DISPOSE,
+        vec![Value::new(entry.clone())],
+    );
+    Ok(())
 }

--- a/crates/cordis-loader/tests/events.rs
+++ b/crates/cordis-loader/tests/events.rs
@@ -232,4 +232,3 @@ fn debounced_write_back_coalesces_updates() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
-

--- a/crates/cordis-loader/tests/events.rs
+++ b/crates/cordis-loader/tests/events.rs
@@ -1,0 +1,235 @@
+//! The loader/entry-* event family and debounced write-backs.
+
+use cordis::{Context, Inject, plugin_sync};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::events;
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("cordis-events-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn worker_registry() -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", || {
+        plugin_sync::<Node, _>("worker", Inject::default(), |_, _| {
+            Ok(cordis::PluginOutput::none())
+        })
+    });
+    registry
+}
+
+#[derive(Default)]
+struct Counts {
+    entry_init: AtomicUsize,
+    before_patch: AtomicUsize,
+    after_patch: AtomicUsize,
+    config_update: AtomicUsize,
+    partial_dispose: AtomicUsize,
+    patched_ids: Mutex<Vec<String>>,
+}
+
+fn listen(root: &Context, counts: &Arc<Counts>) {
+    let bus = root.events();
+    let c = counts.clone();
+    bus.on(
+        events::ENTRY_INIT,
+        move |event| {
+            let entry = event.arg::<cordis_include::Entry>(0)?.expect("entry arg");
+            c.entry_init.fetch_add(1, Ordering::SeqCst);
+            assert!(!entry.id().is_empty());
+            Ok(None)
+        },
+        cordis::EventOptions::default(),
+    )
+    .unwrap();
+    let c = counts.clone();
+    bus.on(
+        events::BEFORE_PATCH,
+        move |_| {
+            c.before_patch.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        },
+        cordis::EventOptions::default(),
+    )
+    .unwrap();
+    let c = counts.clone();
+    bus.on(
+        events::AFTER_PATCH,
+        move |event| {
+            c.after_patch.fetch_add(1, Ordering::SeqCst);
+            let entry = event.arg::<cordis_include::Entry>(0)?.expect("entry arg");
+            lock(&c.patched_ids).push(entry.id().to_string());
+            Ok(None)
+        },
+        cordis::EventOptions::default(),
+    )
+    .unwrap();
+    let c = counts.clone();
+    bus.on(
+        events::CONFIG_UPDATE,
+        move |event| {
+            c.config_update.fetch_add(1, Ordering::SeqCst);
+            let entry = event.arg::<cordis_include::Entry>(0)?.expect("entry arg");
+            let config = event.arg::<Node>(1)?.expect("config arg");
+            assert!(!entry.id().is_empty());
+            assert_eq!(config["port"].as_i64(), Some(9));
+            Ok(None)
+        },
+        cordis::EventOptions::default(),
+    )
+    .unwrap();
+    let c = counts.clone();
+    bus.on(
+        events::PARTIAL_DISPOSE,
+        move |_| {
+            c.partial_dispose.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        },
+        cordis::EventOptions::default(),
+    )
+    .unwrap();
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+#[test]
+fn loader_events_trace_the_state_machine() {
+    let dir = temp_dir("family");
+    let config_path = dir.join("cordis.yml");
+    let counts = Arc::new(Counts::default());
+
+    let root = Context::new();
+    listen(&root, &counts);
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&config_path)
+            .with_registry(worker_registry())
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+    assert_eq!(counts.entry_init.load(Ordering::SeqCst), 1);
+
+    // Config-only reload edit -> before/after patch, no new init.
+    std::fs::write(
+        &config_path,
+        "entries:\n  - id: w1\n    name: worker\n    config:\n      port: 5\n",
+    )
+    .unwrap();
+    loader.reload().unwrap();
+    assert_eq!(counts.entry_init.load(Ordering::SeqCst), 1);
+    assert_eq!(counts.before_patch.load(Ordering::SeqCst), 1);
+    assert_eq!(counts.after_patch.load(Ordering::SeqCst), 1);
+    assert_eq!(*lock(&counts.patched_ids), vec!["w1".to_string()]);
+
+    // Runtime config change -> config-update.
+    loader
+        .update_config(
+            "w1",
+            [("port".to_string(), Node::Int(9))].into_iter().collect(),
+        )
+        .unwrap();
+    assert_eq!(counts.config_update.load(Ordering::SeqCst), 1);
+
+    // Removing the entry stops it without a partial-dispose (that is for
+    // self-killed plugins only).
+    std::fs::write(&config_path, "entries:\n").unwrap();
+    loader.reload().unwrap();
+    assert_eq!(counts.partial_dispose.load(Ordering::SeqCst), 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn self_kill_emits_partial_dispose() {
+    let dir = temp_dir("selfkill");
+    let config_path = dir.join("cordis.yml");
+    let victim: Arc<Mutex<Option<cordis::Fiber>>> = Arc::new(Mutex::new(None));
+    let mut registry = PluginRegistry::new();
+    registry.register("victim", {
+        let victim = victim.clone();
+        move || {
+            let victim = victim.clone();
+            plugin_sync::<Node, _>("victim", Inject::default(), move |ctx, _| {
+                *lock(&victim) = Some(ctx.fiber()?);
+                Ok(cordis::PluginOutput::none())
+            })
+        }
+    });
+
+    let root = Context::new();
+    // Bound with `_` so the loader (and its status listener) stays alive
+    // for the whole test even though this test never touches it directly.
+    let _loader = Loader::open(
+        &root,
+        LoaderConfig::new(&config_path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("victim").with_id("v1"),
+            ])),
+    )
+    .unwrap();
+    let counts = Arc::new(Counts::default());
+    // Register after open so the earlier lifecycle does not count.
+    listen(&root, &counts);
+
+    lock(&victim).clone().unwrap().dispose().unwrap();
+    assert_eq!(counts.partial_dispose.load(Ordering::SeqCst), 1);
+    let text = std::fs::read_to_string(&config_path).unwrap();
+    assert!(text.contains("disabled: true"), "{text}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn debounced_write_back_coalesces_updates() {
+    let dir = temp_dir("debounce");
+    let config_path = dir.join("cordis.yml");
+
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&config_path)
+            .with_registry(worker_registry())
+            .with_write_debounce(Duration::from_millis(300))
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+
+    for port in [1, 2, 3] {
+        loader
+            .update_config(
+                "w1",
+                [("port".to_string(), Node::Int(port))]
+                    .into_iter()
+                    .collect(),
+            )
+            .unwrap();
+    }
+    loader.file().flush_deferred();
+
+    let text = std::fs::read_to_string(&config_path).unwrap();
+    assert!(text.contains("port: 3"), "latest config persisted: {text}");
+    assert!(
+        !text.contains("port: 1"),
+        "stale writes coalesced away: {text}"
+    );
+    assert!(loader.file().last_deferred_error().is_none());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+


### PR DESCRIPTION
## What

Items 2 and 3 from the loader backlog.

### cordis-include: `LoaderFile::write_deferred`
Coalesced writes: rapid calls merge (latest document wins), one physical write lands after a quiet window; suspension at flush time postpones until lifted; weak-referenced flusher thread dies with the last handle; `flush_deferred()` waits out pending work; drop flushes leftovers synchronously; spawn failure degrades to synchronous writes.

### cordis-loader
- **Event family** (`loader/entry-init | before-patch | after-patch | partial-dispose | config-update`) on the root event bus — first arg the affected `Entry`, `config-update` also carries the new `Node`. Listener failures go to `last_error()`, never abort the state machine.
- **Debounced write-backs**: `LoaderConfig::with_write_debounce` / `Loader::set_write_debounce` route persistence through `write_deferred` — bursty `update_config` / self-kill writes coalesce.

One test-semantics bug caught while iterating: dropping the `Loader` handle immediately after `open` invalidates the weak status listener (self-kill detection silently stops) — documented in the test.

## Verification

Full pinned-1.85 gate: fmt, clippy `-D warnings`, 22 test targets (5 new: 2 deferred-write, 3 events/debounce), `cargo doc -D warnings`, all five READMEs as doctests.