### PR TITLE
docs: align loader, CLI, and include docs with actual behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Override `validate_config()` to normalize config or return `CordisError::validat
 
 ## Runtime notes
 
-The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. `Fiber::await_ready`, async event modes, async plugins, and async disposers remain available.
+The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. `Fiber::await_ready`, async event modes, async plugins, and async disposers remain available; `await_ready` and `dispose_async` are synchronous pass-throughs that never yield — awaiting them blocks the calling thread for the duration.
 
 Executor-independent futures work everywhere. If a future creates runtime-specific resources (for example `tokio::time::sleep`), call Cordis while that runtime is entered.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -305,7 +305,7 @@ impl Plugin for Worker {
 
 ## 运行时说明
 
-TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供 `Fiber::await_ready`、异步事件模式、异步插件和异步 disposer。
+TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供 `Fiber::await_ready`、异步事件模式、异步插件和异步 disposer；其中 `await_ready` 与 `dispose_async` 是同步直通实现，从不让出执行器——await 期间会阻塞调用线程直至完成。
 
 与执行器无关的 future 可以在任何环境中运行。如果 future 会创建特定运行时资源（例如 `tokio::time::sleep`），请在对应运行时已经进入的情况下调用 Cordis。
 

--- a/crates/cordis-cli/README.md
+++ b/crates/cordis-cli/README.md
@@ -13,9 +13,15 @@ cordis: worker ready (2 entries, config: cordis.yml)
 
 - **daemon / worker** — `cordis run` supervises a worker subprocess that
   boots the loader. The worker exits with code `51` to request a hot
-  restart and `52` to quit; only `51` respawns.
+  restart, `52` to quit, and `53` when the loader never booted; only `51`
+  respawns.
 - **signals** — `SIGINT` / `SIGTERM` dispose the root context gracefully
-  and exit `52`, so Ctrl+C stops the whole application cleanly.
+  and exit `52`, so Ctrl+C stops the whole application cleanly. A signal
+  that reaches only the daemon (`kill <pid>`, supervisors with per-process
+  kill modes) is forwarded: the daemon closes the worker's stdin pipe, the
+  worker tears down through the same graceful path, and one that ignores
+  it for ten seconds is killed — so the worker also exits when the daemon
+  dies for any reason.
 - **dotenv** — `.env` and `.env.local` are loaded from the working
   directory at startup (existing environment variables always win), and
   `${{ env.NAME }}` templates in the config expand from there.
@@ -33,7 +39,10 @@ handle.restart(); // full worker reload (exit 51)
 ## Scope
 
 The stock binary registers only the built-in `group` plugin; entries with
-other names are recorded in the loader's `last_error()` and skipped.
-Embedding applications register their own plugins via
+other names are recorded in the loader's `last_error()` and skipped,
+unless `--plugin-dir <dir>` (repeatable) lets them resolve from
+dynamic-library plugins fingerprint-checked against the running toolchain —
+a changed library hot-restarts the worker. Embedding applications register
+their own plugins via
 [`cordis_loader::PluginRegistry`](https://docs.rs/cordis-loader) or fork
-this runner; dynamic library loading (`dynamic` feature) is future work.
+this runner.

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -42,7 +42,8 @@ assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
 # }
 ```
 
-Files round-trip through [`LoaderFile`] with atomic `.tmp` + rename writes,
+Files round-trip through [`LoaderFile`] with atomic, writer-serialized
+`.tmp` + rename writes (concurrent writers cannot interleave),
 readonly detection, unknown top-level keys preserved, and coalesced
 deferred writes (`write_deferred`) for bursty callers:
 
@@ -60,8 +61,8 @@ entries:
 ## Feature flags
 
 - **`watch`** — debounced file watching through [`notify`](https://crates.io/crates/notify).
-  Events observed while the file is suspended (our own writes, or reloads in
-  progress) do not fire the callback.
+  Events observed while the file is suspended — by a caller-held suspend
+  guard, e.g. around the caller's own writes — do not fire the callback.
 
 ## Scope
 

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -145,18 +145,21 @@ changes. See the `dynamic` module docs for the full safety model.
   enabled entry; group children start beneath their group fiber's context,
   so disposing a group cascades. A corrupt or unreadable main file fails
   the open instead of silently starting an empty tree.
-- **reload** — re-read the file under a suspend guard and reconcile:
-  created entries start, removed subtrees stop, moved entries restart
-  under their new parent, entries whose plugin name / inject declaration /
-  enabled flag changed stop and restart with their new options, and
-  config-only changes patch in place. Generated ids are persisted
-  afterwards so the next reload matches them.
+- **reload** — re-read the file and reconcile (serialized against
+  `update_config` and `dispose`): created entries start, removed subtrees
+  stop, moved entries restart under their new parent, entries whose plugin
+  name / inject declaration / enabled flag changed stop and restart with
+  their new options, and config-only changes patch in place — a patch the
+  plugin rejects keeps the fiber on its old config and is retried by the
+  next reload. Generated ids are persisted afterwards so the next reload
+  matches them.
 - **dispose** — stop every entry, stop watching files, and release the
   loader's root-level effects (the status listener and the `loader`
   service); a fresh `Loader::open` on the same root works afterwards.
 - **self-kill** — a fiber that reaches `Disposed` outside loader operation
   was killed by its own plugin; the loader persists `disabled: true` for
-  that entry. Removing an entry from the file just stops it.
+  that entry shortly after (deferred off the dying fiber's transition
+  lock). Removing an entry from the file just stops it.
 - **inject** — an entry's `inject` list is merged with the plugin's own
   declaration (both gate startup), so services going away or coming back
   reconciles entries through the core machinery. The import graph must be

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -34,11 +34,16 @@
 //!   for free.
 //! - **Self-kill vs. removal**: a fiber that reaches `Disposed` outside
 //!   loader operation was killed by its own plugin; the loader persists
-//!   `disabled: true` for that entry. Removing an entry from the file just
-//!   stops it.
+//!   `disabled: true` for that entry shortly after, deferred off the dying
+//!   fiber's transition lock. Removing an entry from the file just stops
+//!   it.
 //! - **Write-back**: [`Loader::update_config`] is the runtime entry point —
-//!   it updates the fiber *and* persists the config. Reloads never echo
-//!   back (file-level suspend).
+//!   it updates the fiber *and* persists the config. Reloads apply their
+//!   patches without writing them back; only newly generated ids are
+//!   persisted. `reload`, `update_config`, and `dispose` serialize through
+//!   one operation lock (reentrant from event listeners), so a
+//!   watch-thread reload cannot interleave with a plugin-thread
+//!   `update_config`.
 //!
 //! # Example
 //!

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -274,9 +274,13 @@ impl Loader {
     /// entries restart under their new parent, redefined entries (plugin
     /// name, inject declaration, or enabled flag changed) stop and start
     /// with their new options, and updated entries are patched in place —
-    /// their config-only change never restarts the fiber. While the reload
-    /// runs, the file is suspended, so the patches it causes are not
-    /// written back; generated ids are persisted afterwards.
+    /// their config-only change never restarts the fiber. A patch the
+    /// plugin rejects leaves the fiber on its current config and is
+    /// retried by the next reload. Patches are never written back to the
+    /// file; only newly generated ids are persisted afterwards. The whole
+    /// reconcile runs under the loader's operation lock, serialized
+    /// against [`update_config`](Self::update_config) and
+    /// [`dispose`](Self::dispose).
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
         // Whole-reload exclusion: compose, diff, fiber transitions, and the


### PR DESCRIPTION
## Summary

Post-#40 documentation audit. While aligning docs with the fixes from #40, several **pre-existing** claims also turned out to describe mechanisms that no longer (or never) existed in the code, so this PR corrects both.

### Fixed alongside the #40 changes

- **Self-kill persistence is now deferred** (off the dying fiber's transition lock, lands shortly after `dispose()` returns) — loader crate docs and README now say so, so nobody writes a test asserting the file is rewritten the instant `dispose()` returns.
- **Reload semantics** — README/rustdoc now mention that `reload`/`update_config`/`dispose` serialize through the loader's operation lock and that a plugin-rejected patch keeps the fiber on its old config and is retried by the next reload.
- **CLI** — the daemon forwards shutdown to the worker by closing its stdin pipe (covers `kill <daemon-pid>` and even a SIGKILLed daemon; 10s grace kill); exit code `53` (boot failure) was missing from the README.
- **include** — atomic writes are now also writer-serialized (concurrent writers cannot interleave).
- **Root READMEs (en/zh)** — one sentence noting `await_ready`/`dispose_async` are synchronous pass-throughs that never yield.

### Pre-existing inaccuracies corrected

- Loader docs claimed reloads re-read the file "under a suspend guard" and "never echo back (file-level suspend)". No code path holds a suspend guard during reload (`suspend()` is only exercised by tests); patches simply are not written back, and only generated-id persistence writes (which can re-arm the watcher once for a no-op reload). The docs now describe the real mechanism.
- cordis-include's `watch` bullet attributed suspension to "our own writes, or reloads in progress" — suspension is caller-held, not automatic.
- cordis-cli's Scope section called dynamic library loading "future work" although `cordis run --plugin-dir <dir>` has shipped (fingerprint-checked, with worker-restart HMR on library changes).

Docs-only change; no code touched.

## Verification

Full gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (28 suites), `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`, and both README doctests (9 + 9, exit 0).