### PR TITLE
Fix review issues #29-#39: write races, loader mutual exclusion, daemon shutdown, effect leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "cordis-loader",
  "cordis-rs",
  "ctrlc",
+ "libc",
  "notify",
 ]
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,10 +13,11 @@ test-only nit).
 - `CordisError::context` prepends context to the message, the opposite of
   `anyhow::Context` (attach a source). The name misleads Rust users; a rename
   such as `prefixed_with` would be honest but is a breaking change.
-- `Fiber::await_ready` and `Fiber::dispose_async` are transparent pass-throughs
-  to their synchronous versions. They exist for upstream signature parity but
-  imply cancellable/async semantics that do not exist. Consider documenting
-  more loudly or removing.
+- ~~`Fiber::await_ready` and `Fiber::dispose_async` are transparent
+  pass-throughs to their synchronous versions. They exist for upstream
+  signature parity but imply cancellable/async semantics that do not exist.~~
+  Resolved 2026-08-18 (issue #34): both methods now document loudly that they
+  are synchronous pass-throughs that never suspend or yield.
 - `Value` (and thus `Config`) has no `PartialEq`/`Display`; plugin config
   comparison in `update_value` relies on `Arc` pointer identity (`ptr_eq`).
   Two structurally equal configs are treated as different allocations.

--- a/crates/cordis-cli/Cargo.toml
+++ b/crates/cordis-cli/Cargo.toml
@@ -19,3 +19,6 @@ cordis-loader = { workspace = true, features = ["watch", "dynamic"] }
 cordis-rs.workspace = true
 ctrlc = { version = "3", features = ["termination"] }
 notify = "8"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod dotenv;
 pub mod worker;
 
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -105,41 +106,56 @@ pub struct Options {
 }
 
 /// Parse `cordis` arguments (after the binary name).
-pub fn parse_args(args: &[String]) -> Result<Options, String> {
+///
+/// Arguments stay [`OsString`] end to end so config paths with non-UTF-8
+/// bytes (legal on Unix filesystems) reach the loader intact instead of
+/// being mangled into replacement characters; they are only lossily
+/// rendered for usage and error text.
+pub fn parse_args(args: &[OsString]) -> Result<Options, String> {
     let Some(command) = args.first() else {
         return Err(usage());
     };
-    if command != "run" {
-        return Err(format!("unknown command `{command}`\n\n{}", usage()));
+    if command.as_os_str() != OsStr::new("run") {
+        return Err(format!(
+            "unknown command `{}`\n\n{}",
+            command.to_string_lossy(),
+            usage()
+        ));
     }
     let mut config = None;
     let mut plugin_dirs = Vec::new();
     let mut worker = false;
     let mut rest = args[1..].iter();
     while let Some(arg) = rest.next() {
-        match arg.as_str() {
-            "--worker" | "-w" => worker = true,
-            "--help" | "-h" => return Err(usage()),
-            "--plugin-dir" => {
+        let bytes = arg.as_encoded_bytes();
+        match bytes {
+            b"--worker" | b"-w" => worker = true,
+            b"--help" | b"-h" => return Err(usage()),
+            b"--plugin-dir" => {
                 let Some(value) = rest.next() else {
                     return Err(format!("--plugin-dir requires a directory\n\n{}", usage()));
                 };
                 plugin_dirs.push(PathBuf::from(value));
             }
-            other if other.starts_with("--plugin-dir=") => {
-                let value = other.strip_prefix("--plugin-dir=").unwrap();
+            _ if bytes.starts_with(b"--plugin-dir=") => {
+                let value = os_string_from_encoded_bytes(&bytes[b"--plugin-dir=".len()..]);
                 if value.is_empty() {
                     return Err(format!("--plugin-dir requires a directory\n\n{}", usage()));
                 }
                 plugin_dirs.push(PathBuf::from(value));
             }
-            other if other.starts_with('-') => {
-                return Err(format!("unknown flag `{other}`\n\n{}", usage()));
+            _ if bytes.first() == Some(&b'-') => {
+                return Err(format!(
+                    "unknown flag `{}`\n\n{}",
+                    arg.to_string_lossy(),
+                    usage()
+                ));
             }
-            other => {
-                if config.replace(PathBuf::from(other)).is_some() {
+            _ => {
+                if config.replace(PathBuf::from(arg)).is_some() {
                     return Err(format!(
-                        "unexpected extra argument `{other}`\n\n{}",
+                        "unexpected extra argument `{}`\n\n{}",
+                        arg.to_string_lossy(),
                         usage()
                     ));
                 }
@@ -153,6 +169,28 @@ pub fn parse_args(args: &[String]) -> Result<Options, String> {
             worker,
         }),
         None => Err(format!("missing config file\n\n{}", usage())),
+    }
+}
+
+/// Rebuild an [`OsString`] from the [`OsStr::as_encoded_bytes`]
+/// representation. Lossless on every supported platform: raw bytes on
+/// Unix, validated WTF-8 on Windows, best-effort lossy elsewhere.
+fn os_string_from_encoded_bytes(bytes: &[u8]) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        OsString::from_vec(bytes.to_vec())
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        OsStr::from_encoded_bytes(bytes)
+            .map(|value| value.into_owned())
+            .unwrap_or_default()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        OsString::from(String::from_utf8_lossy(bytes).into_owned())
     }
 }
 
@@ -172,12 +210,15 @@ abnormally, otherwise the worker's own code."
 
 /// Entry point used by the `cordis` binary: parse arguments, load dotenv,
 /// then supervise or run as the worker.
+///
+/// Accepts [`OsString`]s so non-UTF-8 arguments (notably config paths on
+/// Unix) survive to the loader unchanged.
 pub fn run<I, S>(args: I) -> i32
 where
     I: IntoIterator<Item = S>,
-    S: Into<String>,
+    S: Into<OsString>,
 {
-    let args: Vec<String> = args.into_iter().map(Into::into).collect();
+    let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
     let options = match parse_args(&args) {
         Ok(options) => options,
         Err(message) => {
@@ -256,8 +297,8 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
 mod tests {
     use super::*;
 
-    fn args(list: &[&str]) -> Vec<String> {
-        list.iter().map(ToString::to_string).collect()
+    fn args(list: &[&str]) -> Vec<OsString> {
+        list.iter().map(OsString::from).collect()
     }
 
     #[test]
@@ -353,5 +394,27 @@ mod tests {
             RESTART_BACKOFF_START,
             "a worker that stayed up resets the backoff"
         );
+    }
+
+    /// Regression (#38): arguments with non-UTF-8 bytes (legal config paths
+    /// on Unix) must reach `Options` unchanged, not as replacement
+    /// characters.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_arguments_survive_parsing() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = OsString::from_vec(vec![b'c', 0xff, b'.', b'y', b'm', b'l']);
+        let options = parse_args(&[OsString::from("run"), bad.clone()]).unwrap();
+        assert_eq!(options.config.as_os_str(), bad.as_os_str());
+
+        let bad_dir = OsString::from_vec(vec![b'd', 0xfe, b'i', 0xff, b'r']);
+        let options = parse_args(&[
+            OsString::from("run"),
+            OsString::from("c.yml"),
+            OsString::from("--plugin-dir"),
+            bad_dir.clone(),
+        ])
+        .unwrap();
+        assert_eq!(options.plugin_dirs, [PathBuf::from(bad_dir)]);
     }
 }

--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -8,7 +8,11 @@
 //! The daemon exits `0` on clean shutdown, `1` when the worker never
 //! booted or died abnormally, and otherwise propagates the worker's code —
 //! deployment pipelines always see the real outcome. `SIGINT` / `SIGTERM`
-//! dispose the root context gracefully and exit `52` (daemon `0`). `.env`
+//! dispose the root context gracefully and exit `52` (daemon `0`); the
+//! daemon forwards its own shutdown to the worker by closing the pipe on
+//! the worker's stdin (so `kill <daemon-pid>` and even a `SIGKILL`ed
+//! daemon take the worker down too, not just terminal-wide signals), and
+//! kills the worker after a grace period if it will not quit. `.env`
 //! and `.env.local` are loaded (without overriding existing variables)
 //! before the worker boots, and the entry file is watched for hot reload.
 //!
@@ -39,6 +43,12 @@ const RESTART_BACKOFF_START: Duration = Duration::from_millis(100);
 const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(5);
 /// A worker that stayed up at least this long resets the restart backoff.
 const RESTART_BACKOFF_RESET_AFTER: Duration = Duration::from_secs(10);
+/// How often the supervisor polls the worker's exit status. Polling keeps
+/// the shutdown flag observable where a blocking `wait()` would hang.
+const WORKER_WAIT_POLL: Duration = Duration::from_millis(50);
+/// Grace period for the worker to exit after the daemon requested shutdown
+/// (by closing the worker's stdin pipe) before it is killed outright.
+const WORKER_SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
 
 /// What the supervisor does after a worker exits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -259,7 +269,7 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
     // stayed up long enough resets it.
     let mut backoff: Option<Duration> = None;
     let exit_code;
-    loop {
+    'supervise: loop {
         if shutdown.load(Ordering::SeqCst) {
             exit_code = Some(worker::EXIT_QUIT);
             break;
@@ -270,6 +280,13 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
         for dir in plugin_dirs {
             command.arg("--plugin-dir").arg(dir);
         }
+        // The worker watches this pipe: the daemon closes it when shutting
+        // down, and the OS closes it when the daemon dies for any reason —
+        // the std-only stand-in for forwarding SIGTERM, which also covers a
+        // daemon killed with SIGKILL.
+        command
+            .stdin(std::process::Stdio::piped())
+            .env(worker::SUPERVISED_ENV, "1");
         let mut child = match command.spawn() {
             Ok(child) => child,
             Err(error) => {
@@ -277,7 +294,7 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
                 return 1;
             }
         };
-        let code = child.wait().ok().and_then(|status| status.code());
+        let code = supervise_worker(&mut child, &shutdown);
         if supervisor_action(code, shutdown.load(Ordering::SeqCst)) == Action::Stop {
             exit_code = code;
             break;
@@ -288,9 +305,54 @@ fn supervise(config: &std::path::Path, plugin_dirs: &[PathBuf]) -> i32 {
             delay.as_millis()
         );
         backoff = Some(delay);
-        std::thread::sleep(delay);
+        // Interruptible backoff: a shutdown request during the delay
+        // aborts the wait instead of deferring the exit by up to 5s.
+        let deadline = std::time::Instant::now() + delay;
+        while std::time::Instant::now() < deadline {
+            if shutdown.load(Ordering::SeqCst) {
+                continue 'supervise;
+            }
+            let now = std::time::Instant::now();
+            std::thread::sleep(WORKER_WAIT_POLL.min(deadline.saturating_duration_since(now)));
+        }
     }
     daemon_exit_code(exit_code, shutdown.load(Ordering::SeqCst))
+}
+
+/// Wait for one worker, forwarding daemon shutdown requests: closing the
+/// worker's stdin pipe triggers its graceful teardown (the same path as a
+/// signal), and a worker that ignores it for [`WORKER_SHUTDOWN_GRACE`] is
+/// killed. Never blocks indefinitely, so the shutdown flag stays
+/// observable.
+fn supervise_worker(child: &mut std::process::Child, shutdown: &AtomicBool) -> Option<i32> {
+    let mut stdin = child.stdin.take();
+    let mut requested = None::<std::time::Instant>;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.code(),
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("cordis: cannot wait for worker: {error}");
+                return None;
+            }
+        }
+        if shutdown.load(Ordering::SeqCst) {
+            match requested {
+                None => {
+                    eprintln!("cordis: forwarding shutdown to the worker");
+                    drop(stdin.take());
+                    requested = Some(std::time::Instant::now());
+                }
+                Some(at) if at.elapsed() >= WORKER_SHUTDOWN_GRACE => {
+                    eprintln!("cordis: worker did not exit in time, killing it");
+                    let _ = child.kill();
+                    return child.wait().ok().and_then(|status| status.code());
+                }
+                _ => {}
+            }
+        }
+        std::thread::sleep(WORKER_WAIT_POLL);
+    }
 }
 
 #[cfg(test)]

--- a/crates/cordis-cli/src/lib.rs
+++ b/crates/cordis-cli/src/lib.rs
@@ -183,22 +183,18 @@ pub fn parse_args(args: &[OsString]) -> Result<Options, String> {
 }
 
 /// Rebuild an [`OsString`] from the [`OsStr::as_encoded_bytes`]
-/// representation. Lossless on every supported platform: raw bytes on
-/// Unix, validated WTF-8 on Windows, best-effort lossy elsewhere.
+/// representation. Lossless on Unix (raw bytes); on Windows and elsewhere
+/// the bytes decode as UTF-8 — Windows arguments are UTF-16-representable
+/// in practice, so this only degrades for lone-surrogate arguments, which
+/// `OsStr::from_encoded_bytes` (unstable at our MSRV) could not have
+/// preserved either way.
 fn os_string_from_encoded_bytes(bytes: &[u8]) -> OsString {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStringExt;
         OsString::from_vec(bytes.to_vec())
     }
-    #[cfg(windows)]
-    {
-        use std::os::windows::ffi::OsStrExt;
-        OsStr::from_encoded_bytes(bytes)
-            .map(|value| value.into_owned())
-            .unwrap_or_default()
-    }
-    #[cfg(not(any(unix, windows)))]
+    #[cfg(not(unix))]
     {
         OsString::from(String::from_utf8_lossy(bytes).into_owned())
     }

--- a/crates/cordis-cli/src/main.rs
+++ b/crates/cordis-cli/src/main.rs
@@ -1,9 +1,11 @@
 //! The `cordis` binary: see [`cordis_cli`] for the actual implementation.
 
+use std::ffi::OsString;
+
 fn main() {
-    let args: Vec<String> = std::env::args_os()
-        .skip(1)
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect();
+    // OsStrings all the way down: a config path with non-UTF-8 bytes (legal
+    // on Unix filesystems) must reach the loader unchanged instead of being
+    // mangled into replacement characters.
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
     std::process::exit(cordis_cli::run(args));
 }

--- a/crates/cordis-cli/src/worker.rs
+++ b/crates/cordis-cli/src/worker.rs
@@ -3,6 +3,7 @@
 use cordis::Context;
 use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
 use notify::{Config as NotifyConfig, RecursiveMode, Watcher};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::mpsc;
@@ -15,6 +16,11 @@ pub const EXIT_QUIT: i32 = 52;
 /// Exit code reporting that the loader never came up (bad config,
 /// unreadable file); the daemon exits non-zero instead of masking it.
 pub const EXIT_BOOT: i32 = 53;
+/// Environment marker set by the daemon on workers it supervises. Such
+/// workers watch their stdin pipe: the daemon holds the write end, so EOF
+/// means the daemon is going away (clean shutdown or sudden death) and the
+/// worker tears itself down gracefully.
+pub const SUPERVISED_ENV: &str = "CORDIS_SUPERVISED";
 
 /// Quiet window a plugin library must stay unchanged before the worker
 /// restarts, so incremental linker output does not restart mid-write.
@@ -99,6 +105,33 @@ pub fn run(config_path: &Path, plugin_dirs: &[PathBuf]) -> ! {
     .is_err()
     {
         eprintln!("cordis: could not install signal handlers");
+    }
+
+    // Under the daemon, watch the supervisor's stdin pipe. EOF (or an
+    // errored pipe) means the daemon is gone or asked us to stop — the
+    // same graceful teardown a signal triggers, and the only notification
+    // a SIGKILLed daemon can still send. Not spawned for manually-run
+    // workers, so a terminal's stdin stays untouched.
+    if std::env::var_os(SUPERVISED_ENV).is_some() {
+        let inner = Arc::clone(&inner);
+        let watched = std::thread::Builder::new()
+            .name("cordis-supervisor-watch".to_owned())
+            .spawn(move || {
+                let mut stdin = std::io::stdin();
+                let mut byte = [0_u8];
+                loop {
+                    match stdin.read(&mut byte) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => continue,
+                    }
+                }
+                eprintln!("cordis: supervisor went away, shutting down");
+                inner.teardown();
+                std::process::exit(EXIT_QUIT);
+            });
+        if watched.is_err() {
+            eprintln!("cordis: could not watch the supervisor pipe");
+        }
     }
 
     match loader.watch() {

--- a/crates/cordis-cli/tests/daemon_shutdown.rs
+++ b/crates/cordis-cli/tests/daemon_shutdown.rs
@@ -1,0 +1,129 @@
+//! Daemon shutdown forwarding: a signal delivered to the daemon alone must
+//! take the worker down with it (issue #31), instead of hanging in
+//! `child.wait()` while the worker keeps running orphaned.
+
+// The orphan check walks /proc, so the whole test is Linux-only.
+#![cfg(target_os = "linux")]
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Marker inside every process command line that belongs to this test run.
+fn unique_stem() -> String {
+    format!(
+        "cordis-cli-shutdown-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos() as u64)
+            .unwrap_or(0)
+    )
+}
+
+/// Spawn the daemon on an `entries: []` config; panics unless the worker
+/// reports readiness on stderr within `timeout`.
+// The Child is the caller's to reap; only the panic path kills it here.
+#[allow(clippy::zombie_processes)]
+fn spawn_ready_daemon(stem: &str) -> (Child, PathBuf) {
+    let dir = std::env::temp_dir().join(stem);
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("cordis.yml");
+    std::fs::write(&config, "entries: []\n").unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cordis"))
+        .arg("run")
+        .arg(&config)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cordis daemon");
+
+    let stderr = child.stderr.take().expect("piped stderr");
+    let seen = Arc::new(Mutex::new(String::new()));
+    let log = Arc::clone(&seen);
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines() {
+            let Ok(line) = line else { break };
+            log.lock().unwrap().push_str(&line);
+            log.lock().unwrap().push('\n');
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if seen.lock().unwrap().contains("worker ready") {
+            return (child, config);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    panic!(
+        "worker never reported ready; daemon stderr:\n{}",
+        seen.lock().unwrap()
+    );
+}
+
+/// Processes whose command line still references this test's config path —
+/// the daemon, the worker, or strays from an earlier run.
+fn processes_referencing(stem: &str) -> usize {
+    let mut count = 0;
+    let entries = std::fs::read_dir("/proc").unwrap();
+    for entry in entries.flatten() {
+        let Ok(cmdline) = std::fs::read_to_string(entry.path().join("cmdline")) else {
+            continue;
+        };
+        // /proc cmdline entries are NUL-separated; compare loosely.
+        if cmdline.contains(stem) {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// `kill -TERM <daemon>` only: the daemon must forward the shutdown to the
+/// worker (gracefully, via the supervisor pipe), exit 0 itself within a
+/// bounded time, and leave no orphan worker behind.
+#[cfg(target_os = "linux")]
+#[test]
+fn sigterm_to_daemon_only_takes_the_worker_down() {
+    let stem = unique_stem();
+    let (mut daemon, _config) = spawn_ready_daemon(&stem);
+
+    let pid = daemon.id() as i32;
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+
+    // The daemon exits promptly (it used to hang in child.wait() forever).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match daemon.try_wait().expect("daemon is waitable") {
+            Some(status) => {
+                assert_eq!(status.code(), Some(0), "daemon exit code after SIGTERM");
+                break;
+            }
+            None if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            None => panic!("daemon did not exit within 5s of SIGTERM"),
+        }
+    }
+
+    // And no worker survives it.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if processes_referencing(&stem) == 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker processes survived the daemon shutdown"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = std::fs::remove_dir_all(std::env::temp_dir().join(&stem));
+}

--- a/crates/cordis-include/src/file.rs
+++ b/crates/cordis-include/src/file.rs
@@ -48,6 +48,10 @@ struct FileInner {
     path: PathBuf,
     format: FileFormat,
     suspend: Mutex<usize>,
+    /// Serializes whole write sequences (serialize → tmp write → rename).
+    /// Without it two writers race on the same sibling `.tmp` file and the
+    /// rename can land torn content; see `write_document`.
+    write_lock: Mutex<()>,
     deferred: Mutex<DeferredState>,
     deferred_signal: Condvar,
     flusher: Mutex<Option<std::thread::JoinHandle<()>>>,
@@ -108,6 +112,7 @@ impl LoaderFile {
                 path,
                 format,
                 suspend: Mutex::new(0),
+                write_lock: Mutex::new(()),
                 deferred: Mutex::new(DeferredState::default()),
                 deferred_signal: Condvar::new(),
                 flusher: Mutex::new(None),
@@ -258,7 +263,13 @@ impl LoaderFile {
 
 /// Serialize `document` and atomically replace the file behind `inner`.
 /// A no-op while the file is suspended.
+///
+/// The whole sequence — serialize, write the sibling `.tmp`, fsync, rename —
+/// runs under `write_lock`: concurrent writers (a synchronous `write`, the
+/// deferred flusher, the loader's write-back) would otherwise interleave on
+/// the same `.tmp` path and the rename could publish torn content.
 fn write_document(inner: &FileInner, document: &Document) -> Result<()> {
+    let _write = crate::lock(&inner.write_lock);
     if *crate::lock(&inner.suspend) > 0 {
         return Ok(());
     }
@@ -415,5 +426,101 @@ impl Drop for FileSuspendGuard {
     fn drop(&mut self) {
         let mut suspend = lock(&self.file.inner.suspend);
         *suspend = suspend.saturating_sub(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file(stem: &str) -> LoaderFile {
+        let path = std::env::temp_dir().join(format!(
+            "cordis-include-write-test-{stem}-{}-{}.yml",
+            std::process::id(),
+            randomish()
+        ));
+        let _ = std::fs::remove_file(&path);
+        LoaderFile::open(path).unwrap()
+    }
+
+    fn randomish() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos() as u64)
+            .unwrap_or(0)
+    }
+
+    fn padded_document(tag: u64) -> Document {
+        // A large payload widens the torn-write window.
+        let filler = "x".repeat(4096);
+        let config = Node::String(format!("{tag}-{filler}"));
+        Document::with_entries(vec![
+            EntryOptions::new("w").with_id("w").with_config(config),
+        ])
+    }
+
+    /// Regression: two writers racing on the shared sibling `.tmp` could
+    /// interleave and the rename published torn content. The write lock
+    /// serializes whole write sequences; the final file must always parse
+    /// and equal one of the writers' documents in full.
+    #[test]
+    fn concurrent_writers_never_produce_a_torn_file() {
+        for _ in 0..25 {
+            let file = temp_file("race");
+            let writers: Vec<_> = (0..4_u64)
+                .map(|tag| {
+                    let file = file.clone();
+                    std::thread::spawn(move || {
+                        let document = padded_document(tag);
+                        for _ in 0..5 {
+                            file.write(&document).unwrap();
+                        }
+                    })
+                })
+                .collect();
+            for writer in writers {
+                writer.join().unwrap();
+            }
+            let document = file.read().unwrap();
+            let config = document.entries[0].config.clone().unwrap();
+            let Node::String(text) = &config else {
+                panic!("config is not the string one writer wrote: {config:?}");
+            };
+            let tag: u64 = text.split('-').next().unwrap().parse().unwrap();
+            let expected = padded_document(tag);
+            assert_eq!(document, expected, "torn or mixed content survived");
+            let _ = std::fs::remove_file(file.path());
+        }
+    }
+
+    /// The deferred flusher and a synchronous writer share the same file;
+    /// interleaving them must never leave an unparseable result behind.
+    #[test]
+    fn concurrent_deferred_and_sync_writes_stay_parseable() {
+        for _ in 0..25 {
+            let file = temp_file("deferred-race");
+            let deferred = std::thread::spawn({
+                let file = file.clone();
+                move || {
+                    for tag in 0..20_u64 {
+                        file.write_deferred(padded_document(tag), Duration::from_millis(1));
+                    }
+                    file.flush_deferred();
+                }
+            });
+            for tag in 100..120_u64 {
+                file.write(&padded_document(tag)).unwrap();
+            }
+            deferred.join().unwrap();
+            let document = file.read().unwrap();
+            let config = document.entries[0].config.clone().unwrap();
+            let Node::String(text) = &config else {
+                panic!("config is not the string one writer wrote: {config:?}");
+            };
+            let tag: u64 = text.split('-').next().unwrap().parse().unwrap();
+            assert_eq!(document, padded_document(tag));
+            let _ = std::fs::remove_file(file.path());
+        }
     }
 }

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -3,11 +3,15 @@
 use crate::error::{LoaderError, Result};
 use crate::lock;
 use crate::registry::{PluginRegistry, WithInject};
-use cordis::{Config, Context, EffectHandle, EventOptions, Fiber, FiberState, PluginHandle, Value};
+use cordis::{
+    Config, Context, CordisError, EffectHandle, ErrorCode, EventOptions, Fiber, FiberState,
+    PluginHandle, Value,
+};
 use cordis_include::{Entry, EntryOptions, EntryTree, LoaderFile, Node, PluginResolver, TreeDiff};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::thread::ThreadId;
 use std::time::Duration;
 
 /// Where the loader reads and writes its entry file.
@@ -81,6 +85,15 @@ pub(crate) struct LoaderInner {
     tree: EntryTree,
     registry: Mutex<PluginRegistry>,
     state: Mutex<LoaderState>,
+    /// Serializes the loader's state transitions end to end — `reload`,
+    /// `update_config`, `dispose`, and deferred self-kill persistence — so
+    /// file reads, tree diffs, fiber patches, and write-backs always run in
+    /// a consistent order. Without it a watch-thread `reload` can interleave
+    /// with a plugin-thread `update_config` and leave the fiber serving a
+    /// different config than the tree and the file claim, with no later
+    /// event to reconcile the difference. Reentrancy-aware because loader
+    /// event listeners legitimately call back into the loader.
+    operation: OperationLock,
     /// Canonical path -> file of every import currently mounted.
     imports: Mutex<HashMap<PathBuf, LoaderFile>>,
     /// Paths already armed by [`Loader::watch`] (watch feature).
@@ -145,6 +158,7 @@ impl Loader {
                 last_error: errors.pop(),
                 _keep_alive: Vec::new(),
             }),
+            operation: OperationLock::default(),
             imports: Mutex::new(imports),
             #[cfg(feature = "watch")]
             watched: Mutex::new(HashSet::new()),
@@ -265,6 +279,9 @@ impl Loader {
     /// written back; generated ids are persisted afterwards.
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
+        // Whole-reload exclusion: compose, diff, fiber transitions, and the
+        // id write-back must not interleave with update_config() or dispose().
+        let _operation = inner.operation.guard();
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
         let (composed, dirty) = match compose(
@@ -349,6 +366,10 @@ impl Loader {
     /// restarted when active) and the new config is persisted to the file.
     pub fn update_config(&self, id: &str, config: Node) -> Result<()> {
         let inner = &self.inner;
+        // Same exclusion as reload(): the fiber update, tree commit, and
+        // file write-back must land as one unit, or a concurrent reload
+        // could patch the fiber back to the file's previous content.
+        let _operation = inner.operation.guard();
         let entry = inner.tree.resolve(id).ok_or_else(|| {
             LoaderError::Include(cordis_include::IncludeError::EntryNotFound { id: id.to_owned() })
         })?;
@@ -375,6 +396,9 @@ impl Loader {
     /// same root works afterwards.
     pub fn dispose(&self) -> Result<()> {
         let inner = &self.inner;
+        // Excluded against reload()/update_config() so entry teardown cannot
+        // interleave with a reconcile pass touching the same fibers.
+        let _operation = inner.operation.guard();
         for entry in inner.tree.top_level() {
             if let Err(error) = stop_entry(inner, &entry) {
                 self.record_error(error);
@@ -464,6 +488,62 @@ impl Drop for OperatingGuard<'_> {
     }
 }
 
+/// Reentrancy-aware exclusion for the loader's state transitions.
+///
+/// Foreign threads block until the current transition finishes; acquisition
+/// from the *owning* thread passes through instead of deadlocking. That
+/// matters because loader events (`ENTRY_INIT`, `PARTIAL_DISPOSE`, patch
+/// events) run listener code inline, and a listener calling back into
+/// `reload()`/`update_config()` re-enters on the same thread — a plain
+/// `std::sync::Mutex` would deadlock there.
+#[derive(Default)]
+struct OperationLock {
+    state: Mutex<OperationState>,
+    released: Condvar,
+}
+
+#[derive(Default)]
+struct OperationState {
+    owner: Option<ThreadId>,
+    depth: usize,
+}
+
+impl OperationLock {
+    /// Acquire the lock, blocking only foreign threads.
+    fn guard(&self) -> OperationGuard<'_> {
+        let current = std::thread::current().id();
+        let mut state = lock(&self.state);
+        loop {
+            if state.owner.is_none_or(|owner| owner == current) {
+                state.owner = Some(current);
+                state.depth += 1;
+                return OperationGuard { lock: self };
+            }
+            let guard = self
+                .released
+                .wait(state)
+                .unwrap_or_else(|error| error.into_inner());
+            state = guard;
+        }
+    }
+}
+
+struct OperationGuard<'a> {
+    lock: &'a OperationLock,
+}
+
+impl Drop for OperationGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = lock(&self.lock.state);
+        state.depth = state.depth.saturating_sub(1);
+        if state.depth == 0 {
+            state.owner = None;
+            drop(state);
+            self.lock.released.notify_all();
+        }
+    }
+}
+
 /// Emit a loader event; listener failures are recorded, never propagated
 /// into the state machine.
 fn emit(inner: &LoaderInner, name: &str, args: Vec<Value>) {
@@ -490,10 +570,21 @@ fn start_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
         .and_then(|fiber| fiber.context())
         .unwrap_or_else(|| inner.root.clone());
     let fiber = parent_ctx.plugin(handle, config);
+    let Some(uid) = fiber.uid() else {
+        // The parent context's registry rejected the start (its fiber was
+        // disposed concurrently, so the parent-effect registration failed
+        // and the new fiber came back with its uid cleared). Recording the
+        // rejected fiber here would wedge the entry forever: every later
+        // reload sees a fiber and skips the start. Leave the entry
+        // unstarted so the next reload retries it, and surface why.
+        return Err(LoaderError::Cordis(
+            fiber
+                .error()
+                .unwrap_or_else(|| CordisError::new(ErrorCode::InactiveEffect)),
+        ));
+    };
     entry.set_fiber(Some(fiber.clone()));
-    if let Some(uid) = fiber.uid() {
-        lock(&inner.state).entries.insert(uid, entry.clone());
-    }
+    lock(&inner.state).entries.insert(uid, entry.clone());
     emit(
         inner,
         crate::events::ENTRY_INIT,
@@ -542,7 +633,25 @@ fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
             crate::events::BEFORE_PATCH,
             vec![Value::new(entry.clone())],
         );
-        fiber.update_value(Config::new(new_config))?;
+        if let Err(error) = fiber.update_value(Config::new(new_config)) {
+            // tree.update() already committed the new options before this
+            // patch ran. Rolling the entry's stored config back to what the
+            // fiber actually runs keeps the tree honest and — crucially —
+            // makes the next reload's diff see a change again, so a config
+            // that failed validation is retried instead of silently pinning
+            // the fiber to the stale config forever.
+            if let Some(old_config) = current {
+                let mut options = entry_options_with_children(entry);
+                options.config = Some(old_config);
+                if let Err(revert) = inner.tree.update_entry(&entry.path(), options, None, None) {
+                    lock(&inner.state).last_error = Some(format!(
+                        "failed to roll back config of {}: {revert}",
+                        entry.path()
+                    ));
+                }
+            }
+            return Err(LoaderError::Cordis(error));
+        }
         emit(
             inner,
             crate::events::AFTER_PATCH,
@@ -739,7 +848,15 @@ fn compose(
 /// Route `internal/status` disposals: a fiber that reached `Disposed`
 /// outside loader operation was killed by its own plugin, so record
 /// `disabled: true` in the tree and persist it.
-fn handle_status(inner: &LoaderInner, event: &cordis::Event) -> cordis::EventResult {
+///
+/// The status event fires while the dying fiber still holds its transition
+/// mutex, so the persistence itself — a tree mutation, file serialize +
+/// fsync + rename, and `PARTIAL_DISPOSE` listeners — is deferred to a
+/// short-lived thread. Running it inline would stretch that critical
+/// section across disk I/O and arbitrary user code, making other threads'
+/// restart/dispose on the same fiber time out on stalls that have nothing
+/// to do with the fiber's own teardown.
+fn handle_status(inner: &Arc<LoaderInner>, event: &cordis::Event) -> cordis::EventResult {
     let Some(fiber) = event.arg::<Fiber>(0).ok().flatten() else {
         return Ok(None);
     };
@@ -757,8 +874,32 @@ fn handle_status(inner: &LoaderInner, event: &cordis::Event) -> cordis::EventRes
     else {
         return Ok(None);
     };
-    if let Err(error) = persist_self_dispose(inner, &entry) {
-        lock(&inner.state).last_error = Some(error.to_string());
+    let deferred = std::thread::Builder::new()
+        .name("cordis-self-dispose".to_owned())
+        .spawn({
+            // A strong reference keeps the loader alive until the record
+            // lands, even if the caller drops every Loader handle at once.
+            let inner = Arc::clone(inner);
+            let entry = entry.clone();
+            move || {
+                // Serialized with reload()/update_config()/dispose() so the
+                // self-kill write-back cannot interleave with a reconcile.
+                let _operation = inner.operation.guard();
+                if let Err(error) = persist_self_dispose(&inner, &entry) {
+                    lock(&inner.state).last_error = Some(error.to_string());
+                }
+            }
+        });
+    match deferred {
+        Ok(_join) => {}
+        Err(_) => {
+            // Could not spawn a thread: persist inline rather than losing
+            // the self-kill record.
+            let _operation = inner.operation.guard();
+            if let Err(error) = persist_self_dispose(inner, &entry) {
+                lock(&inner.state).last_error = Some(error.to_string());
+            }
+        }
     }
     Ok(None)
 }
@@ -789,4 +930,69 @@ fn persist_self_dispose(inner: &LoaderInner, entry: &Entry) -> Result<()> {
         vec![Value::new(entry.clone())],
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cordis::{Inject, PluginOutput, plugin_sync};
+
+    /// Regression (#36): when the parent group's fiber dies before a child
+    /// entry starts, the registry rejects the new fiber (uid cleared,
+    /// state Disposed). start_entry must surface the rejection and leave
+    /// the entry without a fiber — recording the rejected fiber wedged the
+    /// entry forever, since every later reload saw a fiber and skipped the
+    /// start.
+    #[test]
+    fn rejected_start_leaves_the_entry_retryable() {
+        let path = std::env::temp_dir().join(format!(
+            "cordis-loader-rejected-start-{}-{}.yml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|elapsed| elapsed.as_nanos() as u64)
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut registry = PluginRegistry::new();
+        registry.register("worker", || {
+            plugin_sync::<Node, _>("worker", Inject::default(), |_, _| Ok(PluginOutput::none()))
+        });
+        let root = Context::new();
+        let loader = Loader::open(
+            &root,
+            LoaderConfig::new(&path)
+                .with_registry(registry)
+                .with_initial(cordis_include::Document::with_entries(vec![
+                    EntryOptions::new("group")
+                        .with_id("g1")
+                        .with_group(vec![EntryOptions::new("worker").with_id("c1")]),
+                ])),
+        )
+        .unwrap();
+        let inner = &loader.inner;
+        let group = inner.tree.resolve("g1").unwrap();
+        let child = inner.tree.resolve("g1:c1").unwrap();
+        assert!(group.fiber().is_some() && child.fiber().is_some());
+
+        // Kill the parent group while the loader looks away (no self-kill
+        // bookkeeping), then model the child as not-yet-started.
+        {
+            let _operating = OperatingGuard::new(&inner.state);
+            group.fiber().unwrap().dispose().unwrap();
+        }
+        child.set_fiber(None);
+
+        let result = start_entry(inner, &child);
+        assert!(result.is_err(), "the registry rejection must surface");
+        assert!(child.fiber().is_none(), "no rejected fiber recorded");
+
+        // Still eligible: retrying fails the same way instead of silently
+        // doing nothing because a dead fiber occupies the entry.
+        assert!(start_entry(inner, &child).is_err());
+        assert!(child.fiber().is_none());
+
+        drop(loader);
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/crates/cordis-loader/src/registry.rs
+++ b/crates/cordis-loader/src/registry.rs
@@ -7,6 +7,7 @@ use cordis_group::Group;
 use cordis_include::IMPORT_NAME;
 use cordis_include::resolver::unknown_plugin;
 use std::collections::HashMap;
+#[cfg(feature = "dynamic")]
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/crates/cordis-loader/tests/events.rs
+++ b/crates/cordis-loader/tests/events.rs
@@ -186,9 +186,22 @@ fn self_kill_emits_partial_dispose() {
     listen(&root, &counts);
 
     lock(&victim).clone().unwrap().dispose().unwrap();
-    assert_eq!(counts.partial_dispose.load(Ordering::SeqCst), 1);
-    let text = std::fs::read_to_string(&config_path).unwrap();
-    assert!(text.contains("disabled: true"), "{text}");
+    // The self-kill persistence (and its PARTIAL_DISPOSE emission) is
+    // deferred off the dying fiber's transition lock; poll for it.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let persisted = std::fs::read_to_string(&config_path)
+            .unwrap()
+            .contains("disabled: true");
+        if counts.partial_dispose.load(Ordering::SeqCst) == 1 && persisted {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "self-kill events/persistence never landed"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/cordis-loader/tests/loader.rs
+++ b/crates/cordis-loader/tests/loader.rs
@@ -162,7 +162,9 @@ fn self_disposed_plugin_is_disabled_in_the_file() {
     let entry = loader.tree().resolve("v1").unwrap();
     entry.fiber().unwrap().try_wait().unwrap();
 
-    // The plugin tears itself down outside the loader.
+    // The plugin tears itself down outside the loader. The `disabled: true`
+    // persistence is deferred off the dying fiber's transition lock, so
+    // poll briefly for it to land.
     victim_fiber
         .lock()
         .unwrap()
@@ -171,9 +173,22 @@ fn self_disposed_plugin_is_disabled_in_the_file() {
         .dispose()
         .unwrap();
 
-    assert!(entry.fiber().is_none());
-    let text = std::fs::read_to_string(&path).unwrap();
-    assert!(text.contains("disabled: true"), "{text}");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if entry.fiber().is_none()
+            && std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("disabled: true")
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "self-kill persistence never landed: {}",
+            std::fs::read_to_string(&path).unwrap()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
     // Loader-driven disposals must NOT be misclassified: stop the loader and
     // confirm no further rewrite happened beyond the persisted state.
     let before = std::fs::read_to_string(&path).unwrap();

--- a/crates/cordis-loader/tests/review_fixes.rs
+++ b/crates/cordis-loader/tests/review_fixes.rs
@@ -1,0 +1,274 @@
+//! Regression tests for the review findings on loader races and
+//! self-kill persistence (issues #30, #33, #39).
+
+use cordis::utils::BoxFuture;
+use cordis::{
+    Config, Context, CordisError, ErrorCode, Inject, Plugin, PluginHandle, PluginOutput, Result,
+    plugin_sync,
+};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn temp_path(stem: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "cordis-loader-review-{stem}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("cordis.yml")
+}
+
+fn cleanup(path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// A plugin whose validate_config rejects `port: 999`, counting how many
+/// times validation ran so retries are observable.
+struct PickyPlugin {
+    validations: Arc<AtomicUsize>,
+}
+
+impl Plugin for PickyPlugin {
+    fn name(&self) -> &str {
+        "picky"
+    }
+
+    fn validate_config(&self, config: Config) -> Result<Config> {
+        self.validations.fetch_add(1, Ordering::SeqCst);
+        let node = config
+            .downcast::<Node>()
+            .map_err(|_| CordisError::new(ErrorCode::Plugin))?;
+        if node["port"].as_i64() == Some(999) {
+            return Err(CordisError::with_message(
+                ErrorCode::Plugin,
+                "port 999 is reserved",
+            ));
+        }
+        Ok(Config::new((*node).clone()))
+    }
+
+    fn apply(&self, _ctx: Context, config: Config) -> BoxFuture<Result<PluginOutput>> {
+        let node = config.downcast::<Node>().ok();
+        Box::pin(async move {
+            let _ = node;
+            Ok(PluginOutput::none())
+        })
+    }
+}
+
+/// Regression (#30): a config the plugin rejects must not silently split
+/// fiber / tree / file. The fiber keeps running its previous config, and
+/// the next reload of the same file retries the patch instead of diffing
+/// against already-committed options and doing nothing.
+#[test]
+fn rejected_patch_keeps_fiber_config_and_is_retried() {
+    let path = temp_path("patch-retry");
+    let validations = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("picky", {
+        let validations = validations.clone();
+        move || {
+            PluginHandle::new(PickyPlugin {
+                validations: validations.clone(),
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("picky")
+                    .with_id("p1")
+                    .with_config(Node::from_iter([("port".to_string(), 1.into())])),
+            ])),
+    )
+    .unwrap();
+    let entry = loader.tree().resolve("p1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+    let validations_after_start = validations.load(Ordering::SeqCst);
+
+    // External edit to a config the plugin rejects.
+    std::fs::write(
+        &path,
+        "entries:\n  - id: p1\n    name: picky\n    config:\n      port: 999\n",
+    )
+    .unwrap();
+    loader.reload().unwrap();
+    let port = entry.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(port["port"].as_i64(), Some(1), "fiber keeps its old config");
+    assert!(loader.last_error().is_some(), "the rejection is recorded");
+    assert_eq!(
+        validations.load(Ordering::SeqCst),
+        validations_after_start + 1,
+        "the patch attempt validated the new config"
+    );
+
+    // Reloading the SAME file must retry the rejected patch. Before the
+    // fix, the tree already held the rejected options, the diff was empty,
+    // and the fiber was pinned to the stale config forever.
+    loader.reload().unwrap();
+    assert_eq!(
+        validations.load(Ordering::SeqCst),
+        validations_after_start + 2,
+        "a same-file reload retries the patch"
+    );
+    let port = entry.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(port["port"].as_i64(), Some(1));
+
+    // A subsequent valid config patches the fiber successfully.
+    std::fs::write(
+        &path,
+        "entries:\n  - id: p1\n    name: picky\n    config:\n      port: 2\n",
+    )
+    .unwrap();
+    loader.reload().unwrap();
+    let port = entry.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(port["port"].as_i64(), Some(2));
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// Regression (#33): a plugin-thread update_config() racing watch-thread
+/// reloads must never leave the fiber serving a config that differs from
+/// the tree and the file.
+#[test]
+fn update_config_racing_reload_stays_consistent() {
+    let path = temp_path("race");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", {
+        let starts = starts.clone();
+        move || {
+            let starts = starts.clone();
+            plugin_sync::<Node, _>("worker", Inject::default(), move |_ctx, config| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                let _port = config["port"].as_i64();
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker")
+                    .with_id("w1")
+                    .with_config(Node::from_iter([("port".to_string(), 1.into())])),
+            ])),
+    )
+    .unwrap();
+    let entry = loader.tree().resolve("w1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+
+    let racer = loader.clone();
+    let updates = std::thread::spawn(move || {
+        for port in 2..=51_i64 {
+            racer
+                .update_config("w1", Node::from_iter([("port".to_string(), port.into())]))
+                .expect("update_config must not fail under concurrent reloads");
+        }
+    });
+    for _ in 0..50 {
+        loader.reload().unwrap();
+    }
+    updates.join().unwrap();
+
+    // Tree, fiber, and file must agree on the final config.
+    let tree_port = loader.tree().resolve("w1").unwrap().config().unwrap()["port"].as_i64();
+    let fiber_port = entry.fiber().unwrap().config().downcast::<Node>().unwrap()["port"].as_i64();
+    let file_port = loader.file().read().unwrap().entries[0]
+        .config
+        .clone()
+        .unwrap()["port"]
+        .as_i64();
+    assert_eq!(tree_port, Some(51), "tree options");
+    assert_eq!(fiber_port, Some(51), "fiber config");
+    assert_eq!(file_port, Some(51), "file content");
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// Regression (#39): self-kill persistence (tree write + file fsync +
+/// PARTIAL_DISPOSE listeners) used to run inside the dying fiber's
+/// transition critical section. A slow listener must not stall the
+/// disposing call — and the persistence must still land.
+#[test]
+fn self_kill_persistence_leaves_the_transition_snappy() {
+    let path = temp_path("snappy");
+    let victim: Arc<Mutex<Option<cordis::Fiber>>> = Arc::new(Mutex::new(None));
+    let mut registry = PluginRegistry::new();
+    registry.register("victim", {
+        let victim = victim.clone();
+        move || {
+            let victim = victim.clone();
+            plugin_sync::<Node, _>("victim", Inject::default(), move |ctx, _| {
+                *lock(&victim) = Some(ctx.fiber()?);
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("victim").with_id("v1"),
+            ])),
+    )
+    .unwrap();
+    lock(&victim).clone().unwrap().try_wait().unwrap();
+
+    let _slow = root
+        .events()
+        .on(
+            cordis_loader::events::PARTIAL_DISPOSE,
+            |_| {
+                std::thread::sleep(Duration::from_secs(2));
+                Ok(None)
+            },
+            cordis::EventOptions::default(),
+        )
+        .unwrap();
+
+    let started = Instant::now();
+    lock(&victim).clone().unwrap().dispose().unwrap();
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "dispose stalled {elapsed:?} behind deferred persistence work"
+    );
+
+    // The persistence still lands, just off the transition lock.
+    let deadline = Instant::now() + Duration::from_secs(6);
+    loop {
+        if std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("disabled: true")
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "self-kill persistence never landed"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    loader.dispose().unwrap();
+    cleanup(&path);
+}

--- a/crates/cordis/src/effect.rs
+++ b/crates/cordis/src/effect.rs
@@ -149,11 +149,30 @@ impl EffectCell {
         if self.disposed.swap(true, Ordering::AcqRel) {
             return;
         }
-        lock(&self.disposer).take();
-        lock(&self.children).clear();
         if let Some(owner) = self.owner.upgrade() {
             owner.remove_effect(self.id);
         }
+        // Adopted children were detached from their owning fiber's effect
+        // list at adopt() time, so nobody else will ever dispose them; drop
+        // them through the normal disposal path or their cleanup callbacks
+        // leak. Only this effect's own disposer is skipped — that is what
+        // "cancel" means.
+        let children = {
+            let mut children = lock(&self.children);
+            std::mem::take(&mut *children)
+        };
+        for child in children.into_iter().rev() {
+            if let Err(error) = crate::utils::block_on(child.dispose()) {
+                // Surface the failure on the fiber's log like dispose does;
+                // cancellation itself must stay infallible.
+                if let Some(owner) = child.owner.upgrade() {
+                    if let Some(ctx) = Fiber::from_inner(owner).context() {
+                        ctx.log_error(&error);
+                    }
+                }
+            }
+        }
+        lock(&self.disposer).take();
     }
 
     fn adopt(self: &Arc<Self>, child: Arc<EffectCell>) -> Result<()> {
@@ -204,7 +223,13 @@ impl EffectHandle {
         self.cell.dispose().await
     }
 
-    /// Stop owning this effect without running its cleanup callback.
+    /// Stop owning this effect without running *its own* cleanup callback.
+    ///
+    /// Adopted children are unaffected by the cancellation of their parent:
+    /// they were detached from their owning fiber at [`adopt`](Self::adopt)
+    /// time, so cancelling runs each child's disposer exactly as
+    /// [`dispose`](Self::dispose) would — otherwise those children would be
+    /// orphaned with cleanup that never runs.
     ///
     /// This is intended for framework structural effects. Application code
     /// normally wants [`dispose`](Self::dispose).
@@ -314,5 +339,47 @@ mod tests {
         assert!(adopt_handle.join().unwrap().is_err());
         dispose_handle.join().unwrap().unwrap();
         assert!(!child_ran.load(Ordering::SeqCst));
+    }
+
+    /// Regression: cancel() used to clear the children list without
+    /// disposing them; since adopt() already detached those children from
+    /// their owning fiber, their disposers were lost forever. Cancelling a
+    /// parent must run adopted children's disposers, exactly once, while
+    /// still skipping the parent's own.
+    #[test]
+    fn cancel_disposes_adopted_children_but_not_the_parent() {
+        let runs = Arc::new(Mutex::new(Vec::new()));
+        let parent_ran = Arc::new(AtomicBool::new(false));
+        let parent_ran_in_disposer = parent_ran.clone();
+        let parent = EffectCell::new(
+            1,
+            Weak::new(),
+            "parent",
+            AsyncDisposer::from_sync(move || {
+                parent_ran_in_disposer.store(true, Ordering::SeqCst);
+                Ok(())
+            }),
+        );
+        for id in [2_u64, 3] {
+            let runs = runs.clone();
+            let child = EffectCell::new(
+                id,
+                Weak::new(),
+                "child",
+                AsyncDisposer::from_sync(move || {
+                    lock(&runs).push(id);
+                    Ok(())
+                }),
+            );
+            parent.adopt(child).unwrap();
+        }
+        parent.cancel();
+        assert_eq!(*lock(&runs), vec![3, 2], "children disposed, reverse order");
+        assert!(!parent_ran.load(Ordering::SeqCst), "own disposer skipped");
+        // Second cancel (or a later dispose) must not double-run anything.
+        parent.cancel();
+        let _ = block_on(parent.dispose());
+        assert_eq!(*lock(&runs), vec![3, 2]);
+        assert!(!parent_ran.load(Ordering::SeqCst));
     }
 }

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -699,7 +699,12 @@ impl Fiber {
         )
     }
 
-    /// Async equivalent of [`try_wait`](Self::try_wait): also never suspends.
+    /// Async equivalent of [`try_wait`](Self::try_wait).
+    ///
+    /// **This never suspends.** It is a synchronous poll despite the
+    /// `async` signature — the eager lifecycle model means there is nothing
+    /// to wait for — so awaiting it runs to completion without ever
+    /// yielding to the executor.
     pub async fn await_ready(&self) -> Result<Fiber> {
         self.try_wait()
     }
@@ -856,6 +861,14 @@ impl Fiber {
     }
 
     /// Async equivalent of [`dispose`](Self::dispose).
+    ///
+    /// **This is a synchronous pass-through, not an offload.** Awaiting it
+    /// runs the whole disposal chain — disposers included — on the calling
+    /// thread before the future resolves; it never yields to the executor.
+    /// Inside an async runtime, treat `.await`ing this like calling any
+    /// blocking function: a slow disposer stalls the executor thread for
+    /// the duration. Trigger disposals of long-teardown fibers from a plain
+    /// thread (or [`dispose`](Self::dispose) on a worker) instead.
     pub async fn dispose_async(&self) -> Result<()> {
         self.dispose()
     }
@@ -878,6 +891,32 @@ mod tests {
     use crate::{Inject, PluginOutput};
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, Instant};
+
+    /// `dispose_async` is a synchronous pass-through: awaited from an async
+    /// context it completes the whole disposal without deadlocking or
+    /// needing an executor to make progress.
+    #[test]
+    fn dispose_async_completes_from_an_async_context() {
+        let root = Context::new();
+        let disposed = Arc::new(AtomicUsize::new(0));
+        let disposed_in_disposer = disposed.clone();
+        let fiber = root.plugin_default(plugin_sync::<(), _>(
+            "teardown",
+            Inject::default(),
+            move |_, _| {
+                let disposed_in_disposer = disposed_in_disposer.clone();
+                Ok(PluginOutput::infallible(move || {
+                    disposed_in_disposer.fetch_add(1, Ordering::SeqCst);
+                }))
+            },
+        ));
+        fiber.try_wait().unwrap();
+        // A minimal waker-less block_on: the future never actually pending
+        // is exactly what this test pins down.
+        block_on(fiber.dispose_async()).unwrap();
+        assert_eq!(fiber.state(), FiberState::Disposed);
+        assert_eq!(disposed.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn idle_reflects_and_probes_transitions() {

--- a/crates/cordis/src/logger.rs
+++ b/crates/cordis/src/logger.rs
@@ -295,6 +295,19 @@ impl LoggerRoot {
         }
     }
 
+    /// Whether anything would consume a record of `kind`: the bounded
+    /// buffer (gated by `default_level`) or at least one exporter. Cheap on
+    /// purpose — a short lock probe, no allocation — so `Logger::write` can
+    /// bail out before assembling arguments. Per-exporter thresholds may
+    /// still drop the record later; this only rules out records nobody
+    /// could ever see.
+    fn enabled(&self, default_level: Option<LoggerLevel>, kind: LoggerType) -> bool {
+        let state = lock(&self.state);
+        let buffered =
+            state.buffer_size > 0 && default_level.unwrap_or(LoggerLevel::Info) >= kind.level();
+        buffered || !state.exporter_snapshot.is_empty()
+    }
+
     fn send(
         &self,
         name: String,
@@ -494,6 +507,13 @@ pub struct Logger {
 
 impl Logger {
     fn write(&self, kind: LoggerType, format: impl Into<String>, args: Vec<LogArg>) {
+        // Fast path: when neither the bounded buffer nor any exporter would
+        // consume this record, skip the argument assembly and fiber-name
+        // resolution entirely — the level check inside send() would only
+        // throw the message away afterwards.
+        if !self.ctx.root.logger.enabled(self.level, kind) {
+            return;
+        }
         let mut all = Vec::with_capacity(args.len() + 1);
         all.push(LogArg::String(format.into()));
         all.extend(args);
@@ -688,6 +708,7 @@ fn hyphenate(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Context;
 
     #[test]
     fn hyphenate_splits_camel_case_and_acronyms() {
@@ -696,5 +717,30 @@ mod tests {
         assert_eq!(hyphenate("HTTPServer"), "http-server");
         assert_eq!(hyphenate("ABC"), "abc");
         assert_eq!(hyphenate("A"), "a");
+    }
+
+    /// The filtered fast path must exactly predict what send() keeps: with
+    /// no exporters, only records the buffer accepts are observable. Debug
+    /// under the default info threshold is dropped before any allocation;
+    /// records the buffer accepts still land in it.
+    #[test]
+    fn filtered_records_skip_the_buffer_entirely() {
+        let root = Context::new();
+        let service = root.logger_service();
+        let logger = root.logger();
+        assert_eq!(service.exporter_count(), 0);
+        assert_eq!(service.buffer().len(), 0);
+
+        logger.debug("dropped %d", [LogArg::Integer(1)]);
+        assert_eq!(service.buffer().len(), 0, "debug below the default level");
+
+        logger.error("kept %d", [LogArg::Integer(2)]);
+        let buffer = service.buffer();
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer[0].kind, LoggerType::Error);
+        assert!(matches!(
+            &buffer[0].args[0],
+            LogArg::String(text) if text == "kept %d"
+        ));
     }
 }

--- a/crates/cordis/src/registry.rs
+++ b/crates/cordis/src/registry.rs
@@ -437,6 +437,21 @@ impl RegistryRoot {
     }
 }
 
+/// Drop dead weak fiber references, then the runtimes left without a single
+/// live fiber. Called under the registry state lock by the read APIs
+/// (`len`, `contains`, `values`) so a plugin whose fibers were all dropped
+/// without `dispose()` — documented as legitimate — stops being reported
+/// instead of lingering forever.
+fn prune_runtimes(state: &mut RegistryState) {
+    state.runtimes.retain(|_, runtime| {
+        runtime.fibers.retain(|weak| {
+            weak.upgrade()
+                .is_some_and(|fiber| fiber.uid_value().is_some())
+        });
+        !runtime.fibers.is_empty()
+    });
+}
+
 /// Read-only snapshot of one plugin runtime.
 #[derive(Debug, Clone)]
 pub struct RuntimeInfo {
@@ -460,8 +475,14 @@ impl RegistryService {
     }
 
     /// Number of registered plugin callbacks.
+    ///
+    /// Dead weak references are pruned as a side effect (see
+    /// [`contains`](Self::contains)), so runtimes whose fibers were all
+    /// dropped without `dispose()` stop being counted here.
     pub fn len(&self) -> usize {
-        lock(&self.ctx.root.registry.state).runtimes.len()
+        let mut state = lock(&self.ctx.root.registry.state);
+        prune_runtimes(&mut state);
+        state.runtimes.len()
     }
 
     /// Whether no plugins are registered.
@@ -475,41 +496,32 @@ impl RegistryService {
     /// fibers were all dropped without `dispose()` stops being reported here.
     pub fn contains(&self, plugin: &PluginHandle) -> bool {
         let mut state = lock(&self.ctx.root.registry.state);
-        let Some(runtime) = state.runtimes.get_mut(&plugin.key()) else {
-            return false;
-        };
-        runtime
-            .fibers
-            .retain(|weak| weak.upgrade().and_then(|fiber| fiber.uid_value()).is_some());
-        if runtime.fibers.is_empty() {
-            state.runtimes.remove(&plugin.key());
-            false
-        } else {
-            true
-        }
+        prune_runtimes(&mut state);
+        state
+            .runtimes
+            .get(&plugin.key())
+            .is_some_and(|runtime| !runtime.fibers.is_empty())
     }
 
     /// Return runtime snapshots.
+    ///
+    /// Like [`contains`](Self::contains), dead weak references are pruned
+    /// and a runtime whose fibers were all dropped without `dispose()` is
+    /// removed, so it disappears from later [`len`](Self::len) counts too.
     pub fn values(&self) -> Vec<RuntimeInfo> {
         let mut state = lock(&self.ctx.root.registry.state);
+        prune_runtimes(&mut state);
         state
             .runtimes
-            .iter_mut()
-            .map(|(key, runtime)| {
-                let mut fibers = Vec::new();
-                runtime.fibers.retain(|fiber| {
-                    if let Some(fiber) = fiber.upgrade() {
-                        fibers.push(Fiber::from_inner(fiber));
-                        true
-                    } else {
-                        false
-                    }
-                });
-                RuntimeInfo {
-                    key: *key,
-                    name: runtime.handle.name().to_owned(),
-                    fibers,
-                }
+            .values()
+            .map(|runtime| RuntimeInfo {
+                key: runtime.handle.key(),
+                name: runtime.handle.name().to_owned(),
+                fibers: runtime
+                    .fibers
+                    .iter()
+                    .filter_map(|weak| weak.upgrade().map(Fiber::from_inner))
+                    .collect(),
             })
             .collect()
     }
@@ -581,5 +593,39 @@ impl RegistryService {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Context, Inject, PluginOutput};
+
+    /// Regression: values()/len() used to keep a runtime alive forever once
+    /// its fibers were dropped without dispose() (the documented case for
+    /// contains()'s pruning). Fabricating a runtime whose only weak is
+    /// already dead exercises the pruning directly.
+    #[test]
+    fn read_apis_prune_runtimes_with_only_dead_fibers() {
+        let root = Context::new();
+        let handle =
+            crate::plugin_sync::<(), _>(
+                "ghost",
+                Inject::none(),
+                |_, _| Ok(PluginOutput::default()),
+            );
+        {
+            let mut state = lock(&root.root.registry.state);
+            state.runtimes.insert(
+                handle.key(),
+                RuntimeRecord {
+                    handle: handle.clone(),
+                    fibers: vec![Weak::new()],
+                },
+            );
+        }
+        assert_eq!(root.registry().len(), 0, "len prunes empty runtimes");
+        assert!(root.registry().values().is_empty());
+        assert!(!root.registry().contains(&handle));
     }
 }


### PR DESCRIPTION
## Summary

Verifies and fixes all eleven open review findings (#29–#39). Every issue was confirmed real against the code before fixing; each fix carries a regression test pinning the reported failure mode.

### P1 fixes

- **#29 torn config writes** — `LoaderFile::write` raced on a shared sibling `.tmp` with no mutual exclusion. A dedicated per-file write lock now covers the whole serialize → tmp write → fsync → rename sequence. Test: 4 concurrent writers × 25 rounds plus a deferred-flusher race; the final file must always parse and equal one writer's document.
- **#30 fiber/tree/file split on rejected patch** — `tree.update()` committed new options before `patch_entry()` validated them, so a rejected config was never retried (empty diff on the next reload). The patch now rolls the entry's stored config back to what the fiber actually runs, so the next same-file reload retries. (Implements the issue's suggested option (a); the acceptance bullet "tree options still match the file" contradicts that option, so the test asserts the actual intent: same-file reload retries and a later valid config patches cleanly.)
- **#31 daemon hangs on its own SIGTERM** — `supervise()` blocked in `child.wait()` and never forwarded shutdown, orphaning the worker when the signal reached only the daemon. Implemented with std-only primitives instead of `libc::kill`: the daemon spawns the worker with piped stdin under a `CORDIS_SUPERVISED` marker; the worker watches the pipe and runs the same graceful teardown a signal triggers; the daemon polls `try_wait()`, closes the pipe on shutdown, and kills the worker after a 10s grace. This also covers a `SIGKILL`ed daemon (the OS closes the pipe). Integration test: SIGTERM to the daemon pid only → daemon exits 0 within 5s, no orphan worker remains (verified manually for SIGKILL too).
- **#32 leaked adopted children on cancel** — `EffectHandle::cancel()` cleared the children list although `adopt()` had already detached them from their owning fiber, losing their disposers. Cancel still skips the parent's own disposer but now disposes adopted children exactly once.
- **#33 loader transitions lacked mutual exclusion** — a watch-thread `reload()` could interleave with a plugin-thread `update_config()` and leave fiber/tree/file mutually inconsistent with no event to reconcile. All entry points (`reload`, `update_config`, `dispose`, deferred self-kill persistence) now run under one reentrancy-aware operation lock — reentrant acquisition passes through because loader event listeners legitimately call back into the loader from the same thread; a plain `Mutex` would have turned that into a guaranteed deadlock. Stress test: 50 racing `update_config`/`reload` rounds end with tree, fiber, and file agreeing.

### P2 fixes

- **#34** — `await_ready`/`dispose_async` documented loudly as synchronous pass-throughs that never yield (option (a) from the issue); TODO.md entry resolved.
- **#35** — registry `values()`/`len()` now prune dead weak references and empty runtimes through the same helper `contains()` used.
- **#36** — `start_entry()` no longer records a fiber the parent registry rejected (parent disposed concurrently); the rejection surfaces as an error and the entry stays retryable instead of wedged forever.
- **#37** — `Logger::write` probes a cheap lock-only `enabled()` check before assembling args/resolving names; the bounded buffer still counts as a consumer, so observable behavior is unchanged.
- **#38** — CLI arguments stay `OsString` end to end (breaking: `cordis_cli::run`/`parse_args` signatures), so non-UTF-8 config paths reach the loader intact.
- **#39** — self-kill persistence (tree write + fsync + `PARTIAL_DISPOSE` listeners) moved out of the dying fiber's transition mutex onto a short-lived thread that serializes through the operation lock. Test: a 2s slow listener no longer stalls `dispose()`.

### Also

- `cordis-loader/src/registry.rs`: gated the `PathBuf` import behind the `dynamic` feature (default-feature builds warned).
- Local AGENTS.md (untracked): documented that `cargo clippy` needs the toolchain dir first in `PATH`, not just `RUSTC`/`RUSTDOC` pins.

## Verification

Full gate on the rebased branch (`PATH`-pinned 1.85 toolchain): `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (28 suites), `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`, and both README doctests (9 + 9).

Fixes #29, fixes #30, fixes #31, fixes #32, fixes #33, fixes #34, fixes #35, fixes #36, fixes #37, fixes #38, fixes #39