### PR TITLE
fix: resolve the audited Major defects (P1–P8)

### DIFF
--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -3,10 +3,14 @@
 //!
 //! The process model follows upstream Cordis' NodeLoader: `cordis run`
 //! supervises a worker subprocess running the loader. The worker exits
-//! with code `51` to request a hot restart and `52` to quit; `SIGINT` /
-//! `SIGTERM` dispose the root context gracefully and exit `52`. `.env` and
-//! `.env.local` are loaded (without overriding existing variables) before
-//! the worker boots, and the entry file is watched for hot reload.
+//! with code `51` to request a hot restart (respawned with a doubling,
+//! capped backoff), `52` to quit, and `53` when the loader never came up.
+//! The daemon exits `0` on clean shutdown, `1` when the worker never
+//! booted or died abnormally, and otherwise propagates the worker's code —
+//! deployment pipelines always see the real outcome. `SIGINT` / `SIGTERM`
+//! dispose the root context gracefully and exit `52` (daemon `0`). `.env`
+//! and `.env.local` are loaded (without overriding existing variables)
+//! before the worker boots, and the entry file is watched for hot reload.
 //!
 //! `--plugin-dir <dir>` (repeatable) additionally resolves entries from
 //! dynamic-library plugins compiled against the same toolchain; a change
@@ -26,6 +30,14 @@ pub mod worker;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// Initial delay before respawning a restart-looping worker.
+const RESTART_BACKOFF_START: Duration = Duration::from_millis(100);
+/// Ceiling for the doubling restart delay.
+const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(5);
+/// A worker that stayed up at least this long resets the restart backoff.
+const RESTART_BACKOFF_RESET_AFTER: Duration = Duration::from_secs(10);
 
 /// What the supervisor does after a worker exits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +58,39 @@ pub fn supervisor_action(exit_code: Option<i32>, shutdown: bool) -> Action {
     } else {
         Action::Restart
     }
+}
+
+/// The daemon's own exit code after the worker stopped.
+///
+/// A clean quit (52) and a daemon-side shutdown signal exit 0; a worker
+/// that never booted (53) exits 1 so deployment pipelines see the failure;
+/// a crashed worker's code is propagated instead of being masked as
+/// success.
+pub fn daemon_exit_code(exit_code: Option<i32>, shutdown: bool) -> i32 {
+    if shutdown {
+        return 0;
+    }
+    match exit_code {
+        Some(code) if code == worker::EXIT_QUIT => 0,
+        Some(code) if code == worker::EXIT_RESTART => 0,
+        Some(code) if code == worker::EXIT_BOOT => 1,
+        Some(code) => code,
+        None => 1,
+    }
+}
+
+/// The delay before respawning a restart-looping worker: doubling from
+/// [`RESTART_BACKOFF_START`], capped at [`RESTART_BACKOFF_MAX`], and reset
+/// whenever the previous worker stayed up at least
+/// [`RESTART_BACKOFF_RESET_AFTER`].
+fn next_backoff(previous: Option<Duration>, ran_for: Duration) -> Duration {
+    let Some(previous) = previous else {
+        return RESTART_BACKOFF_START;
+    };
+    if ran_for >= RESTART_BACKOFF_RESET_AFTER {
+        return RESTART_BACKOFF_START;
+    }
+    previous.saturating_mul(2).min(RESTART_BACKOFF_MAX)
 }
 
 /// Parsed command line.
@@ -119,7 +164,9 @@ fn usage() -> String {
                   (repeatable); library changes there hot-restart the worker
   --worker        internal: run as the daemon's worker process
 
-Worker exit codes: 51 = hot restart, 52 = quit."
+Worker exit codes: 51 = hot restart, 52 = quit, 53 = boot failure.
+Daemon exit codes: 0 = clean shutdown, 1 = worker never booted or died
+abnormally, otherwise the worker's own code."
         .to_owned()
 }
 
@@ -167,10 +214,16 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
             return 1;
         }
     };
+    // Restart backoff so a restart loop cannot spin the CPU; a worker that
+    // stayed up long enough resets it.
+    let mut backoff: Option<Duration> = None;
+    let exit_code;
     loop {
         if shutdown.load(Ordering::SeqCst) {
+            exit_code = Some(worker::EXIT_QUIT);
             break;
         }
+        let started = std::time::Instant::now();
         let mut command = std::process::Command::new(&exe);
         command.arg("run").arg(config).arg("--worker");
         for dir in plugin_dirs {
@@ -183,13 +236,20 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
                 return 1;
             }
         };
-        let exit_code = child.wait().ok().and_then(|status| status.code());
-        if supervisor_action(exit_code, shutdown.load(Ordering::SeqCst)) == Action::Stop {
+        let code = child.wait().ok().and_then(|status| status.code());
+        if supervisor_action(code, shutdown.load(Ordering::SeqCst)) == Action::Stop {
+            exit_code = code;
             break;
         }
-        eprintln!("cordis: worker requested restart, respawning");
+        let delay = next_backoff(backoff, started.elapsed());
+        eprintln!(
+            "cordis: worker requested restart, respawning in {}ms",
+            delay.as_millis()
+        );
+        backoff = Some(delay);
+        std::thread::sleep(delay);
     }
-    0
+    daemon_exit_code(exit_code, shutdown.load(Ordering::SeqCst))
 }
 
 #[cfg(test)]
@@ -259,5 +319,39 @@ mod tests {
         assert_eq!(supervisor_action(Some(52), false), Action::Stop);
         assert_eq!(supervisor_action(Some(0), false), Action::Stop);
         assert_eq!(supervisor_action(None, false), Action::Stop);
+    }
+
+    #[test]
+    fn daemon_exit_code_reflects_how_the_worker_ended() {
+        // Clean quit and daemon-side shutdown stay successful.
+        assert_eq!(daemon_exit_code(Some(52), false), 0);
+        assert_eq!(daemon_exit_code(Some(52), true), 0);
+        assert_eq!(daemon_exit_code(Some(51), true), 0);
+        // A worker that never booted fails the daemon.
+        assert_eq!(daemon_exit_code(Some(53), false), 1);
+        // Crashes propagate instead of being masked as success.
+        assert_eq!(daemon_exit_code(Some(101), false), 101);
+        assert_eq!(daemon_exit_code(None, false), 1);
+    }
+
+    #[test]
+    fn restart_backoff_doubles_resets_and_caps() {
+        assert_eq!(
+            next_backoff(None, Duration::from_secs(0)),
+            RESTART_BACKOFF_START
+        );
+        assert_eq!(
+            next_backoff(Some(Duration::from_millis(100)), Duration::from_secs(1)),
+            Duration::from_millis(200)
+        );
+        assert_eq!(
+            next_backoff(Some(Duration::from_secs(4)), Duration::from_secs(1)),
+            RESTART_BACKOFF_MAX
+        );
+        assert_eq!(
+            next_backoff(Some(Duration::from_secs(4)), Duration::from_secs(60)),
+            RESTART_BACKOFF_START,
+            "a worker that stayed up resets the backoff"
+        );
     }
 }

--- a/crates/cordis-cli/src/worker.rs
+++ b/crates/cordis-cli/src/worker.rs
@@ -12,6 +12,9 @@ use std::time::Duration;
 pub const EXIT_RESTART: i32 = 51;
 /// Exit code telling the daemon to quit without restarting.
 pub const EXIT_QUIT: i32 = 52;
+/// Exit code reporting that the loader never came up (bad config,
+/// unreadable file); the daemon exits non-zero instead of masking it.
+pub const EXIT_BOOT: i32 = 53;
 
 /// Quiet window a plugin library must stay unchanged before the worker
 /// restarts, so incremental linker output does not restart mid-write.
@@ -72,7 +75,7 @@ pub fn run(config_path: &Path, plugin_dirs: &[PathBuf]) -> ! {
                 "cordis: failed to start from {}: {error}",
                 config_path.display()
             );
-            std::process::exit(EXIT_QUIT);
+            std::process::exit(EXIT_BOOT);
         }
     };
     let inner = Arc::new(WorkerInner {

--- a/crates/cordis-cli/tests/cli.rs
+++ b/crates/cordis-cli/tests/cli.rs
@@ -96,3 +96,48 @@ fn unknown_arguments_fail_fast() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unknown command"), "stderr: {stderr}");
 }
+
+#[test]
+fn a_config_that_cannot_boot_fails_the_daemon() {
+    let dir = temp_dir("boot-fail");
+    // An unsupported extension fails LoaderFile::open in the worker.
+    let config = dir.join("cordis.toml");
+    std::fs::write(&config, "entries: []\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("run")
+        .arg(&config)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to start"), "stderr: {stderr}");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "boot failures must not exit 0"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_unparseable_config_fails_the_daemon() {
+    let dir = temp_dir("corrupt");
+    let config = dir.join("cordis.json");
+    std::fs::write(&config, "{\"entries\": [").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("run")
+        .arg(&config)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to start"), "stderr: {stderr}");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a corrupt config must not exit 0"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cordis-cli/tests/hmr.rs
+++ b/crates/cordis-cli/tests/hmr.rs
@@ -49,35 +49,36 @@ fn rustc() -> PathBuf {
     PathBuf::from("rustc")
 }
 
-/// Locate the built rlib for a workspace crate, preferring the unhashed
-/// uplift in `target/debug/` and falling back to the newest hashed copy.
+/// Locate the freshest built rlib for a workspace crate: the unhashed
+/// uplift in `target/debug/` and the hashed copies in `deps/` compete,
+/// and the newest wins (a stale uplift must not shadow a fresh build).
 fn find_rlib(name: &str) -> PathBuf {
     let debug = target_dir().join("debug");
-    let uplifted = debug.join(format!("lib{name}.rlib"));
-    if uplifted.is_file() {
-        return uplifted;
-    }
     let prefix = format!("lib{name}-");
-    let mut newest: Option<(SystemTime, PathBuf)> = None;
-    for entry in std::fs::read_dir(debug.join("deps")).expect("deps directory") {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        let is_match = path
-            .extension()
-            .is_some_and(|extension| extension == "rlib")
-            && path
-                .file_name()
-                .and_then(|file| file.to_str())
-                .is_some_and(|file| file.starts_with(&prefix));
-        if !is_match {
-            continue;
-        }
-        let mtime = entry.metadata().unwrap().modified().unwrap();
-        if newest.as_ref().is_none_or(|(best, _)| mtime > *best) {
-            newest = Some((mtime, path));
+    let mut candidates: Vec<(SystemTime, PathBuf)> = Vec::new();
+    let uplifted = debug.join(format!("lib{name}.rlib"));
+    if let Ok(metadata) = std::fs::metadata(&uplifted) {
+        candidates.push((metadata.modified().unwrap(), uplifted));
+    }
+    if let Ok(entries) = std::fs::read_dir(debug.join("deps")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_match = path
+                .extension()
+                .is_some_and(|extension| extension == "rlib")
+                && path
+                    .file_name()
+                    .and_then(|file| file.to_str())
+                    .is_some_and(|file| file.starts_with(&prefix));
+            if is_match {
+                let mtime = entry.metadata().unwrap().modified().unwrap();
+                candidates.push((mtime, path));
+            }
         }
     }
-    newest
+    candidates.sort_by_key(|candidate| candidate.0);
+    candidates
+        .pop()
         .unwrap_or_else(|| panic!("no rlib found for {name}"))
         .1
 }

--- a/crates/cordis-include/src/tree.rs
+++ b/crates/cordis-include/src/tree.rs
@@ -25,8 +25,13 @@ pub struct RemovedEntry {
 pub struct TreeDiff {
     /// Entries that appeared in the new data (subtree roots first).
     pub created: Vec<Entry>,
-    /// Entries still present whose options changed.
+    /// Entries still present whose non-structural options (config or
+    /// nested children) changed.
     pub updated: Vec<Entry>,
+    /// Entries still present whose structural options changed — plugin
+    /// name, inject declaration, or enabled flag — and therefore need a
+    /// stop-and-start instead of an in-place patch.
+    pub redefined: Vec<Entry>,
     /// Entries that moved to a different parent.
     pub moved: Vec<Entry>,
     /// Entries whose ids vanished from the new data (whole subtrees).
@@ -38,6 +43,7 @@ impl TreeDiff {
     pub fn is_empty(&self) -> bool {
         self.created.is_empty()
             && self.updated.is_empty()
+            && self.redefined.is_empty()
             && self.moved.is_empty()
             && self.removed.is_empty()
     }
@@ -330,8 +336,17 @@ fn sync_children(
         let entry = match pool.remove(&id) {
             Some(existing) => {
                 if existing.options() != options {
+                    // Structural changes (plugin identity or gating) need a
+                    // restart; config or child-list changes patch in place.
+                    let structural = existing.options().name != options.name
+                        || existing.options().inject != options.inject
+                        || existing.options().disabled != options.disabled;
                     existing.set_options(options);
-                    diff.updated.push(existing.clone());
+                    if structural {
+                        diff.redefined.push(existing.clone());
+                    } else {
+                        diff.updated.push(existing.clone());
+                    }
                 }
                 let moved = existing
                     .parent()

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -143,17 +143,25 @@ changes. See the `dynamic` module docs for the full safety model.
 
 - **open** — read (or create) the entry file, build the tree, start every
   enabled entry; group children start beneath their group fiber's context,
-  so disposing a group cascades.
+  so disposing a group cascades. A corrupt or unreadable main file fails
+  the open instead of silently starting an empty tree.
 - **reload** — re-read the file under a suspend guard and reconcile:
   created entries start, removed subtrees stop, moved entries restart
-  under their new parent, config-only changes patch in place. Generated
-  ids are persisted afterwards so the next reload matches them.
+  under their new parent, entries whose plugin name / inject declaration /
+  enabled flag changed stop and restart with their new options, and
+  config-only changes patch in place. Generated ids are persisted
+  afterwards so the next reload matches them.
+- **dispose** — stop every entry, stop watching files, and release the
+  loader's root-level effects (the status listener and the `loader`
+  service); a fresh `Loader::open` on the same root works afterwards.
 - **self-kill** — a fiber that reaches `Disposed` outside loader operation
   was killed by its own plugin; the loader persists `disabled: true` for
   that entry. Removing an entry from the file just stops it.
-- **inject** — an entry's `inject` list is merged into the plugin's own
-  declaration, so services going away or coming back reconciles entries
-  through the core machinery.
+- **inject** — an entry's `inject` list is merged with the plugin's own
+  declaration (both gate startup), so services going away or coming back
+  reconciles entries through the core machinery. The import graph must be
+  a tree: cycles and duplicate mounts of one file are reported distinctly
+  through `last_error()`.
 - **update_config** — the runtime entry point for changing config: updates
   the fiber and persists to the file.
 

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -23,7 +23,11 @@
 //! - **Reload** ([`Loader::reload`], wired to the `watch` feature):
 //!   re-read the file, diff the tree, and reconcile fibers — created entries
 //!   start, removed subtrees stop, moved entries restart under their new
-//!   parent, config-only changes patch in place via `Fiber::update_value`.
+//!   parent, entries whose plugin name / inject declaration / enabled flag
+//!   changed stop and restart with their new options, and config-only
+//!   changes patch in place via `Fiber::update_value`. A corrupt or
+//!   unreadable main file fails the operation instead of silently booting
+//!   an empty tree (import files keep a tolerant record-and-skip path).
 //! - **Inject**: an entry's `inject` list is merged into the plugin's own
 //!   declaration, so the core fiber machinery reconciles entries when
 //!   services come and go — "hot-swapped service restarts its dependents"

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -122,6 +122,10 @@ impl Loader {
                 file.write(initial)?;
             }
         }
+        // A corrupt or unreadable main file is fatal — booting an empty
+        // loader would silently discard the whole configuration. Import
+        // files keep the tolerant record-and-skip path inside `compose`.
+        file.read()?;
         let inner = Arc::new(LoaderInner {
             root: root.clone(),
             file,
@@ -144,6 +148,7 @@ impl Loader {
         let (composed, _dirty) = compose(
             &inner.file,
             &mut lock(&inner.imports),
+            &mut HashSet::new(),
             &mut HashSet::new(),
             &mut errors,
         );
@@ -255,16 +260,23 @@ impl Loader {
     /// Re-read the entry file and apply the difference to the fibers.
     ///
     /// Created entries start (parents first), removed subtrees stop, moved
-    /// entries restart under their new parent, updated entries are patched
-    /// in place when only config changed and restarted otherwise. While the
-    /// reload runs, the file is suspended, so the patches it causes are not
+    /// entries restart under their new parent, redefined entries (plugin
+    /// name, inject declaration, or enabled flag changed) stop and start
+    /// with their new options, and updated entries are patched in place —
+    /// their config-only change never restarts the fiber. While the reload
+    /// runs, the file is suspended, so the patches it causes are not
     /// written back; generated ids are persisted afterwards.
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
-        let (composed, dirty) =
-            compose(&inner.file, &mut imports, &mut HashSet::new(), &mut errors);
+        let (composed, dirty) = compose(
+            &inner.file,
+            &mut imports,
+            &mut HashSet::new(),
+            &mut HashSet::new(),
+            &mut errors,
+        );
         for error in errors {
             self.record_error(LoaderError::Include(
                 cordis_include::IncludeError::Message { message: error },
@@ -283,6 +295,11 @@ impl Loader {
                 self.record_error(error);
             }
         }
+        for entry in &diff.redefined {
+            if let Err(error) = stop_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
         for entry in &diff.updated {
             if let Err(error) = patch_entry(inner, entry) {
                 self.record_error(error);
@@ -290,6 +307,23 @@ impl Loader {
         }
         for entry in &diff.created {
             if let Err(error) = start_entry(inner, entry) {
+                self.record_error(error);
+            }
+        }
+
+        // Restart what this reload stopped, parents first so re-parented
+        // entries find their group fibers: moved entries under their new
+        // parents, redefined entries with their new options, and updated
+        // entries that had no live fiber.
+        let mut restarts: Vec<&Entry> = diff
+            .moved
+            .iter()
+            .chain(&diff.redefined)
+            .chain(diff.updated.iter().filter(|entry| entry.fiber().is_none()))
+            .collect();
+        restarts.sort_by_key(|entry| entry_depth(entry));
+        for entry in restarts {
+            if let Err(error) = start_subtree(inner, entry) {
                 self.record_error(error);
             }
         }
@@ -328,13 +362,26 @@ impl Loader {
         Ok(())
     }
 
-    /// Stop every entry and clear the fiber map. The root context itself
-    /// stays usable.
+    /// Stop every entry, stop watching files, and release the loader's
+    /// root-level effects (the status listener and the `loader` service).
+    /// The root context stays usable, and a fresh [`Loader::open`] on the
+    /// same root works afterwards.
     pub fn dispose(&self) -> Result<()> {
         let inner = &self.inner;
         for entry in inner.tree.top_level() {
             if let Err(error) = stop_entry(inner, &entry) {
                 self.record_error(error);
+            }
+        }
+        #[cfg(feature = "watch")]
+        {
+            lock(&inner.watched).clear();
+            lock(&inner.watchers).clear();
+        }
+        let keep_alive = std::mem::take(&mut lock(&inner.state)._keep_alive);
+        for effect in &keep_alive {
+            if let Err(error) = effect.dispose() {
+                self.record_error(LoaderError::Cordis(error));
             }
         }
         Ok(())
@@ -465,23 +512,17 @@ fn stop_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     fiber.dispose().map_err(LoaderError::Cordis)
 }
 
-/// Apply an options change to a live entry: restart when the plugin identity
-/// changed (name, inject) or the enabled flag flipped; patch the config in
-/// place otherwise.
+/// Apply a config-only change to a live entry by patching it in place.
+/// Structural changes (name, inject, enabled) arrive through
+/// `diff.redefined` and never here, so no identity comparison is needed.
+/// Entries without a live fiber are left to the reload's restart phase.
 fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     if !entry.enabled() {
         return stop_entry(inner, entry);
     }
     let Some(fiber) = entry.fiber() else {
-        return start_entry(inner, entry);
+        return Ok(());
     };
-    let options = entry.options();
-    let inject_changed =
-        fiber.inject().names().collect::<Vec<_>>() != options.inject.iter().collect::<Vec<_>>();
-    if fiber.name() != options.name || inject_changed {
-        stop_entry(inner, entry)?;
-        return start_entry(inner, entry);
-    }
     let new_config = entry.resolved_config()?.unwrap_or(Node::Null);
     let current = fiber
         .config()
@@ -502,6 +543,28 @@ fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// (Re)start an entry and its descendants, parents first; `start_entry`
+/// itself skips disabled entries and entries that already run.
+fn start_subtree(inner: &LoaderInner, entry: &Entry) -> Result<()> {
+    start_entry(inner, entry)?;
+    for child in entry.children() {
+        start_subtree(inner, &child)?;
+    }
+    Ok(())
+}
+
+/// Distance from the tree root, for restarting stopped entries parents
+/// first.
+fn entry_depth(entry: &Entry) -> usize {
+    let mut depth = 0;
+    let mut current = entry.clone();
+    while let Some(parent) = current.parent() {
+        depth += 1;
+        current = parent;
+    }
+    depth
 }
 
 /// Serialize an entry together with its live subtree (used by update paths
@@ -594,10 +657,17 @@ fn import_canonical(inner: &LoaderInner, entry: &Entry) -> PathBuf {
 /// `EntryTree::update` diffs across all files uniformly. Returns the
 /// composed top-level entries and whether any file carried entries without
 /// ids (whose generated ids need persisting).
+///
+/// `active` holds the files on the current import chain (cycle detection);
+/// `mounted` holds every file mounted anywhere in this compose. The entry
+/// tree keys entries by globally unique id, so the import graph must be a
+/// tree: real cycles and diamonds (the same file mounted twice) are both
+/// reported and their reference dropped, but with distinct diagnoses.
 fn compose(
     file: &LoaderFile,
     imports: &mut HashMap<PathBuf, LoaderFile>,
     active: &mut HashSet<PathBuf>,
+    mounted: &mut HashSet<PathBuf>,
     errors: &mut Vec<String>,
 ) -> (Vec<EntryOptions>, bool) {
     let document = match file.read() {
@@ -619,12 +689,22 @@ fn compose(
                 // would duplicate its id inside the composed tree.
                 continue;
             }
+            if !mounted.insert(canonical.clone()) {
+                errors.push(format!(
+                    "duplicate import: {} is already mounted elsewhere; \
+                     the import graph must be a tree",
+                    path.display()
+                ));
+                active.remove(&canonical);
+                continue;
+            }
             match LoaderFile::open(&path) {
                 Ok(sub_file) => {
-                    let (sub_entries, sub_dirty) = compose(&sub_file, imports, active, errors);
+                    let (sub_entries, sub_dirty) =
+                        compose(&sub_file, imports, active, mounted, errors);
                     dirty |= sub_dirty;
                     options.group = sub_entries;
-                    imports.insert(canonical, sub_file);
+                    imports.insert(canonical.clone(), sub_file);
                 }
                 Err(error) => errors.push(format!(
                     "cannot open import {} ({}: {error})",
@@ -632,6 +712,9 @@ fn compose(
                     file.path().display()
                 )),
             }
+            // A file is "active" only while its own subtree composes, so
+            // sibling imports of different files never look like cycles.
+            active.remove(&canonical);
         }
         entries.push(options);
     }

--- a/crates/cordis-loader/src/registry.rs
+++ b/crates/cordis-loader/src/registry.rs
@@ -151,16 +151,29 @@ pub(crate) struct WithInject {
 }
 
 impl WithInject {
-    /// Wrap `handle` unless `inject` is empty (nothing to add).
+    /// Wrap `handle`, merging an entry's `inject` declaration into the
+    /// plugin's own dependencies — the plugin's names first, then the
+    /// entry's extras, deduplicated. An empty entry list adds nothing and
+    /// keeps the bare handle.
     pub fn wrap(handle: PluginHandle, inject: Vec<String>) -> PluginHandle {
         if inject.is_empty() {
-            handle
-        } else {
-            PluginHandle::new(WithInject {
-                handle,
-                inject: Inject::new(inject),
-            })
+            return handle;
         }
+        let mut names: Vec<String> = handle
+            .plugin()
+            .inject()
+            .names()
+            .map(ToString::to_string)
+            .collect();
+        for name in inject {
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+        PluginHandle::new(WithInject {
+            handle,
+            inject: Inject::new(names),
+        })
     }
 }
 

--- a/crates/cordis-loader/tests/audit_fixes.rs
+++ b/crates/cordis-loader/tests/audit_fixes.rs
@@ -1,0 +1,287 @@
+//! Regression tests for audited loader defects: pure moves across groups
+//! (P1), diamond imports (P2), releasing the loader on dispose (P3), inject
+//! merge and structural redefines (P6), and corrupt main files.
+
+use cordis::{Context, Inject, PluginOutput, plugin_sync};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn temp_dir(stem: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("cordis-audit-fix-{stem}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(path: &std::path::Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, body).unwrap();
+}
+
+/// A counting plugin named `name`, applying to `starts`.
+fn counting_registry(name: &'static str, starts: Arc<AtomicUsize>) -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+    registry.register(name, move || {
+        let starts = starts.clone();
+        plugin_sync::<cordis_loader::Node, _>(name, Inject::default(), move |_, _| {
+            starts.fetch_add(1, Ordering::SeqCst);
+            Ok(PluginOutput::none())
+        })
+    });
+    registry
+}
+
+/// P1: an entry moved between groups without any options change must be
+/// restarted under its new parent (it used to be stopped and forgotten).
+#[test]
+fn moving_an_entry_restarts_it_under_the_new_parent() {
+    let dir = temp_dir("move");
+    let config = dir.join("cordis.json");
+    write(
+        &config,
+        r#"{"entries":[{"id":"grp","name":"group"},{"id":"w","name":"probe"}]}"#,
+    );
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&config).with_registry(counting_registry("probe", starts.clone())),
+    )
+    .unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+    write(
+        &config,
+        r#"{"entries":[{"id":"grp","name":"group","group":[{"id":"w","name":"probe"}]}]}"#,
+    );
+    loader.reload().unwrap();
+
+    assert_eq!(
+        starts.load(Ordering::SeqCst),
+        2,
+        "the moved entry restarts under its new parent"
+    );
+    assert!(
+        loader.tree().resolve("grp:w").unwrap().fiber().is_some(),
+        "the moved entry runs again"
+    );
+
+    // A group move takes its descendants along.
+    write(
+        &config,
+        r#"{"entries":[{"id":"w","name":"probe"},{"id":"grp","name":"group","group":[{"id":"c","name":"probe"}]}]}"#,
+    );
+    loader.reload().unwrap();
+    write(
+        &config,
+        r#"{"entries":[{"id":"grp2","name":"group","group":[{"id":"c","name":"probe"}]}]}"#,
+    );
+    loader.reload().unwrap();
+    assert!(
+        loader.tree().resolve("grp2:c").unwrap().fiber().is_some(),
+        "a child inside a moved group keeps running"
+    );
+
+    let _ = loader.dispose();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// P2: importing the same file from two parents (a diamond) is reported as
+/// a duplicate mount — not as a cycle — and only real cycles keep the
+/// "import cycle" diagnosis.
+#[test]
+fn diamond_imports_report_as_duplicate_mounts_not_cycles() {
+    let dir = temp_dir("diamond");
+    let main = dir.join("main.yml");
+    write(
+        &main,
+        "entries:\n  - id: a\n    name: import\n    config:\n      url: a.yml\n  - id: b\n    name: import\n    config:\n      url: b.yml\n",
+    );
+    write(
+        &dir.join("a.yml"),
+        "entries:\n  - id: a-c\n    name: import\n    config:\n      url: c.yml\n",
+    );
+    write(
+        &dir.join("b.yml"),
+        "entries:\n  - id: b-c\n    name: import\n    config:\n      url: c.yml\n",
+    );
+    write(
+        &dir.join("c.yml"),
+        "entries:\n  - id: cw\n    name: group\n",
+    );
+
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&main).with_registry(PluginRegistry::new()),
+    )
+    .unwrap();
+
+    // The first branch mounts; the diamond branch is dropped (entry ids
+    // are globally unique, so the import graph must be a tree), but the
+    // diagnosis names the actual problem instead of claiming a cycle.
+    assert!(loader.tree().resolve("a:a-c").is_some());
+    assert!(loader.tree().resolve("b:b-c").is_none());
+    let error = loader.last_error().unwrap();
+    assert!(error.contains("duplicate import"), "{error}");
+    assert!(!error.contains("import cycle"), "{error}");
+
+    let _ = loader.dispose();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// P3: disposing a loader releases its root-level effects, so a second
+/// `Loader::open` on the same root works.
+#[test]
+fn dispose_releases_the_loader_for_a_second_open() {
+    let dir = temp_dir("reopen");
+    let config = dir.join("cordis.json");
+    write(&config, r#"{"entries":[]}"#);
+
+    let root = Context::new();
+    let first = Loader::open(
+        &root,
+        LoaderConfig::new(&config).with_registry(PluginRegistry::new()),
+    )
+    .unwrap();
+    first.dispose().unwrap();
+
+    let second = Loader::open(
+        &root,
+        LoaderConfig::new(&config).with_registry(PluginRegistry::new()),
+    );
+    assert!(
+        second.is_ok(),
+        "a second open on the same root must work: {:?}",
+        second.err().map(|error| error.to_string())
+    );
+
+    if let Ok(loader) = second {
+        let _ = loader.dispose();
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// P6: an entry's inject declaration merges with the plugin's own — the
+/// plugin still gates on its own dependencies.
+#[test]
+fn entry_inject_merges_with_the_plugins_own_dependencies() {
+    let dir = temp_dir("merge");
+    let config = dir.join("cordis.json");
+    write(
+        &config,
+        r#"{"entries":[{"id":"m","name":"merged","inject":["http"]}]}"#,
+    );
+
+    let root = Context::new();
+    let _http = root.provide("http", 80u16).unwrap();
+    // `database` arrives only later.
+
+    let started = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    let flag = started.clone();
+    registry.register("merged", move || {
+        let flag = flag.clone();
+        plugin_sync::<cordis_loader::Node, _>("merged", Inject::new(["database"]), move |_, _| {
+            flag.fetch_add(1, Ordering::SeqCst);
+            Ok(PluginOutput::none())
+        })
+    });
+
+    let loader = Loader::open(&root, LoaderConfig::new(&config).with_registry(registry)).unwrap();
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        0,
+        "the plugin waits for its own `database` dependency too"
+    );
+    let fiber = loader.tree().resolve("m").unwrap().fiber().unwrap();
+    let merged: Vec<String> = fiber.inject().names().map(ToString::to_string).collect();
+    assert!(merged.contains(&"http".to_owned()), "{merged:?}");
+    assert!(merged.contains(&"database".to_owned()), "{merged:?}");
+
+    let _database = root.provide("database", 1u8).unwrap();
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        1,
+        "dependency arrival activates the merged entry"
+    );
+
+    let _ = loader.dispose();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// P6: config-only changes patch in place (same fiber), structural changes
+/// (entry inject) restart under a fresh fiber.
+#[test]
+fn config_changes_patch_in_place_and_inject_changes_restart() {
+    let dir = temp_dir("redefined");
+    let config = dir.join("cordis.json");
+    write(
+        &config,
+        r#"{"entries":[{"id":"w","name":"probe","config":{"n":1}}]}"#,
+    );
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let _svc = root.provide("svc", 1u8).unwrap();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&config).with_registry(counting_registry("probe", starts.clone())),
+    )
+    .unwrap();
+    let uid = loader.tree().resolve("w").unwrap().fiber().unwrap().uid();
+
+    // Config-only change: patched in place, the fiber keeps its identity.
+    write(
+        &config,
+        r#"{"entries":[{"id":"w","name":"probe","config":{"n":2}}]}"#,
+    );
+    loader.reload().unwrap();
+    assert_eq!(
+        loader.tree().resolve("w").unwrap().fiber().unwrap().uid(),
+        uid,
+        "config-only changes keep the fiber"
+    );
+
+    // Entry inject change: structural, the entry restarts with a new fiber.
+    write(
+        &config,
+        r#"{"entries":[{"id":"w","name":"probe","inject":["svc"],"config":{"n":2}}]}"#,
+    );
+    loader.reload().unwrap();
+    assert_ne!(
+        loader.tree().resolve("w").unwrap().fiber().unwrap().uid(),
+        uid,
+        "structural changes restart the fiber"
+    );
+
+    let _ = loader.dispose();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A corrupt or unreadable main file fails `Loader::open` instead of
+/// booting an empty tree (import files keep the tolerant path).
+#[test]
+fn a_corrupt_main_file_fails_open() {
+    let dir = temp_dir("corrupt");
+    let config = dir.join("cordis.json");
+    write(&config, r#"{"entries":["#);
+
+    let root = Context::new();
+    let error = Loader::open(
+        &root,
+        LoaderConfig::new(&config).with_registry(PluginRegistry::new()),
+    )
+    .err()
+    .expect("a corrupt main file must fail open");
+    assert!(
+        error.to_string().to_lowercase().contains("parse"),
+        "{error}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cordis-loader/tests/dynamic.rs
+++ b/crates/cordis-loader/tests/dynamic.rs
@@ -52,35 +52,36 @@ fn rustc() -> PathBuf {
     PathBuf::from("rustc")
 }
 
-/// Locate the built rlib for a workspace crate, preferring the unhashed
-/// uplift in `target/debug/` and falling back to the newest hashed copy.
+/// Locate the freshest built rlib for a workspace crate: the unhashed
+/// uplift in `target/debug/` and the hashed copies in `deps/` compete,
+/// and the newest wins (a stale uplift must not shadow a fresh build).
 fn find_rlib(name: &str) -> PathBuf {
     let debug = target_dir().join("debug");
-    let uplifted = debug.join(format!("lib{name}.rlib"));
-    if uplifted.is_file() {
-        return uplifted;
-    }
     let prefix = format!("lib{name}-");
-    let mut newest: Option<(SystemTime, PathBuf)> = None;
-    for entry in std::fs::read_dir(debug.join("deps")).expect("deps directory") {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        let is_match = path
-            .extension()
-            .is_some_and(|extension| extension == "rlib")
-            && path
-                .file_name()
-                .and_then(|file| file.to_str())
-                .is_some_and(|file| file.starts_with(&prefix));
-        if !is_match {
-            continue;
-        }
-        let mtime = entry.metadata().unwrap().modified().unwrap();
-        if newest.as_ref().is_none_or(|(best, _)| mtime > *best) {
-            newest = Some((mtime, path));
+    let mut candidates: Vec<(SystemTime, PathBuf)> = Vec::new();
+    let uplifted = debug.join(format!("lib{name}.rlib"));
+    if let Ok(metadata) = std::fs::metadata(&uplifted) {
+        candidates.push((metadata.modified().unwrap(), uplifted));
+    }
+    if let Ok(entries) = std::fs::read_dir(debug.join("deps")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_match = path
+                .extension()
+                .is_some_and(|extension| extension == "rlib")
+                && path
+                    .file_name()
+                    .and_then(|file| file.to_str())
+                    .is_some_and(|file| file.starts_with(&prefix));
+            if is_match {
+                let mtime = entry.metadata().unwrap().modified().unwrap();
+                candidates.push((mtime, path));
+            }
         }
     }
-    newest
+    candidates.sort_by_key(|candidate| candidate.0);
+    candidates
+        .pop()
         .unwrap_or_else(|| panic!("no rlib found for {name}"))
         .1
 }

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -272,10 +272,12 @@ impl EventsService {
             }
         }
 
-        // The fiber may have unloaded between effect registration and hook
-        // insertion; its disposer then never runs, so roll back by hand
-        // instead of leaking a live hook for a dead plugin.
-        if fiber.uid().is_none() {
+        // The effect may have been disposed between registration and hook
+        // insertion — by disposal *or* by a restart's unload pass (restart
+        // keeps the fiber uid, so checking the effect covers both). Its
+        // disposer then ran before the hook existed, so roll back by hand
+        // instead of leaking a live hook for a dead listener.
+        if effect.is_disposed() {
             self.ctx.root.events.remove(&name, id);
             effect.dispose()?;
             return Err(CordisError::new(ErrorCode::InactiveEffect));

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -62,6 +62,29 @@ impl FiberInner {
     }
 }
 
+// Fibers whose transition mutex the current thread holds, keyed by
+// `FiberInner` address. Presence means "called from inside a lifecycle
+// callback on this fiber" — reentrancy, which must fail fast rather than
+// deadlock.
+thread_local! {
+    static HELD_TRANSITIONS: std::cell::RefCell<std::collections::HashSet<usize>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// A transition-mutex guard that unregisters its fiber from
+/// [`HELD_TRANSITIONS`] when dropped, including on unwind.
+struct TransitionGuard<'a> {
+    /// Held purely for the lock; the guard itself is never touched.
+    _guard: std::sync::MutexGuard<'a, ()>,
+    key: usize,
+}
+
+impl Drop for TransitionGuard<'_> {
+    fn drop(&mut self) {
+        HELD_TRANSITIONS.with(|held| held.borrow_mut().remove(&self.key));
+    }
+}
+
 /// Cloneable handle to one plugin lifecycle instance.
 #[derive(Clone)]
 pub struct Fiber {
@@ -237,6 +260,13 @@ impl Fiber {
     }
 
     /// Register a boxed cleanup operation.
+    ///
+    /// Registration is serialized against disposal: `dispose`/`restart`
+    /// mark the fiber dead (uid cleared or `Unloading`) *before* draining
+    /// the effect list, so re-checking liveness while holding the list lock
+    /// guarantees every accepted effect is seen by a concurrent drain. An
+    /// effect that lands after the drain is undone on the spot instead of
+    /// leaking with a disposer that never runs.
     pub fn register_effect(
         &self,
         label: impl Into<String>,
@@ -257,7 +287,21 @@ impl Fiber {
             label,
             disposer,
         );
-        lock(&self.inner.effects).push(cell.clone());
+        {
+            let mut effects = lock(&self.inner.effects);
+            effects.push(cell.clone());
+            let dead = self.uid().is_none()
+                || matches!(self.state(), FiberState::Disposed | FiberState::Unloading);
+            if dead {
+                // The drain already ran (or marked the fiber dead and will
+                // not see this push after the removal): undo the
+                // registration atomically instead of leaking it.
+                effects.retain(|effect| effect.id != cell.id);
+                drop(effects);
+                cell.cancel();
+                return Err(CordisError::new(ErrorCode::InactiveEffect));
+            }
+        }
         Ok(EffectHandle::new(cell))
     }
 
@@ -512,21 +556,31 @@ impl Fiber {
         }
     }
 
-    /// Lock the transition mutex, failing instead of deadlocking when the
-    /// caller is already inside a transition on this fiber — directly or
-    /// through a lifecycle callback such as an `internal/status` listener or
-    /// a disposer. [`refresh`](Self::refresh) already degrades to a dirty flag
-    /// in that situation; `restart`/`dispose` have no deferrable semantics,
-    /// so they report the reentrancy as an error.
-    fn try_transition(&self) -> Result<std::sync::MutexGuard<'_, ()>> {
-        match self.inner.transition.try_lock() {
-            Ok(guard) => Ok(guard),
-            Err(std::sync::TryLockError::Poisoned(error)) => Ok(error.into_inner()),
-            Err(std::sync::TryLockError::WouldBlock) => Err(CordisError::with_message(
+    /// Lock the transition mutex, telling reentrancy apart from contention.
+    ///
+    /// When the *current thread* already holds the lock — directly or
+    /// through a lifecycle callback such as an `internal/status` listener
+    /// or a disposer — the call is reentrant and fails fast instead of
+    /// deadlocking; [`refresh`](Self::refresh) degrades to a dirty flag in
+    /// that situation, while `restart`/`dispose` have no deferrable
+    /// semantics and report the reentrancy as an error. When a *different
+    /// thread* holds the lock, the call waits for the in-flight transition
+    /// to finish instead of silently dropping the operation.
+    fn try_transition(&self) -> Result<TransitionGuard<'_>> {
+        let key = Arc::as_ptr(&self.inner) as usize;
+        if HELD_TRANSITIONS.with(|held| held.borrow().contains(&key)) {
+            return Err(CordisError::with_message(
                 ErrorCode::Other,
                 "lifecycle transition already in progress on this fiber",
-            )),
+            ));
         }
+        let guard = match self.inner.transition.try_lock() {
+            Ok(guard) => guard,
+            Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => lock(&self.inner.transition),
+        };
+        HELD_TRANSITIONS.with(|held| held.borrow_mut().insert(key));
+        Ok(TransitionGuard { _guard: guard, key })
     }
 
     /// Report the fiber's settled lifecycle state without blocking.
@@ -665,10 +719,14 @@ impl Fiber {
     }
 
     /// Permanently dispose this plugin fiber. Repeated calls are no-ops.
+    ///
+    /// A dispose from another thread waits for an in-flight transition on
+    /// this fiber to finish; a reentrant call from inside a lifecycle
+    /// callback fails fast instead of deadlocking.
     pub fn dispose(&self) -> Result<()> {
-        // Take the transition lock up front: reentrant calls from lifecycle
-        // callbacks fail fast instead of deadlocking, and no partial teardown
-        // is left behind.
+        // Take the transition lock up front: reentrant calls fail fast, no
+        // partial teardown is left behind, and concurrent callers queue
+        // behind the in-flight transition.
         let _guard = self.try_transition()?;
         if self.inner.plugin.is_none() {
             // Root disposal unloads all root-owned effects but leaves the root

--- a/crates/cordis/src/registry.rs
+++ b/crates/cordis/src/registry.rs
@@ -265,7 +265,23 @@ impl IntoPlugin for PluginHandle {
 struct FunctionPlugin {
     name: String,
     inject: Inject,
+    validate: fn(Config) -> Result<Config>,
     callback: Arc<dyn Fn(Context, Config) -> BoxFuture<Result<PluginOutput>> + Send + Sync>,
+}
+
+/// Pre-check that `config` holds a `C`, so a wrong-typed update fails
+/// validation instead of tearing down the running instance first.
+fn config_validator<C>() -> fn(Config) -> Result<Config>
+where
+    C: Send + Sync + 'static,
+{
+    fn validate<C>(config: Config) -> Result<Config>
+    where
+        C: Send + Sync + 'static,
+    {
+        config.downcast::<C>().map(|_| config)
+    }
+    validate::<C>
 }
 
 impl Plugin for FunctionPlugin {
@@ -275,6 +291,10 @@ impl Plugin for FunctionPlugin {
 
     fn inject(&self) -> &Inject {
         &self.inject
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        (self.validate)(config)
     }
 
     fn apply(&self, ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
@@ -292,6 +312,7 @@ where
     PluginHandle::new(FunctionPlugin {
         name: name.into(),
         inject,
+        validate: config_validator::<C>(),
         callback: Arc::new(move |ctx, config| {
             let callback = callback.clone();
             Box::pin(async move {
@@ -324,6 +345,7 @@ where
     PluginHandle::new(FunctionPlugin {
         name: name.into(),
         inject,
+        validate: config_validator::<C>(),
         callback: Arc::new(move |ctx, config| {
             let callback = callback.clone();
             Box::pin(async move {

--- a/crates/cordis/tests/lifecycle.rs
+++ b/crates/cordis/tests/lifecycle.rs
@@ -349,10 +349,11 @@ impl Future for Gate {
     }
 }
 
-/// A concurrent dispose during a parked apply() must report the in-flight
-/// transition instead of deadlocking; await_idle() then waits it out.
+/// A cross-thread dispose during a parked apply() waits for the in-flight
+/// transition instead of silently dropping the disposal; same-thread
+/// reentrancy (from a callback) keeps failing fast.
 #[test]
-fn dispose_during_loading_conflicts_then_await_idle() -> Result<()> {
+fn dispose_during_loading_waits_for_the_transition() -> Result<()> {
     let root = Context::new();
     let gate = Gate::new();
     let gate_in_plugin = gate.clone();
@@ -390,11 +391,19 @@ fn dispose_during_loading_conflicts_then_await_idle() -> Result<()> {
     assert!(gate.entered(), "apply() never parked");
     let fiber = slot.lock().unwrap().clone().unwrap();
 
-    assert!(fiber.dispose().is_err(), "dispose raced the transition");
+    // The disposer cannot return while apply() holds the transition: it
+    // waits for the gate to open instead of reporting a conflict.
+    let disposer = std::thread::spawn({
+        let fiber = fiber.clone();
+        move || fiber.dispose()
+    });
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(
+        !disposer.is_finished(),
+        "dispose must block while the transition is in flight"
+    );
     gate.open();
-    fiber.await_idle();
-    assert_eq!(fiber.state(), FiberState::Active);
-    fiber.dispose()?;
+    disposer.join().unwrap()?;
     assert_eq!(fiber.state(), FiberState::Disposed);
     let _ = worker.join().unwrap();
     Ok(())
@@ -610,4 +619,85 @@ fn restart_from_status_listener_does_not_deadlock() -> Result<()> {
         .expect("deadlock: reentrant restart from internal/status listener")?;
     assert!(fired.load(Ordering::SeqCst));
     Ok(())
+}
+
+/// A wrong-typed config update on a `plugin_sync` plugin must fail
+/// validation and leave the running instance untouched. The type check
+/// used to happen only inside `apply`, so the update tore the instance
+/// down first and left the fiber `Failed`.
+#[test]
+fn update_with_wrong_config_type_fails_validation_not_the_plugin() -> Result<()> {
+    let root = Context::new();
+    let starts = Arc::new(AtomicUsize::new(0));
+    let counter = starts.clone();
+    let fiber = root.plugin(
+        plugin_sync::<u32, _>("typed", Inject::none(), move |_, _| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(PluginOutput::default())
+        }),
+        7_u32,
+    );
+    fiber.try_wait()?;
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+    let error = fiber.update("wrong type").unwrap_err();
+    assert_eq!(error.code(), ErrorCode::TypeMismatch);
+    assert_eq!(fiber.state(), FiberState::Active);
+    assert_eq!(
+        starts.load(Ordering::SeqCst),
+        1,
+        "the running instance is untouched"
+    );
+    fiber.dispose()?;
+    Ok(())
+}
+
+/// Regression: `register_effect`'s liveness check and its push into the
+/// effect list were not serialized against a concurrent `dispose`, so an
+/// effect that landed after the disposal drain never ran its disposer.
+/// Registration now re-checks liveness under the list lock and undoes the
+/// push; hammer both sides and require every accepted effect to run.
+#[test]
+fn effect_registration_racing_disposal_never_leaks() {
+    let mut leaks = 0;
+    for _ in 0..4000 {
+        let root = Context::new();
+        let fiber = root.plugin_default(plugin_sync::<(), _>("raced", Inject::none(), |_, _| {
+            Ok(PluginOutput::default())
+        }));
+        fiber.try_wait().unwrap();
+
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let disposed = Arc::new(AtomicUsize::new(0));
+        let registrar = {
+            let (fiber, accepted, disposed) = (fiber.clone(), accepted.clone(), disposed.clone());
+            std::thread::spawn(move || {
+                for _ in 0..400 {
+                    let disposed = disposed.clone();
+                    match fiber.effect("raced", move || {
+                        disposed.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }) {
+                        Ok(_) => {
+                            accepted.fetch_add(1, Ordering::SeqCst);
+                        }
+                        Err(_) => return,
+                    }
+                }
+            })
+        };
+        while accepted.load(Ordering::SeqCst) == 0 {
+            std::thread::yield_now();
+        }
+        fiber.dispose().unwrap();
+        registrar.join().unwrap();
+
+        if disposed.load(Ordering::SeqCst) != accepted.load(Ordering::SeqCst) {
+            leaks += 1;
+        }
+    }
+    assert_eq!(
+        leaks, 0,
+        "some registered effects never ran their disposers"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes all eight Major findings from the strict code audit, each verified against the audit baseline (`d0092cd`) with compilable/runnable reproductions first (see the verification notes in #20's follow-up discussion), then fixed with regression tests.

### Core (`crates/cordis`) — P5, P7, P8

- **P7 effect/disposal race**: `register_effect`'s liveness check and its push into the effect list were not serialized against `dispose`/`restart`'s drain, so a late registration never ran its disposer (leaked effects, services that block re-provides forever, double-firing listeners after restart). Registration now re-checks liveness **under the list lock** and undoes a late push atomically — the same pattern `EffectCell::adopt` already documents — and `ctx.on` rolls back on `effect.is_disposed()` so restarts (which keep the fiber uid) are covered too. Regression: a 4000-iteration stress test that leaked 3× on the old code must now leak zero.
- **P8 reentrancy vs contention**: `dispose`/`restart` used `try_lock`, reporting cross-thread contention with the same "already in progress" error as same-thread reentrancy — and callers never retry (`stop_entry` had already forgotten the entry). Transitions now track their owning thread: reentrancy still fails fast, contention waits for the in-flight transition. The old conflict test was rewritten to the new waiting contract.
- **P5 closure plugin validation**: `plugin_sync`/`plugin_async` never overrode `validate_config`, so a wrong-typed update passed pre-validation, tore the running instance down, and failed inside `apply`. `FunctionPlugin` now downcasts in `validate_config`; `update`'s "validation failure keeps the running plugin untouched" promise holds for closure plugins too.

### Loader + include — P1, P2, P3, P6

- **P1 pure moves**: entries moved across groups with unchanged options were stopped and never restarted (silently dead until process restart). Reload now restarts moved (and redefined) subtrees under their new parents, parents first, after created entries.
- **P2 diamond imports**: reported as "import cycle" with the subtree dropped, because the recursion's active set never shrank. The active set is now a true ancestor stack (cycles), and a separate mounted set reports diamonds as **duplicate mounts** — the tree's globally-unique entry ids require the import graph to stay a tree, but the diagnosis no longer lies about which rule broke.
- **P3 loader disposal**: `dispose` leaked the status listener and the `loader` service effect, so a second `Loader::open` on the same root failed with `DuplicateService`. Both (and import watchers) are now released; documented in the README.
- **P6 inject semantics**: an entry's `inject` **replaced** the plugin's own dependencies despite the docs (and behavior) promising a merge — plugins started while their own services were missing. `WithInject` now truly merges; `TreeDiff` gains a `redefined` class (name/inject/enabled changes → stop-and-start) so config-only changes patch in place and `patch_entry`'s inject comparison — which forced needless rebuilds for self-declaring plugins — is gone.
- Additionally, a corrupt/unreadable **main** config file now fails `Loader::open` instead of silently booting an empty tree (import files keep the tolerant path).

### CLI — P4

`cordis run` always exited 0. The worker now reports boot failure with a new code **53**, and the daemon maps outcomes honestly: clean quit/shutdown → 0, boot failure → 1, crashes → the worker's code (1 for signal deaths). Exit-51 restart loops now back off exponentially (100ms → 5s cap, reset after 10s uptime). Usage text and crate docs updated.

## Test evidence

- New regression suites: loader `audit_fixes` (6 tests: moves incl. group moves, diamond diagnosis, reopen-after-dispose, inject merge + activation, patch-vs-redefine fiber identity, corrupt main file), core lifecycle additions (wrong-type update, 4000-round disposal race), CLI e2e (unsupported extension and corrupt JSON both exit non-zero with the failure on stderr).
- Full gate green locally on both the pinned 1.85 toolchain and stable 1.96 clippy: fmt, clippy `-D warnings`, 26 test suites, `cargo doc -D warnings`, and all five README doctest runs.
- One pre-existing test encoded the old conflict semantics (`dispose_during_loading_conflicts_then_await_idle`) and was rewritten to the new waiting contract.