### PR TITLE
feat: dynamic library plugins + worker-restart HMR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "cordis-loader",
  "cordis-rs",
  "ctrlc",
+ "notify",
 ]
 
 [[package]]
@@ -64,6 +65,7 @@ dependencies = [
  "cordis-group",
  "cordis-include",
  "cordis-rs",
+ "libloading",
 ]
 
 [[package]]
@@ -177,6 +179,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cordis-include = { version = "0.0.7", path = "crates/cordis-include" }
 cordis-loader = { version = "0.0.6", path = "crates/cordis-loader" }
 cordis-rs = { version = "0.4.4", path = "crates/cordis" }
 indexmap = { version = "2", features = ["serde"] }
+libloading = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"

--- a/README.md
+++ b/README.md
@@ -324,14 +324,14 @@ crates that build on it:
 | --- | --- |
 | [`cordis-include`](../crates/cordis-include) | Config entry trees, YAML/JSON loader files, `${{ env.NAME }}` interpolation, atomic and debounced writes |
 | [`cordis-group`](../crates/cordis-group) | Group plugin: nested entries with cascading disable |
-| [`cordis-loader`](../crates/cordis-loader) | Plugin registry + entry↔fiber state machine, cross-file `import` entries, hot reload, lifecycle events, debounced write-backs |
-| [`cordis-cli`](../crates/cordis-cli) | `cordis run` executable: daemon/worker exit-code protocol, signals, dotenv |
+| [`cordis-loader`](../crates/cordis-loader) | Plugin registry + entry↔fiber state machine, cross-file `import` entries, hot reload, lifecycle events, debounced write-backs, dynamic-library plugins (`dynamic` feature) |
+| [`cordis-cli`](../crates/cordis-cli) | `cordis run` executable: daemon/worker exit-code protocol, signals, dotenv, plugin-library hot restarts |
 
 Ported so far: static plugin registry, groups, `import` sub-files, self-kill
 detection, entry-level inject, config hot reload, the `loader/*` event
-family, debounced writes, and the daemon/worker runner. Not yet ported:
-dynamic library plugins (and the HMR flow built on them) and isolate /
-service migration.
+family, debounced writes, the daemon/worker runner, and dynamic-library
+plugins with worker-restart HMR (`cordis-loader`'s `dynamic` feature plus
+`cordis run --plugin-dir`). Not yet ported: isolate / service migration.
 
 ## Project layout
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -323,12 +323,13 @@ TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采�
 | --- | --- |
 | [`cordis-include`](../crates/cordis-include) | 配置条目树、YAML/JSON 配置文件、`${{ env.NAME }}` 插值、原子写与防抖合并写 |
 | [`cordis-group`](../crates/cordis-group) | 分组插件：嵌套条目与级联禁用 |
-| [`cordis-loader`](../crates/cordis-loader) | 插件注册表 + 条目↔fiber 状态机、跨文件 `import` 条目、配置热重载、生命周期事件、防抖写回 |
-| [`cordis-cli`](../crates/cordis-cli) | `cordis run` 可执行入口：daemon/worker 退出码协议、信号、dotenv |
+| [`cordis-loader`](../crates/cordis-loader) | 插件注册表 + 条目↔fiber 状态机、跨文件 `import` 条目、配置热重载、生命周期事件、防抖写回、动态库插件（`dynamic` feature） |
+| [`cordis-cli`](../crates/cordis-cli) | `cordis run` 可执行入口：daemon/worker 退出码协议、信号、dotenv、插件库热重启 |
 
 已移植：静态插件注册表、分组、`import` 子文件、自杀判别、entry 级
-inject、配置热重载、`loader/*` 事件族、防抖写、daemon/worker 运行器。
-尚未移植：动态库插件（及在其上的 HMR 流程）、isolate / 服务迁移.
+inject、配置热重载、`loader/*` 事件族、防抖写、daemon/worker 运行器，
+以及动态库插件 + worker 重启式 HMR（`cordis-loader` 的 `dynamic`
+feature 与 `cordis run --plugin-dir`）。尚未移植：isolate / 服务迁移.
 
 ## 项目结构
 

--- a/crates/cordis-cli/Cargo.toml
+++ b/crates/cordis-cli/Cargo.toml
@@ -15,6 +15,7 @@ name = "cordis"
 path = "src/main.rs"
 
 [dependencies]
-cordis-loader = { workspace = true, features = ["watch"] }
+cordis-loader = { workspace = true, features = ["watch", "dynamic"] }
 cordis-rs.workspace = true
 ctrlc = { version = "3", features = ["termination"] }
+notify = "8"

--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -8,6 +8,11 @@
 //! `.env.local` are loaded (without overriding existing variables) before
 //! the worker boots, and the entry file is watched for hot reload.
 //!
+//! `--plugin-dir <dir>` (repeatable) additionally resolves entries from
+//! dynamic-library plugins compiled against the same toolchain; a change
+//! to a library in those directories hot-restarts the worker so the new
+//! build is loaded by a fresh process.
+//!
 //! Plugins reach the process controls through the `worker` service
 //! ([`worker::WorkerHandle`]): `restart()` maps to a full worker reload,
 //! and `shutdown()` stops the whole application.
@@ -48,6 +53,8 @@ pub fn supervisor_action(exit_code: Option<i32>, shutdown: bool) -> Action {
 pub struct Options {
     /// Entry config file.
     pub config: PathBuf,
+    /// Directories searched for dynamic-library plugins (repeatable).
+    pub plugin_dirs: Vec<PathBuf>,
     /// Run as the daemon's worker process instead of supervising.
     pub worker: bool,
 }
@@ -61,11 +68,26 @@ pub fn parse_args(args: &[String]) -> Result<Options, String> {
         return Err(format!("unknown command `{command}`\n\n{}", usage()));
     }
     let mut config = None;
+    let mut plugin_dirs = Vec::new();
     let mut worker = false;
-    for arg in &args[1..] {
+    let mut rest = args[1..].iter();
+    while let Some(arg) = rest.next() {
         match arg.as_str() {
             "--worker" | "-w" => worker = true,
             "--help" | "-h" => return Err(usage()),
+            "--plugin-dir" => {
+                let Some(value) = rest.next() else {
+                    return Err(format!("--plugin-dir requires a directory\n\n{}", usage()));
+                };
+                plugin_dirs.push(PathBuf::from(value));
+            }
+            other if other.starts_with("--plugin-dir=") => {
+                let value = other.strip_prefix("--plugin-dir=").unwrap();
+                if value.is_empty() {
+                    return Err(format!("--plugin-dir requires a directory\n\n{}", usage()));
+                }
+                plugin_dirs.push(PathBuf::from(value));
+            }
             other if other.starts_with('-') => {
                 return Err(format!("unknown flag `{other}`\n\n{}", usage()));
             }
@@ -80,16 +102,22 @@ pub fn parse_args(args: &[String]) -> Result<Options, String> {
         }
     }
     match config {
-        Some(config) => Ok(Options { config, worker }),
+        Some(config) => Ok(Options {
+            config,
+            plugin_dirs,
+            worker,
+        }),
         None => Err(format!("missing config file\n\n{}", usage())),
     }
 }
 
 fn usage() -> String {
-    "usage: cordis run <config.yml> [--worker]
+    "usage: cordis run <config.yml> [--plugin-dir <dir>]... [--worker]
 
-  run        start the loader from an entry config file
-  --worker   internal: run as the daemon's worker process
+  run             start the loader from an entry config file
+  --plugin-dir    also resolve plugins from dynamic libraries in <dir>
+                  (repeatable); library changes there hot-restart the worker
+  --worker        internal: run as the daemon's worker process
 
 Worker exit codes: 51 = hot restart, 52 = quit."
         .to_owned()
@@ -114,13 +142,13 @@ where
         dotenv::load(&dir);
     }
     if options.worker {
-        worker::run(&options.config);
+        worker::run(&options.config, &options.plugin_dirs);
     }
-    supervise(&options.config)
+    supervise(&options.config, &options.plugin_dirs)
 }
 
 /// Supervise worker subprocesses until they quit or a signal arrives.
-fn supervise(config: &std::path::Path) -> i32 {
+fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
     let shutdown = Arc::new(AtomicBool::new(false));
     let signal_flag = Arc::clone(&shutdown);
     if ctrlc::set_handler(move || {
@@ -143,12 +171,12 @@ fn supervise(config: &std::path::Path) -> i32 {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
-        let child = std::process::Command::new(&exe)
-            .arg("run")
-            .arg(config)
-            .arg("--worker")
-            .spawn();
-        let mut child = match child {
+        let mut command = std::process::Command::new(&exe);
+        command.arg("run").arg(config).arg("--worker");
+        for dir in plugin_dirs {
+            command.arg("--plugin-dir").arg(dir);
+        }
+        let mut child = match command.spawn() {
             Ok(child) => child,
             Err(error) => {
                 eprintln!("cordis: cannot spawn worker: {error}");
@@ -178,16 +206,41 @@ mod tests {
             parse_args(&args(&["run", "cordis.yml"])).unwrap(),
             Options {
                 config: "cordis.yml".into(),
-                worker: false
+                plugin_dirs: Vec::new(),
+                worker: false,
             }
         );
         assert_eq!(
             parse_args(&args(&["run", "cordis.yml", "--worker"])).unwrap(),
             Options {
                 config: "cordis.yml".into(),
-                worker: true
+                plugin_dirs: Vec::new(),
+                worker: true,
             }
         );
+    }
+
+    #[test]
+    fn parses_plugin_dirs_in_both_forms() {
+        let options = parse_args(&args(&[
+            "run",
+            "cordis.yml",
+            "--plugin-dir",
+            "a",
+            "--plugin-dir=b",
+        ]))
+        .unwrap();
+        assert_eq!(
+            options.plugin_dirs,
+            [PathBuf::from("a"), PathBuf::from("b")]
+        );
+        assert!(!options.worker);
+    }
+
+    #[test]
+    fn rejects_malformed_plugin_dirs() {
+        assert!(parse_args(&args(&["run", "cordis.yml", "--plugin-dir"])).is_err());
+        assert!(parse_args(&args(&["run", "cordis.yml", "--plugin-dir="])).is_err());
     }
 
     #[test]

--- a/crates/cordis-cli/src/worker.rs
+++ b/crates/cordis-cli/src/worker.rs
@@ -1,14 +1,21 @@
 //! Worker runtime: boot the loader, watch the config, exit on signals.
 
 use cordis::Context;
-use cordis_loader::{Loader, LoaderConfig};
-use std::path::Path;
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use notify::{Config as NotifyConfig, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::mpsc;
+use std::time::Duration;
 
 /// Exit code asking the daemon for a hot restart.
 pub const EXIT_RESTART: i32 = 51;
 /// Exit code telling the daemon to quit without restarting.
 pub const EXIT_QUIT: i32 = 52;
+
+/// Quiet window a plugin library must stay unchanged before the worker
+/// restarts, so incremental linker output does not restart mid-write.
+const PLUGIN_CHANGE_DEBOUNCE: Duration = Duration::from_millis(250);
 
 /// Handle exposed as the `worker` service so plugins can stop or restart
 /// the process (upstream's `ctx.loader.exit` / full-reload protocol).
@@ -45,12 +52,20 @@ impl WorkerInner {
     }
 }
 
-/// Run the worker process: load dotenv, boot the loader, watch the entry
-/// file, and block until a signal (or a `worker` service call) exits the
-/// process. Never returns.
-pub fn run(config_path: &Path) -> ! {
+/// Run the worker process: load dotenv, boot the loader (with dynamic
+/// plugin directories, if any), watch the entry file and the plugin
+/// directories, and block until a signal (or a `worker` service call)
+/// exits the process. Never returns.
+pub fn run(config_path: &Path, plugin_dirs: &[PathBuf]) -> ! {
     let root = Context::new();
-    let loader = match Loader::open(&root, LoaderConfig::new(config_path)) {
+    let mut registry = PluginRegistry::new();
+    if !plugin_dirs.is_empty() {
+        registry = registry.with_dynamic_dirs(plugin_dirs.iter());
+    }
+    let loader = match Loader::open(
+        &root,
+        LoaderConfig::new(config_path).with_registry(registry),
+    ) {
         Ok(loader) => loader,
         Err(error) => {
             eprintln!(
@@ -68,7 +83,7 @@ pub fn run(config_path: &Path) -> ! {
     let handle = Arc::new(WorkerHandle {
         inner: Arc::clone(&inner),
     });
-    if let Err(error) = root.provide_arc("worker", handle) {
+    if let Err(error) = root.provide_arc("worker", handle.clone()) {
         eprintln!("cordis: could not expose the worker service: {error}");
     }
 
@@ -90,6 +105,29 @@ pub fn run(config_path: &Path) -> ! {
         ),
     }
 
+    if !plugin_dirs.is_empty() {
+        // A changed library only takes effect through a fresh worker: the
+        // old process never unloads a mapped library, so the watcher asks
+        // the daemon for a restart instead of reloading in place.
+        match watch_plugin_dirs(plugin_dirs, handle) {
+            Ok(()) => eprintln!(
+                "cordis: dynamic plugins from {} (library changes hot-restart the worker)",
+                plugin_dirs
+                    .iter()
+                    .map(|dir| dir.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Err(error) => eprintln!(
+                "cordis: plugin library watching disabled ({error}); restart manually to apply changes"
+            ),
+        }
+    }
+
+    if let Some(error) = loader.last_error() {
+        eprintln!("cordis: startup issue: {error}");
+    }
+
     eprintln!(
         "cordis: worker ready ({} entries, config: {})",
         loader.tree().entries().len(),
@@ -100,5 +138,75 @@ pub fn run(config_path: &Path) -> ! {
     // park until a signal or service call ends the process.
     loop {
         std::thread::park();
+    }
+}
+
+/// Watch `dirs` (non-recursively) for plugin library changes and hot
+/// restart the worker through `handle` once a change settles.
+///
+/// Only files with a dynamic-library extension count; matching by
+/// extension (instead of exact paths) also absorbs macOS FSEvents
+/// reporting realpaths. The thread ends the process on the first settled
+/// change, so there is nothing to return.
+fn watch_plugin_dirs(dirs: &[PathBuf], handle: Arc<WorkerHandle>) -> Result<(), String> {
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::RecommendedWatcher::new(tx, NotifyConfig::default())
+        .map_err(|error| format!("cannot create watcher: {error}"))?;
+    for dir in dirs {
+        watcher
+            .watch(dir, RecursiveMode::NonRecursive)
+            .map_err(|error| format!("cannot watch {}: {error}", dir.display()))?;
+    }
+
+    std::thread::Builder::new()
+        .name("cordis-plugin-watch".to_owned())
+        .spawn(move || {
+            let _watcher = watcher; // keep the watch alive for the thread's lifetime
+            let mut pending = false;
+            loop {
+                match rx.recv_timeout(PLUGIN_CHANGE_DEBOUNCE) {
+                    Ok(Ok(event)) => {
+                        if event.paths.iter().any(|path| is_plugin_library(path)) {
+                            pending = true;
+                        }
+                    }
+                    Ok(Err(_)) => {}
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        if pending {
+                            eprintln!("cordis: plugin library changed, restarting worker");
+                            handle.restart();
+                        }
+                    }
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        })
+        .map_err(|error| format!("cannot spawn watcher thread: {error}"))?;
+    Ok(())
+}
+
+/// Whether `path` looks like a dynamic library by extension.
+fn is_plugin_library(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| {
+        matches!(
+            extension.to_ascii_lowercase().to_str(),
+            Some("so" | "dylib" | "dll")
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_library_extensions_match() {
+        assert!(is_plugin_library(Path::new("libgreeter.so")));
+        assert!(is_plugin_library(Path::new("libgreeter.dylib")));
+        assert!(is_plugin_library(Path::new("greeter.dll")));
+        assert!(is_plugin_library(Path::new("GREETER.SO")));
+        assert!(!is_plugin_library(Path::new("cordis.yml")));
+        assert!(!is_plugin_library(Path::new("libgreeter.so.tmp")));
+        assert!(!is_plugin_library(Path::new("plugins")));
     }
 }

--- a/crates/cordis-cli/tests/fixtures/file_writer.rs
+++ b/crates/cordis-cli/tests/fixtures/file_writer.rs
@@ -1,0 +1,40 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: a plugin that
+//! writes its build tag (`v1`, or `v2` under `--cfg hmr_v2`) to the file
+//! configured as `out`.
+//!
+//! Compiled with the same toolchain and workspace rlibs as the test binary,
+//! so its fingerprint satisfies the loader's check. Everything comes from
+//! the `cordis_loader` prelude so a single `--extern` suffices.
+
+use cordis_loader::Node;
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+#[cfg(hmr_v2)]
+const TEXT: &str = "v2";
+#[cfg(not(hmr_v2))]
+const TEXT: &str = "v1";
+
+/// Writes [`TEXT`] to the configured `out` path on apply.
+pub struct FileWriter;
+
+impl Plugin for FileWriter {
+    fn name(&self) -> &str {
+        "file_writer"
+    }
+
+    fn apply(&self, _ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async move {
+            let node = config.downcast::<Node>()?;
+            let out = node
+                .as_object()
+                .and_then(|object| object.get("out"))
+                .and_then(Node::as_str)
+                .unwrap_or("cordis-dynamic-fixture-out");
+            std::fs::write(out, TEXT)
+                .map_err(|error| format!("file_writer: cannot write {out}: {error}"))?;
+            Ok(PluginOutput::none())
+        })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(FileWriter);

--- a/crates/cordis-cli/tests/hmr.rs
+++ b/crates/cordis-cli/tests/hmr.rs
@@ -93,10 +93,12 @@ fn cdylib_file_name(crate_name: &str) -> String {
     }
 }
 
-/// Output directories of build scripts (`target/debug/build/*/out`),
-/// which hold the native libraries (`-sys` crates) the plugin must link
-/// against on Windows; cargo passes these to rustc, a manual invocation
-/// has to add them itself.
+/// Native library directories a manual rustc invocation must add: cargo
+/// derives them from build scripts, but a plain rustc call does not see
+/// those directives. Two shapes exist: build-script output directories
+/// (`target/debug/build/*/out`), and the `lib/` folders that `windows_*`
+/// helper crates ship inside their registry sources (windows-targets-era
+/// import libraries like `windows.0.53.0.lib` live there, not in OUT_DIR).
 fn native_search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Ok(entries) = std::fs::read_dir(target_dir().join("debug/build")) {
@@ -104,6 +106,29 @@ fn native_search_dirs() -> Vec<PathBuf> {
             let out = entry.path().join("out");
             if out.is_dir() {
                 dirs.push(out);
+            }
+        }
+    }
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            ["HOME", "USERPROFILE"].iter().find_map(|key| {
+                std::env::var_os(key).map(|home| PathBuf::from(home).join(".cargo"))
+            })
+        });
+    if let Some(registry) = cargo_home.map(|home| home.join("registry/src")) {
+        if let Ok(indices) = std::fs::read_dir(&registry) {
+            for index in indices.flatten() {
+                if let Ok(crates) = std::fs::read_dir(index.path()) {
+                    for krate in crates.flatten() {
+                        let lib = krate.path().join("lib");
+                        if krate.file_name().to_string_lossy().starts_with("windows_")
+                            && lib.is_dir()
+                        {
+                            dirs.push(lib);
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/cordis-cli/tests/hmr.rs
+++ b/crates/cordis-cli/tests/hmr.rs
@@ -93,6 +93,30 @@ fn cdylib_file_name(crate_name: &str) -> String {
     }
 }
 
+/// Output directories of build scripts (`target/debug/build/*/out`),
+/// which hold the native libraries (`-sys` crates) the plugin must link
+/// against on Windows; cargo passes these to rustc, a manual invocation
+/// has to add them itself.
+fn native_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(target_dir().join("debug/build")) {
+        for entry in entries.flatten() {
+            let out = entry.path().join("out");
+            if out.is_dir() {
+                dirs.push(out);
+            }
+        }
+    }
+    dirs
+}
+
+/// A path usable inside a JSON string literal: Windows separators are
+/// backslashes, which JSON would treat as invalid escapes. Rust's Windows
+/// file APIs accept forward slashes.
+fn json_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
 /// Compile `tests/fixtures/file_writer.rs` into a `cdylib` in `out_dir`,
 /// with extra `--cfg` flags to select the build tag.
 fn compile_plugin(out_dir: &Path, crate_name: &str, cfgs: &[&str]) -> PathBuf {
@@ -115,6 +139,9 @@ fn compile_plugin(out_dir: &Path, crate_name: &str, cfgs: &[&str]) -> PathBuf {
             "cordis_loader={}",
             find_rlib("cordis_loader").display()
         ));
+    for dir in native_search_dirs() {
+        command.arg("-L").arg(format!("native={}", dir.display()));
+    }
     for cfg in cfgs {
         command.arg(format!("--cfg={cfg}"));
     }
@@ -154,7 +181,7 @@ fn replacing_a_plugin_library_hot_restarts_the_worker() {
         &config,
         format!(
             r#"{{"entries":[{{"id":"w","name":"file_writer","config":{{"out":"{}"}}}}]}}"#,
-            out.display()
+            json_path(&out)
         ),
     )
     .unwrap();

--- a/crates/cordis-cli/tests/hmr.rs
+++ b/crates/cordis-cli/tests/hmr.rs
@@ -1,0 +1,207 @@
+//! End-to-end HMR: replacing a plugin library in a watched `--plugin-dir`
+//! hot-restarts the worker (exit 51) and the new build takes effect.
+//!
+//! Unix only: it replaces a library file that a running process still has
+//! mapped, which Windows forbids. Uses the kill utility on process groups
+//! like the other CLI tests.
+
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime};
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cordis-hmr-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// The workspace `target/` directory holding the built rlibs.
+fn target_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR is `<repo>/crates/cordis-cli`.
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("target")
+        })
+}
+
+/// The rustc that built this test binary: the pinned `RUSTC` override if
+/// present, else the binary next to `cargo`, else PATH.
+fn rustc() -> PathBuf {
+    if let Some(rustc) = std::env::var_os("RUSTC") {
+        let rustc = PathBuf::from(rustc);
+        if rustc.is_file() {
+            return rustc;
+        }
+    }
+    let sibling = PathBuf::from(env!("CARGO")).parent().unwrap().join("rustc");
+    if sibling.is_file() {
+        return sibling;
+    }
+    PathBuf::from("rustc")
+}
+
+/// Locate the built rlib for a workspace crate, preferring the unhashed
+/// uplift in `target/debug/` and falling back to the newest hashed copy.
+fn find_rlib(name: &str) -> PathBuf {
+    let debug = target_dir().join("debug");
+    let uplifted = debug.join(format!("lib{name}.rlib"));
+    if uplifted.is_file() {
+        return uplifted;
+    }
+    let prefix = format!("lib{name}-");
+    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(debug.join("deps")).expect("deps directory") {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let is_match = path
+            .extension()
+            .is_some_and(|extension| extension == "rlib")
+            && path
+                .file_name()
+                .and_then(|file| file.to_str())
+                .is_some_and(|file| file.starts_with(&prefix));
+        if !is_match {
+            continue;
+        }
+        let mtime = entry.metadata().unwrap().modified().unwrap();
+        if newest.as_ref().is_none_or(|(best, _)| mtime > *best) {
+            newest = Some((mtime, path));
+        }
+    }
+    newest
+        .unwrap_or_else(|| panic!("no rlib found for {name}"))
+        .1
+}
+
+/// The file a `cdylib` crate named `crate_name` produces.
+fn cdylib_file_name(crate_name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{crate_name}.dll")
+    } else if cfg!(target_os = "macos") {
+        format!("lib{crate_name}.dylib")
+    } else {
+        format!("lib{crate_name}.so")
+    }
+}
+
+/// Compile `tests/fixtures/file_writer.rs` into a `cdylib` in `out_dir`,
+/// with extra `--cfg` flags to select the build tag.
+fn compile_plugin(out_dir: &Path, crate_name: &str, cfgs: &[&str]) -> PathBuf {
+    std::fs::create_dir_all(out_dir).unwrap();
+    let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/file_writer.rs");
+    let mut command = Command::new(rustc());
+    command
+        .args(["--edition", "2024", "--crate-type", "cdylib"])
+        .arg(format!("--crate-name={crate_name}"))
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg(&source)
+        .arg("-L")
+        .arg(format!(
+            "dependency={}",
+            target_dir().join("debug/deps").display()
+        ))
+        .arg("--extern")
+        .arg(format!(
+            "cordis_loader={}",
+            find_rlib("cordis_loader").display()
+        ));
+    for cfg in cfgs {
+        command.arg(format!("--cfg={cfg}"));
+    }
+    let output = command.output().expect("run rustc");
+    assert!(
+        output.status.success(),
+        "compiling plugin {crate_name} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    out_dir.join(cdylib_file_name(crate_name))
+}
+
+fn wait_for(what: &str, check: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if check() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+#[test]
+fn replacing_a_plugin_library_hot_restarts_the_worker() {
+    let dir = temp_dir("replace");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let build = dir.join("build");
+    let v1 = compile_plugin(&build, "file_writer", &[]);
+    let v2 = compile_plugin(&build, "file_writer_v2", &["hmr_v2"]);
+    std::fs::copy(&v1, plugins.join(cdylib_file_name("file_writer"))).unwrap();
+
+    let out = dir.join("out.txt");
+    let config = dir.join("cordis.json");
+    std::fs::write(
+        &config,
+        format!(
+            r#"{{"entries":[{{"id":"w","name":"file_writer","config":{{"out":"{}"}}}}]}}"#,
+            out.display()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("run")
+        .arg(&config)
+        .arg("--plugin-dir")
+        .arg(&plugins)
+        .process_group(0)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn cordis binary");
+
+    wait_for("the first build to write v1", || {
+        std::fs::read_to_string(&out).ok().as_deref() == Some("v1")
+    });
+
+    // Replace the library atomically, from outside the watched directory
+    // so the staged copy does not trigger an early restart.
+    let staged = dir.join("staged.so");
+    std::fs::copy(&v2, &staged).unwrap();
+    std::fs::rename(&staged, plugins.join(cdylib_file_name("file_writer"))).unwrap();
+
+    // The watcher restarts the worker (exit 51) and the daemon respawns
+    // it; the fresh process loads the new build and writes v2.
+    wait_for("the restarted worker to write v2", || {
+        std::fs::read_to_string(&out).ok().as_deref() == Some("v2")
+    });
+    if let Ok(Some(status)) = child.try_wait() {
+        panic!("cordis exited early with {status}");
+    }
+
+    // Signal the whole process group, like a terminal Ctrl+C would. The
+    // `--` separator keeps the negative pgid from being parsed as a flag.
+    let _ = Command::new("kill")
+        .args(["-TERM", "--", &format!("-{}", child.id())])
+        .status();
+    let output = child.wait_with_output().expect("wait for cordis");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("plugin library changed, restarting worker"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("respawning"), "stderr: {stderr}");
+    assert_eq!(output.status.code(), Some(0), "daemon should exit 0");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cordis-loader/Cargo.toml
+++ b/crates/cordis-loader/Cargo.toml
@@ -14,8 +14,11 @@ readme = "README.md"
 default = []
 # Hot reload of the entry file through cordis-include's watcher.
 watch = ["cordis-include/watch"]
+# Dynamic-library plugins: resolve entry names from .so/.dylib/.dll files.
+dynamic = ["dep:libloading"]
 
 [dependencies]
 cordis-group.workspace = true
 cordis-include.workspace = true
 cordis-rs.workspace = true
+libloading = { workspace = true, optional = true }

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -88,6 +88,57 @@ Reloads compose all involved files into one tree diff; write-back always
 routes mounted entries back to the file they came from (generated ids
 included). Import cycles are reported via `last_error()` and skipped.
 
+## Dynamic library plugins
+
+With the `dynamic` feature, entries can also resolve to plugins compiled
+as `cdylib` libraries — Rust has no stable ABI, so this is gated on a
+strict build fingerprint (cordis-rs version, exact rustc including commit
+hash, target triple, panic strategy): a library built by anything other
+than the loading process' own toolchain is rejected instead of causing
+undefined behavior.
+
+On the plugin side, a `crate-type = ["cdylib"]` crate depending on
+`cordis-loader` with the `dynamic` feature implements `Plugin` and ends
+with the export macro (file name decides the plugin name):
+
+```rust,ignore
+// greeter-plugin/src/lib.rs — builds libgreeter.so / libgreeter.dylib /
+// greeter.dll
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+pub struct Greeter;
+
+impl Plugin for Greeter {
+    fn name(&self) -> &str { "greeter" }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async { Ok(PluginOutput::none()) })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(Greeter);
+```
+
+On the loading side, attach directories to the registry; names missing
+from the static registry resolve from `lib<name>.so` (`.dylib` on macOS,
+`<name>.dll` on Windows) there:
+
+```rust
+# use cordis_loader::PluginRegistry;
+let registry = PluginRegistry::new().with_dynamic_dirs(["/usr/lib/cordis-plugins"]);
+# assert!(registry.names().any(|name| name == "group"));
+```
+
+Each resolve asks the library for a fresh plugin instance in a fresh
+handle. Panics are contained on the plugin side — a `cdylib` links its
+own std, so the export macro wraps every callback in a guard that turns
+panics into errors and fallback values before they can cross the
+boundary. Libraries are never unloaded within a process, and a replaced
+library file requires a fresh process — which is exactly the HMR flow
+`cordis-cli` drives with `cordis run --plugin-dir <dir>`: it watches the
+directories and hot-restarts the worker (exit code 51) when a library
+changes. See the `dynamic` module docs for the full safety model.
+
 ## What the state machine does
 
 - **open** — read (or create) the entry file, build the tree, start every
@@ -129,6 +180,10 @@ let loader = Loader::open(&root, config)?;
 
 - **`watch`** — hot reload: wires `LoaderFile`'s debounced watcher to
   [`Loader::reload`]. Reload errors are recorded in `last_error()`.
+- **`dynamic`** — resolve entries from dynamic-library plugins
+  (`libloading`): fingerprint-checked loading through
+  `PluginRegistry::with_dynamic_dirs`, the `export_plugin!` macro for
+  plugin crates, and panic containment on the plugin side.
 
 The [`cordis-cli`](https://crates.io/crates/cordis-cli) runner builds its
 `cordis run` command on top of this crate.

--- a/crates/cordis-loader/build.rs
+++ b/crates/cordis-loader/build.rs
@@ -1,0 +1,47 @@
+//! Bake the build fingerprint ingredients for the `dynamic` feature into
+//! env vars readable via `env!` from `src`.
+//!
+//! The vars are emitted unconditionally (they are inert without the
+//! feature) and are part of the `cordis_plugin_fingerprint()` protocol:
+//! a dynamic library is only accepted when every ingredient matches the
+//! loading process byte for byte.
+
+use std::process::Command;
+
+fn main() {
+    // No `rerun-if` directives: rerun on any package change (the default),
+    // and the build script itself is recompiled — hence re-run — whenever
+    // the toolchain changes.
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+    let (release, hash) = rustc_version(&rustc);
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown-target".to_owned());
+    let panic = std::env::var("CARGO_CFG_PANIC").unwrap_or_else(|_| "unknown-panic".to_owned());
+    println!("cargo:rustc-env=CORDIS_RUSTC_RELEASE={release}");
+    println!("cargo:rustc-env=CORDIS_RUSTC_COMMIT_HASH={hash}");
+    println!("cargo:rustc-env=CORDIS_BUILD_TARGET={target}");
+    println!("cargo:rustc-env=CORDIS_BUILD_PANIC={panic}");
+}
+
+/// The `release:` and `commit-hash:` fields of `rustc -vV`, falling back to
+/// `unknown` markers when the compiler cannot be queried.
+fn rustc_version(rustc: &str) -> (String, String) {
+    let output = Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+        .unwrap_or_default();
+    let field = |name: &str| {
+        output
+            .lines()
+            .find_map(|line| line.strip_prefix(name))
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && *value != "unknown")
+            .map(ToString::to_string)
+    };
+    (
+        field("release: ").unwrap_or_else(|| "unknown-release".to_owned()),
+        field("commit-hash: ").unwrap_or_else(|| "unknown-hash".to_owned()),
+    )
+}

--- a/crates/cordis-loader/src/dynamic.rs
+++ b/crates/cordis-loader/src/dynamic.rs
@@ -1,0 +1,589 @@
+//! Dynamic-library plugins (behind the `dynamic` feature).
+//!
+//! Rust has no stable ABI, so a `.so`/`.dylib`/`.dll` and the process
+//! loading it are only compatible when they were produced by the *same*
+//! toolchain, target, panic strategy, and `cordis-rs` core version. This
+//! module enforces exactly that through a build fingerprint, then lets the
+//! two sides exchange a [`Plugin`] trait object directly.
+//!
+//! A plugin library is a `cdylib` crate that implements [`Plugin`] and ends
+//! with [`export_plugin!`]:
+//!
+//! ```rust,ignore
+//! // greeter/src/lib.rs — a crate with `crate-type = ["cdylib"]`
+//! use cordis::{plugin_sync, Inject, PluginOutput};
+//!
+//! pub struct Greeter;
+//!
+//! cordis_loader::dynamic::export_plugin!(plugin_sync::<(), _>(
+//!     "greeter",
+//!     Inject::default(),
+//!     |_ctx, _config| Ok(PluginOutput::none()),
+//! ));
+//! ```
+//!
+//! The loading side adds one or more plugin directories to a
+//! [`PluginRegistry`](crate::PluginRegistry); entries whose `name` matches
+//! the library file (`lib<name>.so` / `lib<name>.dylib` / `<name>.dll`)
+//! resolve to a fresh instance of that plugin.
+//!
+//! # Safety model
+//!
+//! - **Fingerprint gate.** Before any Rust value crosses the boundary, the
+//!   library must report this loader's exact [`fingerprint`]: ABI version,
+//!   `cordis-rs` core version, rustc release *and* commit hash, target
+//!   triple, and panic strategy. Any mismatch rejects the library — a
+//!   same-version-different-rustc build is just as incompatible as a
+//!   different cordis version, because vtable layouts differ.
+//! - **Panic containment (plugin side).** A `cdylib` statically links its
+//!   own copy of std, so a panic raised by plugin code is a *foreign*
+//!   exception in the loading process — unwinding it into the loader, or
+//!   trying to catch it there, aborts the process. All containment
+//!   therefore happens inside the library: [`export_plugin!`] wraps the
+//!   plugin in a guard that turns panics from `name`/`inject`/
+//!   `validate_config`/`apply` (poll-time included) into fallback values
+//!   and [`cordis::CordisError`]s, and the `extern "C"` entry points wrap
+//!   construction in [`std::panic::catch_unwind`] because unwinding out
+//!   of an `extern "C"` function is undefined behavior.
+//! - **No in-process unload.** The library handle is intentionally leaked
+//!   after a successful load: instances, vtables, and thread-local
+//!   destructors may reference the mapping forever, so `dlclose` can never
+//!   be proven safe. Unloading happens only at process exit — which is how
+//!   HMR works here anyway: `cordis-cli` watches the plugin directories and
+//!   restarts the whole worker (exit code 51), and the fresh process loads
+//!   the new build. Replacing a `.so` in place is therefore *not* picked up
+//!   by a running worker.
+//! - **Thin pointers.** `Box<dyn Plugin>` is fat; [`export_plugin!`]
+//!   double-boxes it (`Box<Box<dyn Plugin>>`) so the `*mut c_void` round
+//!   trip through the C symbol is lossless.
+
+use cordis::{ErrorCode, PluginHandle, VERSION};
+use cordis_include::resolver::unknown_plugin;
+use libloading::{Library, Symbol};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+// The plugin-authoring prelude: re-exported so a plugin crate can depend
+// on `cordis-loader` alone (these also serve as this module's imports).
+pub use crate::export_plugin;
+pub use cordis::utils::BoxFuture;
+pub use cordis::{Config, Context, Inject, Plugin, PluginOutput, Result};
+
+/// Symbol a dynamic library exports to negotiate the export protocol.
+const ABI_SYMBOL: &[u8] = b"cordis_plugin_abi\0";
+/// Symbol a dynamic library exports to report its build fingerprint.
+const FINGERPRINT_SYMBOL: &[u8] = b"cordis_plugin_fingerprint\0";
+/// Symbol a dynamic library exports to create one plugin instance.
+const CREATE_SYMBOL: &[u8] = b"cordis_plugin_create\0";
+
+/// Version of the dynamic-plugin export protocol (symbols, fingerprint
+/// format, double-boxing contract). Bump whenever the wire format changes.
+pub const DYNAMIC_ABI: u32 = 1;
+
+/// The signature of `cordis_plugin_create`.
+type CreateFn = unsafe extern "C" fn() -> *mut c_void;
+
+/// This build's dynamic-plugin compatibility fingerprint.
+///
+/// Two sides can exchange a `dyn Plugin` only when every ingredient
+/// matches, so the string pins the export protocol version, the
+/// [`cordis`] core version (trait/vtable source of truth), the exact rustc
+/// release *and* commit hash, the target triple, and the panic strategy —
+/// `panic=abort` versus `unwind` changes both unwinding and codegen.
+///
+/// The ingredients come from this crate's build script and are baked into
+/// the dependent's compilation: evaluating them inside a plugin build and
+/// inside the loading application yields the respective build's
+/// fingerprint, and equality is the compatibility check.
+pub fn fingerprint() -> &'static str {
+    static FINGERPRINT: OnceLock<String> = OnceLock::new();
+    FINGERPRINT.get_or_init(|| {
+        format!(
+            "cordis-dynamic/{DYNAMIC_ABI} cordis-rs/{VERSION} \
+             rustc/{}-{} target/{} panic/{}",
+            env!("CORDIS_RUSTC_RELEASE"),
+            env!("CORDIS_RUSTC_COMMIT_HASH"),
+            env!("CORDIS_BUILD_TARGET"),
+            env!("CORDIS_BUILD_PANIC"),
+        )
+    })
+}
+
+/// Backing for the `cordis_plugin_fingerprint` export; macro-internal.
+///
+/// Returns a pointer to a NUL-terminated copy of [`fingerprint`] that is
+/// initialized once and lives for the remainder of the process.
+pub fn plugin_fingerprint_cstr() -> *const c_char {
+    static FINGERPRINT_C: OnceLock<CString> = OnceLock::new();
+    FINGERPRINT_C
+        .get_or_init(|| {
+            // The fingerprint's ingredients cannot contain interior NULs.
+            CString::new(fingerprint()).expect("fingerprint without interior NUL")
+        })
+        .as_ptr()
+}
+
+/// Create one plugin instance for the `cordis_plugin_create` export;
+/// macro-internal.
+///
+/// The plugin is wrapped in [`PanicGuard`] — a cdylib links its own copy
+/// of std, so panics must be caught on this side of the boundary — and
+/// double-boxed: `Box<dyn Plugin>` is a fat pointer that cannot round-trip
+/// through `*mut c_void`, while the outer `Box<Box<dyn Plugin>>` is thin.
+/// Panics are contained because unwinding out of an `extern "C"` function
+/// is undefined behavior; on panic the function returns null, which the
+/// loading side reports as an error.
+pub fn create_boxed_plugin(make: impl FnOnce() -> Box<dyn Plugin>) -> *mut c_void {
+    catch_unwind(AssertUnwindSafe(|| {
+        let plugin: Box<dyn Plugin> = make();
+        let guarded: Box<dyn Plugin> = Box::new(PanicGuard { inner: plugin });
+        let boxed: Box<Box<dyn Plugin>> = Box::new(guarded);
+        Box::into_raw(boxed) as *mut c_void
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Name reported when a plugin panics in `name()`.
+const PANICKED_NAME: &str = "(plugin panicked in name())";
+
+/// An empty inject declaration for plugins that panic in `inject()`.
+fn empty_inject() -> &'static Inject {
+    static EMPTY: OnceLock<Inject> = OnceLock::new();
+    EMPTY.get_or_init(|| Inject::new(Vec::<String>::new()))
+}
+
+/// Wraps a plugin so panics in its callbacks stay inside the dynamic
+/// library that raised them ([`export_plugin!`] installs it).
+///
+/// A `cdylib` statically links its own copy of std: a panic raised by the
+/// plugin is a *foreign* exception in the loading process, and catching it
+/// there aborts ("Rust cannot catch foreign exceptions"). All containment
+/// therefore happens on the plugin side — this type and its
+/// [`std::panic::catch_unwind`] calls are compiled into the library and
+/// share std with the panicking code. Panics surface as a fallback name,
+/// an empty inject declaration, or a [`cordis::CordisError`].
+pub struct PanicGuard {
+    inner: Box<dyn Plugin>,
+}
+
+impl Plugin for PanicGuard {
+    fn name(&self) -> &str {
+        catch_unwind(AssertUnwindSafe(|| self.inner.name())).unwrap_or(PANICKED_NAME)
+    }
+
+    fn inject(&self) -> &Inject {
+        catch_unwind(AssertUnwindSafe(|| self.inner.inject())).unwrap_or_else(|_| empty_inject())
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        catch_unwind(AssertUnwindSafe(|| self.inner.validate_config(config)))
+            .unwrap_or_else(|panic| Err(guard_panic("validate_config()", panic)))
+    }
+
+    fn apply(&self, ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        // The synchronous call producing the future is guarded here; the
+        // future itself is wrapped by GuardedFuture so poll-time panics
+        // are contained as well.
+        let inner = catch_unwind(AssertUnwindSafe(|| self.inner.apply(ctx, config)))
+            .unwrap_or_else(|panic| {
+                let error = guard_panic("apply()", panic);
+                Box::pin(async move { Err(error) })
+            });
+        Box::pin(GuardedFuture { inner })
+    }
+}
+
+/// The [`PanicGuard`] future: polls the plugin's apply future with
+/// catch_unwind so panics raised during polling become apply errors.
+struct GuardedFuture {
+    inner: BoxFuture<Result<PluginOutput>>,
+}
+
+impl std::future::Future for GuardedFuture {
+    type Output = Result<PluginOutput>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match catch_unwind(AssertUnwindSafe(|| self.inner.as_mut().poll(cx))) {
+            Ok(poll) => poll,
+            Err(panic) => std::task::Poll::Ready(Err(guard_panic("apply()", panic))),
+        }
+    }
+}
+
+/// A panic payload as a [`cordis::CordisError`].
+fn guard_panic(operation: &str, panic: Box<dyn std::any::Any + Send>) -> cordis::CordisError {
+    let message = if let Some(text) = panic.downcast_ref::<&str>() {
+        (*text).to_owned()
+    } else if let Some(text) = panic.downcast_ref::<String>() {
+        text.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    };
+    cordis::CordisError::with_message(
+        ErrorCode::Plugin,
+        format!("dynamic plugin panicked in {operation}: {message}"),
+    )
+}
+
+/// Exports a plugin implementation through the cordis dynamic-plugin
+/// protocol so `cordis-loader`'s `dynamic` feature can load it.
+///
+/// Invoke once, at crate root of a `crate-type = ["cdylib"]` crate that
+/// depends on `cordis-loader` with the `dynamic` feature; `$make` is
+/// evaluated for every [`cordis::PluginHandle`] the loader resolves, so
+/// each entry gets its own instance. The file name decides the plugin
+/// name: `libgreeter.so` / `libgreeter.dylib` / `greeter.dll` resolve as
+/// `greeter`.
+///
+/// ```rust,ignore
+/// cordis_loader::dynamic::export_plugin!(MyPlugin::new());
+/// ```
+#[macro_export]
+macro_rules! export_plugin {
+    ($make:expr) => {
+        /// cordis dynamic-plugin export protocol version.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn cordis_plugin_abi() -> u32 {
+            $crate::dynamic::DYNAMIC_ABI
+        }
+
+        /// NUL-terminated build fingerprint of this plugin library.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn cordis_plugin_fingerprint() -> *const ::std::ffi::c_char {
+            $crate::dynamic::plugin_fingerprint_cstr()
+        }
+
+        /// One freshly created, double-boxed plugin instance (null on panic).
+        #[unsafe(no_mangle)]
+        pub extern "C" fn cordis_plugin_create() -> *mut ::std::ffi::c_void {
+            $crate::dynamic::create_boxed_plugin(|| Box::new($make))
+        }
+    };
+}
+
+/// A successfully loaded plugin library: the create entry point plus the
+/// file it came from. The library handle itself is intentionally leaked
+/// (see the [module docs](self)).
+#[derive(Clone)]
+struct LoadedPlugin {
+    create: CreateFn,
+    path: PathBuf,
+}
+
+/// Resolves entry names to plugins compiled as dynamic libraries.
+///
+/// Each directory is searched for the platform's `cdylib` naming scheme
+/// (`lib<name>.so` on Linux, `lib<name>.dylib` on macOS, `<name>.dll` on
+/// Windows). A library is opened and fingerprint-checked once; every
+/// resolve then asks it for a fresh instance wrapped in a new
+/// [`PluginHandle`], mirroring the static registry's one-instance-per-entry
+/// semantics.
+///
+/// Clones share the loaded-library cache, so a registry and its clones
+/// never open the same file twice.
+pub struct DynamicPluginResolver {
+    dirs: Arc<Vec<PathBuf>>,
+    loaded: Arc<Mutex<HashMap<String, LoadedPlugin>>>,
+}
+
+impl DynamicPluginResolver {
+    /// A resolver searching `dirs` (earlier directories win).
+    pub fn new<I, D>(dirs: I) -> Self
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<PathBuf>,
+    {
+        Self {
+            dirs: Arc::new(dirs.into_iter().map(Into::into).collect()),
+            loaded: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// The directories searched, in order.
+    pub fn dirs(&self) -> &[PathBuf] {
+        &self.dirs
+    }
+
+    /// The first existing library file that would satisfy `name`, without
+    /// loading it.
+    pub fn plugin_path(&self, name: &str) -> Option<PathBuf> {
+        self.dirs
+            .iter()
+            .flat_map(|dir| {
+                library_file_names(name)
+                    .into_iter()
+                    .map(move |file| dir.join(file))
+            })
+            .find(|path| path.is_file())
+    }
+
+    fn loaded_plugin(&self, name: &str) -> Result<LoadedPlugin> {
+        // The lock is held across loading: dlopen and the symbol checks are
+        // fast, and holding it makes check-then-load atomic.
+        let mut loaded = crate::lock(&self.loaded);
+        if let Some(plugin) = loaded.get(name) {
+            return Ok(plugin.clone());
+        }
+        let Some(path) = self.plugin_path(name) else {
+            return Err(unknown_plugin(name));
+        };
+        let plugin = load_library(name, &path)?;
+        loaded.insert(name.to_owned(), plugin.clone());
+        Ok(plugin)
+    }
+}
+
+impl Clone for DynamicPluginResolver {
+    fn clone(&self) -> Self {
+        Self {
+            dirs: Arc::clone(&self.dirs),
+            loaded: Arc::clone(&self.loaded),
+        }
+    }
+}
+
+impl cordis_include::PluginResolver for DynamicPluginResolver {
+    fn resolve(&self, name: &str) -> Result<PluginHandle> {
+        validate_name(name)?;
+        let loaded = self.loaded_plugin(name)?;
+        let plugin = create_instance(name, &loaded)?;
+        Ok(PluginHandle::new(plugin))
+    }
+}
+
+/// Reject names that could escape the plugin directories.
+fn validate_name(name: &str) -> Result<()> {
+    let invalid = name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.chars().any(|c| matches!(c, '/' | '\\' | '\0' | ':'));
+    if invalid {
+        return Err(cordis::CordisError::with_message(
+            ErrorCode::Plugin,
+            format!("invalid dynamic plugin name `{name}`"),
+        ));
+    }
+    Ok(())
+}
+
+/// Platform `cdylib` file names for a plugin name.
+fn library_file_names(name: &str) -> Vec<String> {
+    if cfg!(target_os = "macos") {
+        vec![format!("lib{name}.dylib"), format!("{name}.dylib")]
+    } else if cfg!(target_os = "windows") {
+        vec![format!("{name}.dll"), format!("lib{name}.dll")]
+    } else {
+        vec![format!("lib{name}.so"), format!("{name}.so")]
+    }
+}
+
+/// Open `path`, verify the export protocol and fingerprint, and keep the
+/// create entry point.
+#[allow(unsafe_code)]
+fn load_library(name: &str, path: &Path) -> Result<LoadedPlugin> {
+    let context = format!("dynamic plugin `{name}` ({})", path.display());
+    // SAFETY: loading a library runs its initializers; the file was found
+    // in a directory the embedder explicitly designated as trusted plugin
+    // search path.
+    let library = unsafe { Library::new(path) }
+        .map_err(|error| plugin_error(&context, format!("cannot be loaded: {error}")))?;
+
+    // SAFETY: the symbol names are NUL-terminated constants, and the
+    // returned symbols are only dereferenced while `library` is alive
+    // (which is forever — it is leaked below).
+    let abi: Symbol<unsafe extern "C" fn() -> u32> =
+        unsafe { library.get(ABI_SYMBOL) }.map_err(|error| {
+            plugin_error(
+                &context,
+                format!("does not export `cordis_plugin_abi` (not a cordis plugin?): {error}"),
+            )
+        })?;
+    // SAFETY: same lifetime argument as above.
+    let fingerprint_sym: Symbol<unsafe extern "C" fn() -> *const c_char> =
+        unsafe { library.get(FINGERPRINT_SYMBOL) }.map_err(|error| {
+            plugin_error(
+                &context,
+                format!("does not export `cordis_plugin_fingerprint`: {error}"),
+            )
+        })?;
+    // SAFETY: same lifetime argument as above.
+    let create: Symbol<CreateFn> = unsafe { library.get(CREATE_SYMBOL) }.map_err(|error| {
+        plugin_error(
+            &context,
+            format!("does not export `cordis_plugin_create`: {error}"),
+        )
+    })?;
+
+    // SAFETY: these calls run foreign code, which the fingerprint check
+    // below then constrains to code compiled exactly like this process.
+    // A panic inside them aborts the process (extern "C" unwinding is
+    // aborted by modern rustc); the macro-side catch_unwind prevents it
+    // from ever getting that far.
+    let reported_abi = unsafe { abi() };
+    if reported_abi != DYNAMIC_ABI {
+        return Err(plugin_error(
+            &context,
+            format!("reports ABI version {reported_abi}, this loader speaks {DYNAMIC_ABI}"),
+        ));
+    }
+    // SAFETY: see above.
+    let reported_fingerprint = unsafe { fingerprint_sym() };
+    let reported_fingerprint = if reported_fingerprint.is_null() {
+        String::new()
+    } else {
+        // SAFETY: the contract of `cordis_plugin_fingerprint` is a
+        // NUL-terminated string owned by the library; reading it here is
+        // within the library's lifetime.
+        unsafe { CStr::from_ptr(reported_fingerprint) }
+            .to_string_lossy()
+            .into_owned()
+    };
+    if reported_fingerprint != fingerprint() {
+        return Err(plugin_error(
+            &context,
+            format!(
+                "was built for a different toolchain or cordis version; \
+                 library fingerprint `{reported_fingerprint}` does not match \
+                 this process' `{}`",
+                fingerprint()
+            ),
+        ));
+    }
+
+    let create = *create;
+    // SAFETY (deliberate leak): dropping the handle would `dlclose` the
+    // library while plugin instances, vtables, and thread-local state may
+    // still reference it — undefined behavior. Leaking keeps the mapping
+    // alive for the whole process; unloading happens only at process exit
+    // (worker restart), after full teardown. This also means a replaced
+    // file is never re-loaded in the same process, by design.
+    std::mem::forget(library);
+    Ok(LoadedPlugin {
+        create,
+        path: path.to_path_buf(),
+    })
+}
+
+/// Ask a loaded library for one plugin instance and adapt it.
+#[allow(unsafe_code)]
+fn create_instance(name: &str, loaded: &LoadedPlugin) -> Result<DynamicPlugin> {
+    let context = format!("dynamic plugin `{name}` ({})", loaded.path.display());
+    // SAFETY: `create` was recovered from a library whose fingerprint
+    // matches this process byte for byte, so the returned box was allocated
+    // by the same allocator with the same layout contract.
+    let pointer = unsafe { (loaded.create)() };
+    if pointer.is_null() {
+        return Err(plugin_error(
+            &context,
+            "create returned null (constructor panicked?)",
+        ));
+    }
+    // SAFETY: `cordis_plugin_create`'s contract is a double-boxed plugin
+    // (`Box::into_raw(Box::new(PanicGuard { .. }))`); the fingerprint
+    // check guarantees both sides compiled the same trait and box layout,
+    // so reconstructing the box here is sound. We own the allocation.
+    let boxed: Box<Box<dyn Plugin>> = unsafe { Box::from_raw(pointer as *mut Box<dyn Plugin>) };
+
+    // The plugin-side PanicGuard guarantees these cannot panic (and must
+    // not be caught here: a library's panic is foreign to this process'
+    // std and would abort if unwound into our catch_unwind).
+    Ok(DynamicPlugin { inner: *boxed })
+}
+
+/// The loader-side adapter: gives the plugin-owned box a local [`Plugin`]
+/// implementation. Panics are already contained on the plugin side by
+/// [`PanicGuard`]; this wrapper only forwards.
+struct DynamicPlugin {
+    inner: Box<dyn Plugin>,
+}
+
+impl Plugin for DynamicPlugin {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn inject(&self) -> &Inject {
+        self.inner.inject()
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        self.inner.validate_config(config)
+    }
+
+    fn apply(&self, ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        self.inner.apply(ctx, config)
+    }
+}
+
+fn plugin_error(context: &str, message: impl Into<String>) -> cordis::CordisError {
+    cordis::CordisError::with_message(ErrorCode::Plugin, format!("{context}: {}", message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cordis_include::PluginResolver as _;
+
+    #[test]
+    fn fingerprint_pins_every_abi_ingredient() {
+        let fingerprint = fingerprint();
+        assert!(fingerprint.contains("cordis-dynamic/"), "{fingerprint}");
+        assert!(
+            fingerprint.contains(&format!("cordis-rs/{VERSION}")),
+            "{fingerprint}"
+        );
+        assert!(fingerprint.contains("rustc/"), "{fingerprint}");
+        assert!(fingerprint.contains("target/"), "{fingerprint}");
+        assert!(fingerprint.contains("panic/"), "{fingerprint}");
+    }
+
+    #[test]
+    fn names_that_could_escape_the_directories_are_rejected() {
+        for name in ["", ".", "..", "../escape", "a/b", "a\\b", "c:drive"] {
+            assert!(validate_name(name).is_err(), "{name:?}");
+        }
+        for name in ["greeter", "my-plugin", "plugin_v2"] {
+            assert!(validate_name(name).is_ok(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn library_file_names_follow_the_platform_scheme() {
+        let names = library_file_names("greeter");
+        if cfg!(target_os = "macos") {
+            assert_eq!(names, ["libgreeter.dylib", "greeter.dylib"]);
+        } else if cfg!(target_os = "windows") {
+            assert_eq!(names, ["greeter.dll", "libgreeter.dll"]);
+        } else {
+            assert_eq!(names, ["libgreeter.so", "greeter.so"]);
+        }
+    }
+
+    #[test]
+    fn missing_libraries_report_unknown_plugin() {
+        let resolver = DynamicPluginResolver::new([std::env::temp_dir()]);
+        let error = resolver
+            .resolve("definitely_not_a_real_plugin")
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("no plugin registered"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn traversal_names_are_rejected_before_touching_the_filesystem() {
+        let resolver = DynamicPluginResolver::new(["/"]);
+        let error = resolver.resolve("../etc/passwd").unwrap_err();
+        assert!(
+            error.to_string().contains("invalid dynamic plugin name"),
+            "{error}"
+        );
+    }
+}

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -10,7 +10,9 @@
 //!
 //! - **Static registry** ([`PluginRegistry`]) replaces upstream's dynamic
 //!   `import(name)`: register plugins at startup, entries resolve by name.
-//!   The `group` builtin is pre-registered.
+//!   The `group` builtin is pre-registered. With the `dynamic` feature,
+//!   names can also resolve to plugins compiled as dynamic libraries (see
+//!   the [`dynamic`] module).
 //! - **Startup**: [`Loader::open`] reads the entry file (writing
 //!   `initial` when missing), builds the [`EntryTree`], and starts every
 //!   enabled entry — group entries as `cordis_group::Group` fibers, children
@@ -71,13 +73,37 @@
 //! [`Loader::set_write_debounce`]: rapid successive writes coalesce into
 //! one physical write after the quiet window.
 //!
+//! # Dynamic library plugins
+//!
+//! With the `dynamic` feature, plugins can be compiled as `cdylib`
+//! libraries and resolved from a directory instead of being registered
+//! statically:
+//!
+//! ```rust,ignore
+//! let registry = PluginRegistry::new().with_dynamic_dirs(["./plugins"]);
+//! ```
+//!
+//! A plugin library exports its implementation through
+//! [`dynamic::export_plugin!`] and must be built by the exact same
+//! toolchain, target, panic strategy, and cordis-rs version as the loading
+//! process — the loader verifies a build fingerprint before accepting the
+//! library. Libraries are never unloaded within a process; reloading a
+//! changed library is the worker-restart HMR flow implemented by
+//! `cordis-cli`.
+//!
 //! # Not in scope yet
 //!
-//! Isolate/service migration and dynamic library plugins are future work.
+//! Isolate/service migration is future work.
 
-#![forbid(unsafe_code)]
+// `deny` instead of `forbid` because the `dynamic` feature wraps
+// libloading's unsafe primitives; every unsafe operation lives in that one
+// module, item-scoped behind `#[allow(unsafe_code)]` with SAFETY notes
+// (the same pattern cordis-cli uses for dotenv).
+#![deny(unsafe_code)]
 #![warn(missing_docs)]
 
+#[cfg(feature = "dynamic")]
+pub mod dynamic;
 pub mod error;
 pub mod events;
 pub mod loader;

--- a/crates/cordis-loader/src/registry.rs
+++ b/crates/cordis-loader/src/registry.rs
@@ -7,6 +7,7 @@ use cordis_group::Group;
 use cordis_include::IMPORT_NAME;
 use cordis_include::resolver::unknown_plugin;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// A factory producing fresh plugin handles.
@@ -18,9 +19,16 @@ type Factory = Arc<dyn Fn() -> PluginHandle + Send + Sync>;
 /// thus distinct [`cordis::PluginKey`] identities), mirroring one plugin
 /// instance per entry. The registry pre-registers [`cordis_group`]'s
 /// `group` marker.
+///
+/// With the `dynamic` feature, a
+/// [`DynamicPluginResolver`](crate::dynamic::DynamicPluginResolver) can be
+/// attached as a fallback: names missing from the registry are then looked
+/// up as dynamic libraries in its directories.
 #[derive(Clone, Default)]
 pub struct PluginRegistry {
     factories: HashMap<String, Factory>,
+    #[cfg(feature = "dynamic")]
+    dynamic: Option<crate::dynamic::DynamicPluginResolver>,
 }
 
 impl PluginRegistry {
@@ -54,12 +62,43 @@ impl PluginRegistry {
     pub fn names(&self) -> impl Iterator<Item = &str> {
         self.factories.keys().map(String::as_str)
     }
+
+    /// Attach `resolver` as the fallback for unknown names (dynamic
+    /// feature).
+    #[cfg(feature = "dynamic")]
+    pub fn set_dynamic(&mut self, resolver: crate::dynamic::DynamicPluginResolver) {
+        self.dynamic = Some(resolver);
+    }
+
+    /// Builder form of [`PluginRegistry::set_dynamic`]: search `dirs` for
+    /// dynamic-library plugins when a name is not statically registered.
+    #[cfg(feature = "dynamic")]
+    pub fn with_dynamic_dirs<I, D>(mut self, dirs: I) -> Self
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<PathBuf>,
+    {
+        self.set_dynamic(crate::dynamic::DynamicPluginResolver::new(dirs));
+        self
+    }
+
+    /// The attached dynamic resolver, if any (dynamic feature).
+    #[cfg(feature = "dynamic")]
+    pub fn dynamic(&self) -> Option<&crate::dynamic::DynamicPluginResolver> {
+        self.dynamic.as_ref()
+    }
 }
 
 impl cordis_include::PluginResolver for PluginRegistry {
     fn resolve(&self, name: &str) -> Result<PluginHandle> {
         match self.factories.get(name) {
             Some(factory) => Ok(factory()),
+            #[cfg(feature = "dynamic")]
+            None => match &self.dynamic {
+                Some(resolver) => resolver.resolve(name),
+                None => Err(unknown_plugin(name)),
+            },
+            #[cfg(not(feature = "dynamic"))]
             None => Err(unknown_plugin(name)),
         }
     }

--- a/crates/cordis-loader/tests/dynamic.rs
+++ b/crates/cordis-loader/tests/dynamic.rs
@@ -1,0 +1,282 @@
+//! Dynamic-library plugin tests.
+//!
+//! Fixtures under `tests/fixtures/` are compiled to `cdylib` files with the
+//! same toolchain and workspace rlibs that built the test binary, then
+//! loaded through [`DynamicPluginResolver`] — both directly and through a
+//! full [`Loader::open`] run.
+
+#![cfg(feature = "dynamic")]
+
+use cordis_include::PluginResolver as _;
+use cordis_loader::dynamic::DynamicPluginResolver;
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("cordis-dynamic-test-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// The workspace `target/` directory holding the built rlibs.
+fn target_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR is `<repo>/crates/cordis-loader`.
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("target")
+        })
+}
+
+/// The rustc that built this test binary: the pinned `RUSTC` override if
+/// present, else the binary next to `cargo`, else PATH.
+fn rustc() -> PathBuf {
+    if let Some(rustc) = std::env::var_os("RUSTC") {
+        let rustc = PathBuf::from(rustc);
+        if rustc.is_file() {
+            return rustc;
+        }
+    }
+    let sibling = PathBuf::from(env!("CARGO")).parent().unwrap().join("rustc");
+    if sibling.is_file() {
+        return sibling;
+    }
+    PathBuf::from("rustc")
+}
+
+/// Locate the built rlib for a workspace crate, preferring the unhashed
+/// uplift in `target/debug/` and falling back to the newest hashed copy.
+fn find_rlib(name: &str) -> PathBuf {
+    let debug = target_dir().join("debug");
+    let uplifted = debug.join(format!("lib{name}.rlib"));
+    if uplifted.is_file() {
+        return uplifted;
+    }
+    let prefix = format!("lib{name}-");
+    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(debug.join("deps")).expect("deps directory") {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let is_match = path
+            .extension()
+            .is_some_and(|extension| extension == "rlib")
+            && path
+                .file_name()
+                .and_then(|file| file.to_str())
+                .is_some_and(|file| file.starts_with(&prefix));
+        if !is_match {
+            continue;
+        }
+        let mtime = entry.metadata().unwrap().modified().unwrap();
+        if newest.as_ref().is_none_or(|(best, _)| mtime > *best) {
+            newest = Some((mtime, path));
+        }
+    }
+    newest
+        .unwrap_or_else(|| panic!("no rlib found for {name}"))
+        .1
+}
+
+/// The file a `cdylib` crate named `crate_name` produces.
+fn cdylib_file_name(crate_name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{crate_name}.dll")
+    } else if cfg!(target_os = "macos") {
+        format!("lib{crate_name}.dylib")
+    } else {
+        format!("lib{crate_name}.so")
+    }
+}
+
+/// Compile `tests/fixtures/<fixture>.rs` into a `cdylib` in `out_dir`.
+fn compile_fixture(out_dir: &Path, fixture: &str, cfgs: &[&str]) -> PathBuf {
+    std::fs::create_dir_all(out_dir).unwrap();
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(format!("{fixture}.rs"));
+    let mut command = Command::new(rustc());
+    command
+        .args(["--edition", "2024", "--crate-type", "cdylib"])
+        .arg(format!("--crate-name={fixture}"))
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg(&source)
+        .arg("-L")
+        .arg(format!(
+            "dependency={}",
+            target_dir().join("debug/deps").display()
+        ))
+        .arg("--extern")
+        .arg(format!(
+            "cordis_loader={}",
+            find_rlib("cordis_loader").display()
+        ));
+    for cfg in cfgs {
+        command.arg(format!("--cfg={cfg}"));
+    }
+    let output = command.output().expect("run rustc");
+    assert!(
+        output.status.success(),
+        "compiling fixture {fixture} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    out_dir.join(cdylib_file_name(fixture))
+}
+
+fn wait_for(what: &str, check: impl Fn() -> bool) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if check() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+#[test]
+fn resolves_and_applies_dynamic_plugins_end_to_end() {
+    let dir = temp_dir("e2e");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "file_writer", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("file_writer"))).unwrap();
+
+    let out = dir.join("out.txt");
+    let config = dir.join("cordis.json");
+    std::fs::write(
+        &config,
+        format!(
+            r#"{{"entries":[{{"id":"w","name":"file_writer","config":{{"out":"{}"}}}}]}}"#,
+            out.display()
+        ),
+    )
+    .unwrap();
+
+    let root = cordis::Context::new();
+    let registry = PluginRegistry::new().with_dynamic_dirs([&plugins]);
+    let loader = Loader::open(&root, LoaderConfig::new(&config).with_registry(registry)).unwrap();
+    assert!(loader.last_error().is_none(), "{:?}", loader.last_error());
+    wait_for("the plugin to write its output file", || {
+        std::fs::read_to_string(&out).ok().as_deref() == Some("v1")
+    });
+
+    let _ = loader.dispose();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn every_resolve_yields_a_fresh_handle() {
+    let dir = temp_dir("fresh");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "file_writer", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("file_writer"))).unwrap();
+
+    let resolver = DynamicPluginResolver::new([&plugins]);
+    let first = resolver.resolve("file_writer").unwrap();
+    let second = resolver.resolve("file_writer").unwrap();
+    assert_ne!(first.key(), second.key());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn static_registration_takes_priority_over_dynamic_libraries() {
+    let dir = temp_dir("priority");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "file_writer", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("file_writer"))).unwrap();
+
+    let mut registry = PluginRegistry::new().with_dynamic_dirs([&plugins]);
+    registry.register("file_writer", || {
+        cordis::plugin_sync::<(), _>("file_writer", cordis::Inject::default(), |_ctx, _config| {
+            Ok(cordis::PluginOutput::none())
+        })
+    });
+    let handle = cordis_include::PluginResolver::resolve(&registry, "file_writer").unwrap();
+    assert_eq!(handle.name(), "file_writer");
+    // The static factory won: resolving does not even need the file.
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rejects_libraries_with_a_foreign_fingerprint() {
+    let dir = temp_dir("fingerprint");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "bad_fingerprint", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("bad_fingerprint"))).unwrap();
+
+    let resolver = DynamicPluginResolver::new([&plugins]);
+    let error = resolver.resolve("bad_fingerprint").unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("fingerprint") && message.contains("does not match"),
+        "{message}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rejects_libraries_without_the_protocol_exports() {
+    let dir = temp_dir("plain");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "plain_library", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("plain_library"))).unwrap();
+
+    let resolver = DynamicPluginResolver::new([&plugins]);
+    let error = resolver.resolve("plain_library").unwrap_err();
+    assert!(error.to_string().contains("cordis_plugin_abi"), "{}", error);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn panicking_plugins_are_contained_on_the_plugin_side() {
+    let dir = temp_dir("panic");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "panic_on_name", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("panic_on_name"))).unwrap();
+
+    // A cdylib links its own std, so the loader must not see the panic at
+    // all: the plugin-side guard turns it into a fallback name.
+    let resolver = DynamicPluginResolver::new([&plugins]);
+    let handle = resolver.resolve("panic_on_name").unwrap();
+    assert_eq!(handle.name(), "(plugin panicked in name())");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_time_panics_surface_as_fiber_errors() {
+    let dir = temp_dir("panic-apply");
+    let plugins = dir.join("plugins");
+    std::fs::create_dir_all(&plugins).unwrap();
+    let library = compile_fixture(&dir.join("build"), "panic_in_apply", &[]);
+    std::fs::copy(&library, plugins.join(cdylib_file_name("panic_in_apply"))).unwrap();
+
+    // The plugin-side guard converts the poll-time panic into an ordinary
+    // apply failure: the fiber fails instead of the process aborting.
+    let resolver = DynamicPluginResolver::new([&plugins]);
+    let handle = resolver.resolve("panic_in_apply").unwrap();
+    let root = cordis::Context::new();
+    let fiber = root.plugin(handle, cordis::Value::new(()));
+    let error = fiber.try_wait().unwrap_err();
+    assert!(error.to_string().contains("panicked in apply"), "{error}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cordis-loader/tests/dynamic.rs
+++ b/crates/cordis-loader/tests/dynamic.rs
@@ -96,10 +96,12 @@ fn cdylib_file_name(crate_name: &str) -> String {
     }
 }
 
-/// Output directories of build scripts (`target/debug/build/*/out`),
-/// which hold the native libraries (`-sys` crates) the fixture must link
-/// against on Windows; cargo passes these to rustc, a manual invocation
-/// has to add them itself.
+/// Native library directories a manual rustc invocation must add: cargo
+/// derives them from build scripts, but a plain rustc call does not see
+/// those directives. Two shapes exist: build-script output directories
+/// (`target/debug/build/*/out`), and the `lib/` folders that `windows_*`
+/// helper crates ship inside their registry sources (windows-targets-era
+/// import libraries like `windows.0.53.0.lib` live there, not in OUT_DIR).
 fn native_search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Ok(entries) = std::fs::read_dir(target_dir().join("debug/build")) {
@@ -107,6 +109,29 @@ fn native_search_dirs() -> Vec<PathBuf> {
             let out = entry.path().join("out");
             if out.is_dir() {
                 dirs.push(out);
+            }
+        }
+    }
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            ["HOME", "USERPROFILE"].iter().find_map(|key| {
+                std::env::var_os(key).map(|home| PathBuf::from(home).join(".cargo"))
+            })
+        });
+    if let Some(registry) = cargo_home.map(|home| home.join("registry/src")) {
+        if let Ok(indices) = std::fs::read_dir(&registry) {
+            for index in indices.flatten() {
+                if let Ok(crates) = std::fs::read_dir(index.path()) {
+                    for krate in crates.flatten() {
+                        let lib = krate.path().join("lib");
+                        if krate.file_name().to_string_lossy().starts_with("windows_")
+                            && lib.is_dir()
+                        {
+                            dirs.push(lib);
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/cordis-loader/tests/dynamic.rs
+++ b/crates/cordis-loader/tests/dynamic.rs
@@ -96,6 +96,30 @@ fn cdylib_file_name(crate_name: &str) -> String {
     }
 }
 
+/// Output directories of build scripts (`target/debug/build/*/out`),
+/// which hold the native libraries (`-sys` crates) the fixture must link
+/// against on Windows; cargo passes these to rustc, a manual invocation
+/// has to add them itself.
+fn native_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(target_dir().join("debug/build")) {
+        for entry in entries.flatten() {
+            let out = entry.path().join("out");
+            if out.is_dir() {
+                dirs.push(out);
+            }
+        }
+    }
+    dirs
+}
+
+/// A path usable inside a JSON string literal: Windows separators are
+/// backslashes, which JSON would treat as invalid escapes. Rust's Windows
+/// file APIs accept forward slashes.
+fn json_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
 /// Compile `tests/fixtures/<fixture>.rs` into a `cdylib` in `out_dir`.
 fn compile_fixture(out_dir: &Path, fixture: &str, cfgs: &[&str]) -> PathBuf {
     std::fs::create_dir_all(out_dir).unwrap();
@@ -119,6 +143,9 @@ fn compile_fixture(out_dir: &Path, fixture: &str, cfgs: &[&str]) -> PathBuf {
             "cordis_loader={}",
             find_rlib("cordis_loader").display()
         ));
+    for dir in native_search_dirs() {
+        command.arg("-L").arg(format!("native={}", dir.display()));
+    }
     for cfg in cfgs {
         command.arg(format!("--cfg={cfg}"));
     }
@@ -156,7 +183,7 @@ fn resolves_and_applies_dynamic_plugins_end_to_end() {
         &config,
         format!(
             r#"{{"entries":[{{"id":"w","name":"file_writer","config":{{"out":"{}"}}}}]}}"#,
-            out.display()
+            json_path(&out)
         ),
     )
     .unwrap();

--- a/crates/cordis-loader/tests/fixtures/bad_fingerprint.rs
+++ b/crates/cordis-loader/tests/fixtures/bad_fingerprint.rs
@@ -1,0 +1,20 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: exports the
+//! protocol symbols but reports a foreign build fingerprint, so the loader
+//! must reject it. Hand-written to avoid depending on the workspace crates.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cordis_plugin_abi() -> u32 {
+    1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cordis_plugin_fingerprint() -> *const std::ffi::c_char {
+    b"cordis-dynamic/1 cordis-rs/0.0.0 rustc/0.0.0-none target/none panic/none\0"
+        .as_ptr()
+        .cast()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cordis_plugin_create() -> *mut std::ffi::c_void {
+    std::ptr::null_mut()
+}

--- a/crates/cordis-loader/tests/fixtures/file_writer.rs
+++ b/crates/cordis-loader/tests/fixtures/file_writer.rs
@@ -1,0 +1,40 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: a plugin that
+//! writes its build tag (`v1`, or `v2` under `--cfg hmr_v2`) to the file
+//! configured as `out`.
+//!
+//! Compiled with the same toolchain and workspace rlibs as the test binary,
+//! so its fingerprint satisfies the loader's check. Everything comes from
+//! the `cordis_loader` prelude so a single `--extern` suffices.
+
+use cordis_loader::Node;
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+#[cfg(hmr_v2)]
+const TEXT: &str = "v2";
+#[cfg(not(hmr_v2))]
+const TEXT: &str = "v1";
+
+/// Writes [`TEXT`] to the configured `out` path on apply.
+pub struct FileWriter;
+
+impl Plugin for FileWriter {
+    fn name(&self) -> &str {
+        "file_writer"
+    }
+
+    fn apply(&self, _ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async move {
+            let node = config.downcast::<Node>()?;
+            let out = node
+                .as_object()
+                .and_then(|object| object.get("out"))
+                .and_then(Node::as_str)
+                .unwrap_or("cordis-dynamic-fixture-out");
+            std::fs::write(out, TEXT)
+                .map_err(|error| format!("file_writer: cannot write {out}: {error}"))?;
+            Ok(PluginOutput::none())
+        })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(FileWriter);

--- a/crates/cordis-loader/tests/fixtures/panic_in_apply.rs
+++ b/crates/cordis-loader/tests/fixtures/panic_in_apply.rs
@@ -1,0 +1,22 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: a plugin whose
+//! apply future panics, to prove poll-time panics are contained on the
+//! plugin side and surface as a fiber error instead of aborting.
+
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+/// Panics inside the apply future.
+pub struct PanicInApply;
+
+impl Plugin for PanicInApply {
+    fn name(&self) -> &str {
+        "panic_in_apply"
+    }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async {
+            panic!("boom from panic_in_apply");
+        })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(PanicInApply);

--- a/crates/cordis-loader/tests/fixtures/panic_on_name.rs
+++ b/crates/cordis-loader/tests/fixtures/panic_on_name.rs
@@ -1,0 +1,20 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: a plugin whose
+//! `name()` panics, to prove panics are contained at the boundary instead
+//! of unwinding through `extern "C"` or the loader.
+
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+/// Panics in `name()`.
+pub struct PanicOnName;
+
+impl Plugin for PanicOnName {
+    fn name(&self) -> &str {
+        panic!("boom from panic_on_name")
+    }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async { Ok(PluginOutput::none()) })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(PanicOnName);

--- a/crates/cordis-loader/tests/fixtures/plain_library.rs
+++ b/crates/cordis-loader/tests/fixtures/plain_library.rs
@@ -1,0 +1,6 @@
+//! Fixture compiled to a `cdylib` by the dynamic tests: a plain library
+//! with none of the protocol exports.
+
+pub fn hello() -> &'static str {
+    "not a plugin"
+}

--- a/crates/cordis/src/lib.rs
+++ b/crates/cordis/src/lib.rs
@@ -34,6 +34,13 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+/// Version of the cordis-rs core this binary was compiled against.
+///
+/// Dynamic-library plugins (`cordis-loader`'s `dynamic` feature) embed this
+/// in their build fingerprint so a library built against a different core
+/// version is rejected instead of producing undefined behavior.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod context;
 pub mod effect;
 pub mod error;


### PR DESCRIPTION
## Summary

Implements the last outstanding item from the porting backlog: dynamic-library plugin loading (`cordis-loader`'s `dynamic` feature) and the HMR flow built on it (`cordis run --plugin-dir`).

**ABI approach (per the agreed trade-off):** same-toolchain `.cdylib` plugins exchanged as `Box<dyn Plugin>`, gated by a strict build fingerprint — not just the cordis-rs version, but the exact rustc release *and* commit hash, target triple, and panic strategy (baked in by a build script on both sides). Any mismatch rejects the library with a clear error instead of risking undefined behavior.

Boundary details:
- **Double boxing** — `Box<Box<dyn Plugin>>` keeps the fat trait pointer round-trip through `*mut c_void` lossless (`export_plugin!` provides the whole protocol).
- **Panic containment on the plugin side** — a cdylib statically links its own std, so the loading process would see a *foreign* exception and abort ("Rust cannot catch foreign exceptions"); the macro therefore wraps every callback (incl. poll-time panics in apply futures) in a guard compiled into the library, converting panics into fallback values / `CordisError`s.
- **No in-process unload** — the library handle is deliberately leaked; plugin instances and vtables may outlive any scope, so `dlclose` can never be proven safe. Unloading happens only at process exit, which is exactly the HMR model: the CLI watches plugin directories and hot-restarts the worker (exit 51) when a `.so`/`.dylib`/`.dll` settles; the daemon respawns a fresh worker that loads the new build and rebuilds all state.

## API surface

- `cordis::VERSION` — core version constant (fingerprint ingredient).
- `cordis_loader::dynamic` — `DynamicPluginResolver`, `export_plugin!`, `fingerprint()`, plugin-authoring prelude re-exports.
- `PluginRegistry::with_dynamic_dirs / set_dynamic / dynamic` — fallback resolution; static registrations keep priority; each resolve yields a fresh handle.
- `cordis run [--plugin-dir <dir>]...` — forwarded to the worker; directory changes hot-restart it.

## Tests

- Loader integration tests compile fixture `.cdylib`s with the running rustc: happy path through `Loader::open`, fingerprint mismatch rejection, missing-protocol rejection, path-traversal rejection, panic containment (name/apply), fresh-handle semantics, static-over-dynamic priority.
- CLI end-to-end: replace `libfile_writer.so` under a running daemon → worker restarts → new build writes its marker → graceful shutdown (unix-only; Windows cannot replace a mapped DLL).

Docs updated: loader README (new section, doctested loader-side snippet), root READMEs EN/中文 (ecosystem table + porting status), loader lib docs. `#![forbid(unsafe_code)]` relaxed to `deny` in cordis-loader only, with item-scoped `#[allow]` + SAFETY notes in the dynamic module (same pattern as cordis-cli's dotenv).