### PR TITLE
docs: add Chinese READMEs for the satellite crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
           --extern cordis=target/debug/libcordis.rlib
           --extern cordis_include=target/debug/libcordis_include.rlib
 
+      - name: Test cordis-include Chinese README examples
+        run: >-
+          rustdoc --test crates/cordis-include/README.zh-CN.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_include=target/debug/libcordis_include.rlib
+
       - name: Test cordis-group README examples
         run: >-
           rustdoc --test crates/cordis-group/README.md --edition 2024
@@ -108,9 +115,24 @@ jobs:
           --extern cordis=target/debug/libcordis.rlib
           --extern cordis_group=target/debug/libcordis_group.rlib
 
+      - name: Test cordis-group Chinese README examples
+        run: >-
+          rustdoc --test crates/cordis-group/README.zh-CN.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_group=target/debug/libcordis_group.rlib
+
       - name: Test cordis-loader README examples
         run: >-
           rustdoc --test crates/cordis-loader/README.md --edition 2024
+          -L dependency=target/debug/deps
+          --extern cordis=target/debug/libcordis.rlib
+          --extern cordis_include=target/debug/libcordis_include.rlib
+          --extern cordis_loader=target/debug/libcordis_loader.rlib
+
+      - name: Test cordis-loader Chinese README examples
+        run: >-
+          rustdoc --test crates/cordis-loader/README.zh-CN.md --edition 2024
           -L dependency=target/debug/deps
           --extern cordis=target/debug/libcordis.rlib
           --extern cordis_include=target/debug/libcordis_include.rlib

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Override `validate_config()` to normalize config or return `CordisError::validat
 
 ## Runtime notes
 
-The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. `Fiber::await_ready`, async event modes, async plugins, and async disposers remain available.
+The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. `Fiber::await_ready`, async event modes, async plugins, and async disposers remain available; `await_ready` and `dispose_async` are synchronous pass-throughs that never yield — awaiting them blocks the calling thread for the duration.
 
 Executor-independent futures work everywhere. If a future creates runtime-specific resources (for example `tokio::time::sleep`), call Cordis while that runtime is entered.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -305,7 +305,7 @@ impl Plugin for Worker {
 
 ## 运行时说明
 
-TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供 `Fiber::await_ready`、异步事件模式、异步插件和异步 disposer。
+TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供 `Fiber::await_ready`、异步事件模式、异步插件和异步 disposer；其中 `await_ready` 与 `dispose_async` 是同步直通实现，从不让出执行器——await 期间会阻塞调用线程直至完成。
 
 与执行器无关的 future 可以在任何环境中运行。如果 future 会创建特定运行时资源（例如 `tokio::time::sleep`），请在对应运行时已经进入的情况下调用 Cordis。
 

--- a/crates/cordis-cli/README.md
+++ b/crates/cordis-cli/README.md
@@ -13,9 +13,15 @@ cordis: worker ready (2 entries, config: cordis.yml)
 
 - **daemon / worker** — `cordis run` supervises a worker subprocess that
   boots the loader. The worker exits with code `51` to request a hot
-  restart and `52` to quit; only `51` respawns.
+  restart, `52` to quit, and `53` when the loader never booted; only `51`
+  respawns.
 - **signals** — `SIGINT` / `SIGTERM` dispose the root context gracefully
-  and exit `52`, so Ctrl+C stops the whole application cleanly.
+  and exit `52`, so Ctrl+C stops the whole application cleanly. A signal
+  that reaches only the daemon (`kill <pid>`, supervisors with per-process
+  kill modes) is forwarded: the daemon closes the worker's stdin pipe, the
+  worker tears down through the same graceful path, and one that ignores
+  it for ten seconds is killed — so the worker also exits when the daemon
+  dies for any reason.
 - **dotenv** — `.env` and `.env.local` are loaded from the working
   directory at startup (existing environment variables always win), and
   `${{ env.NAME }}` templates in the config expand from there.
@@ -33,7 +39,10 @@ handle.restart(); // full worker reload (exit 51)
 ## Scope
 
 The stock binary registers only the built-in `group` plugin; entries with
-other names are recorded in the loader's `last_error()` and skipped.
-Embedding applications register their own plugins via
+other names are recorded in the loader's `last_error()` and skipped,
+unless `--plugin-dir <dir>` (repeatable) lets them resolve from
+dynamic-library plugins fingerprint-checked against the running toolchain —
+a changed library hot-restarts the worker. Embedding applications register
+their own plugins via
 [`cordis_loader::PluginRegistry`](https://docs.rs/cordis-loader) or fork
-this runner; dynamic library loading (`dynamic` feature) is future work.
+this runner.

--- a/crates/cordis-cli/README.md
+++ b/crates/cordis-cli/README.md
@@ -1,5 +1,7 @@
 # cordis-cli
 
+**English** | [简体中文](README.zh-CN.md)
+
 Command-line runner for the [cordis-rs](https://crates.io/crates/cordis-rs)
 plugin framework: `cordis run <config.yml>`.
 

--- a/crates/cordis-cli/README.zh-CN.md
+++ b/crates/cordis-cli/README.zh-CN.md
@@ -1,0 +1,44 @@
+# cordis-cli
+
+[English](README.md) | **简体中文**
+
+[cordis-rs](https://crates.io/crates/cordis-rs) 插件框架的命令行运行器：
+`cordis run <config.yml>`。
+
+在 [cordis-loader](https://crates.io/crates/cordis-loader) 之上，为配置驱动的
+cordis 应用提供一个进程模型：
+
+```console
+$ cordis run cordis.yml
+cordis: worker ready (2 entries, config: cordis.yml)
+```
+
+- **daemon / worker** —— `cordis run` 监督一个启动 loader 的 worker 子进
+  程。worker 以退出码 `51` 请求热重启、`52` 表示退出、`53` 表示 loader
+  根本没起来；只有 `51` 会触发重新拉起。
+- **信号** —— `SIGINT` / `SIGTERM` 会优雅销毁根 context 并以 `52` 退出，
+  因此 Ctrl+C 能干净地停掉整个应用。只送达 daemon 的信号
+  （`kill <pid>`、按进程单独下杀的 supervisor）也会被转发：daemon 关闭
+  worker 的 stdin 管道，worker 走与信号相同的优雅关停路径；十秒内不退出
+  的 worker 会被强杀——因此 daemon 因任何原因死亡时 worker 都会跟着退出。
+- **dotenv** —— 启动时从工作目录加载 `.env` 和 `.env.local`（已有的环境
+  变量始终优先），配置中的 `${{ env.NAME }}` 模板由此展开。
+- **热重载** —— 条目文件被监视（防抖）；外部编辑通过 loader 的 diff
+  机制协调到 fiber。
+
+插件通过 `worker` 服务停止或重启进程：
+
+```rust,ignore
+// 在插件的 apply 内，`ctx` 为插件 context：
+let handle = ctx.require::<cordis_cli::worker::WorkerHandle>("worker")?;
+handle.restart(); // 整个 worker 重载（退出码 51）
+```
+
+## 范围
+
+原生二进制只注册内置的 `group` 插件；其他名字的条目会被记录到 loader 的
+`last_error()` 并跳过，除非通过 `--plugin-dir <dir>`（可重复）让它们从
+动态库插件解析——加载前会按运行中工具链做指纹校验，库一变更就热重启
+worker。嵌入方应用通过
+[`cordis_loader::PluginRegistry`](https://docs.rs/cordis-loader) 注册自己的
+插件，或 fork 本运行器。

--- a/crates/cordis-group/README.md
+++ b/crates/cordis-group/README.md
@@ -1,5 +1,7 @@
 # cordis-group
 
+**English** | [简体中文](README.zh-CN.md)
+
 Nested plugin groups with cascading disable for the
 [cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
 

--- a/crates/cordis-group/README.zh-CN.md
+++ b/crates/cordis-group/README.zh-CN.md
@@ -1,0 +1,50 @@
+# cordis-group
+
+[English](README.md) | **简体中文**
+
+为 [cordis-rs](https://crates.io/crates/cordis-rs) 插件框架提供带级联禁用的
+嵌套插件分组。
+
+group 是配置文件中携带 `group` 数组的条目。运行时 loader 会把每个 group
+作为一个 [`Group`] fiber 启动，并把子条目启动在**该 fiber 的 context
+之下**：销毁 group 会级联到整棵子树，而祖先链上任意位置的 `disabled`
+标志都会让整棵子树从一开始就不启动。
+
+```yaml
+entries:
+  - id: staging
+    name: group
+    disabled: true      # 级联到每个子条目
+    group:
+      - name: adapter-http
+```
+
+## 示例
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput, FiberState};
+use cordis_group::Group;
+# fn main() -> cordis::Result<()> {
+let root = cordis::Context::new();
+let group = root.plugin_default(Group::handle());
+group.try_wait()?;
+
+// 在 group 的 context 下启动的子条目会随它一起消亡。
+let group_ctx = group.context().unwrap();
+let child = group_ctx.plugin_default(plugin_sync::<(), _>(
+    "child", Inject::default(), |_, _| Ok(PluginOutput::none()),
+));
+child.try_wait()?;
+
+group.dispose()?;
+assert_eq!(child.state(), FiberState::Disposed);
+# Ok(())
+# }
+```
+
+插件本身只是一个 no-op 的嵌套标记——全部编排逻辑（遍历条目树、在正确的
+context 下启动子条目、patch 配置）都位于
+[`cordis-loader`](https://crates.io/crates/cordis-loader)，它会在自己的插件
+注册表里预注册 `group` 这个名字。
+
+[`Group`]: https://docs.rs/cordis-group/latest/cordis_group/struct.Group.html

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -1,5 +1,7 @@
 # cordis-include
 
+**English** | [简体中文](README.zh-CN.md)
+
 Config entry trees and YAML/JSON loader files for the
 [cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
 

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -42,7 +42,8 @@ assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
 # }
 ```
 
-Files round-trip through [`LoaderFile`] with atomic `.tmp` + rename writes,
+Files round-trip through [`LoaderFile`] with atomic, writer-serialized
+`.tmp` + rename writes (concurrent writers cannot interleave),
 readonly detection, unknown top-level keys preserved, and coalesced
 deferred writes (`write_deferred`) for bursty callers:
 
@@ -60,8 +61,8 @@ entries:
 ## Feature flags
 
 - **`watch`** — debounced file watching through [`notify`](https://crates.io/crates/notify).
-  Events observed while the file is suspended (our own writes, or reloads in
-  progress) do not fire the callback.
+  Events observed while the file is suspended — by a caller-held suspend
+  guard, e.g. around the caller's own writes — do not fire the callback.
 
 ## Scope
 

--- a/crates/cordis-include/README.zh-CN.md
+++ b/crates/cordis-include/README.zh-CN.md
@@ -1,0 +1,73 @@
+# cordis-include
+
+[English](README.md) | **简体中文**
+
+为 [cordis-rs](https://crates.io/crates/cordis-rs) 插件框架提供配置条目树
+与 YAML/JSON 配置文件。
+
+本 crate 是 Cordis loader 移植的数据层：它在磁盘配置文件与内存条目树之间
+做映射，为 diff 友好的文件保留对象键序，展开 `${{ env.NAME }}` 模板，并提供
+用于打断 write → watch → write 反馈回路的 suspend guard。
+
+```text
+┌─ cordis-loader   组装层：插件注册表 + fiber 状态机
+├─ cordis-group    group 插件（嵌套标记）
+├─ cordis-include  ← 本 crate：条目树 + 配置文件
+└─ cordis-rs       核心运行时（零依赖）
+```
+
+## 示例
+
+```rust
+use cordis_include::{Entry, EntryOptions, EntryTree, Node};
+# fn main() -> cordis_include::Result<()> {
+let tree = EntryTree::new();
+
+// 载入一组条目（来自文件，或手工构建）。
+let diff = tree.update(vec![
+    EntryOptions::new("group").with_id("srv").with_group(vec![
+        EntryOptions::new("adapter-http").with_config(
+            [("port".to_string(), Node::Int(8080))].into_iter().collect(),
+        ),
+    ]),
+])?;
+assert_eq!(diff.created.len(), 2);
+
+// 整树重载按 id 跨 group 匹配：既有条目对象会被复用（同一指针），
+// 调用方可以保留自己的句柄。
+let kept = tree.resolve("srv").unwrap();
+tree.update(vec![EntryOptions::new("group").with_id("srv")])?;
+assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
+# Ok(())
+# }
+```
+
+文件通过 [`LoaderFile`] 往返读写：原子且写者互斥的 `.tmp` + rename 写入
+（并发写者不会交错出撕裂内容）、只读检测、未知顶层键原样保留，以及面向
+高频调用方的合并延迟写（`write_deferred`）：
+
+```yaml
+entries:
+  - id: srv
+    name: group
+    group:
+      - name: adapter-http
+        config:
+          port: 8080
+          host: ${{ env.HOST }}
+```
+
+## Feature flags
+
+- **`watch`** — 通过 [`notify`](https://crates.io/crates/notify) 实现防抖文件
+  监视。文件处于挂起状态期间（由调用方持有的 suspend guard，例如包住调用方
+  自己的写入）观察到的事件不会触发回调。
+
+## 范围
+
+本 crate 刻意不去关心*插件从哪里来*，也从不启动或停止 fiber：
+[`cordis-loader`](https://crates.io/crates/cordis-loader) 实现这里定义的
+[`PluginResolver`] 契约并驱动生命周期。
+
+[`LoaderFile`]: https://docs.rs/cordis-include/latest/cordis_include/struct.LoaderFile.html
+[`PluginResolver`]: https://docs.rs/cordis-include/latest/cordis_include/trait.PluginResolver.html

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -145,18 +145,21 @@ changes. See the `dynamic` module docs for the full safety model.
   enabled entry; group children start beneath their group fiber's context,
   so disposing a group cascades. A corrupt or unreadable main file fails
   the open instead of silently starting an empty tree.
-- **reload** — re-read the file under a suspend guard and reconcile:
-  created entries start, removed subtrees stop, moved entries restart
-  under their new parent, entries whose plugin name / inject declaration /
-  enabled flag changed stop and restart with their new options, and
-  config-only changes patch in place. Generated ids are persisted
-  afterwards so the next reload matches them.
+- **reload** — re-read the file and reconcile (serialized against
+  `update_config` and `dispose`): created entries start, removed subtrees
+  stop, moved entries restart under their new parent, entries whose plugin
+  name / inject declaration / enabled flag changed stop and restart with
+  their new options, and config-only changes patch in place — a patch the
+  plugin rejects keeps the fiber on its old config and is retried by the
+  next reload. Generated ids are persisted afterwards so the next reload
+  matches them.
 - **dispose** — stop every entry, stop watching files, and release the
   loader's root-level effects (the status listener and the `loader`
   service); a fresh `Loader::open` on the same root works afterwards.
 - **self-kill** — a fiber that reaches `Disposed` outside loader operation
   was killed by its own plugin; the loader persists `disabled: true` for
-  that entry. Removing an entry from the file just stops it.
+  that entry shortly after (deferred off the dying fiber's transition
+  lock). Removing an entry from the file just stops it.
 - **inject** — an entry's `inject` list is merged with the plugin's own
   declaration (both gate startup), so services going away or coming back
   reconciles entries through the core machinery. The import graph must be

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -1,5 +1,7 @@
 # cordis-loader
 
+**English** | [简体中文](README.zh-CN.md)
+
 Config-file driven plugin loader for the
 [cordis-rs](https://crates.io/crates/cordis-rs) plugin framework.
 

--- a/crates/cordis-loader/README.zh-CN.md
+++ b/crates/cordis-loader/README.zh-CN.md
@@ -1,0 +1,190 @@
+# cordis-loader
+
+[English](README.md) | **简体中文**
+
+为 [cordis-rs](https://crates.io/crates/cordis-rs) 插件框架提供由配置文件
+驱动的插件加载器。
+
+本 crate 是移植上游 Cordis loader 的组装层：它把
+[cordis-include](https://crates.io/crates/cordis-include) 的条目树接到
+cordis fiber 上，并在此之上重新导出所需的一切（`cordis-include`、
+`cordis-group`），应用只需依赖本 crate 即可。
+
+```text
+┌─ cordis-loader   ← 本 crate：插件注册表 + fiber 状态机
+├─ cordis-group    group 插件（嵌套标记）
+├─ cordis-include  条目树 + 配置文件
+└─ cordis-rs       核心运行时（零依赖）
+```
+
+## 示例
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+
+# fn main() -> cordis_loader::Result<()> {
+// 按名字注册插件（上游动态 import() 的替代方案）。
+// 工厂为每个条目产出一个全新的 handle。
+let mut registry = PluginRegistry::new();
+registry.register("greeter", || {
+    plugin_sync::<Node, _>(
+        "greeter",
+        Inject::default(),
+        |_ctx, config| {
+            let port = config["port"].as_i64().unwrap_or(80);
+            println!("greeter on port {port}");
+            Ok(PluginOutput::none())
+        },
+    )
+});
+
+let path = std::env::temp_dir().join(format!("cordis-loader-readme-{}.yml", std::process::id()));
+let initial = Document::with_entries(vec![
+    EntryOptions::new("greeter")
+        .with_id("greet")
+        .with_config([("port".to_string(), Node::Int(8080))].into_iter().collect()),
+]);
+
+let root = cordis::Context::new();
+let loader = Loader::open(
+    &root,
+    LoaderConfig::new(&path).with_registry(registry).with_initial(initial),
+)?;
+
+let entry = loader.tree().resolve("greet").unwrap();
+entry.fiber().unwrap().try_wait()?;      // 从文件启动
+loader.update_config("greet", [("port".to_string(), Node::Int(9090))].into_iter().collect())?;
+entry.fiber().unwrap().try_wait()?;      // 以新配置重启
+
+loader.dispose()?;
+let _ = std::fs::remove_file(&path);
+# Ok(())
+# }
+```
+
+## Imports（子文件挂载）
+
+一个 `name: import`、`config: { url: "…" }` 的条目会把另一个配置文件挂载
+为自己的子树——同一套 diff 机制、同样的 id 复用：
+
+```yaml
+# main.yml
+entries:
+  - id: extra
+    name: import
+    config:
+      url: extra.yml
+```
+
+```yaml
+# extra.yml —— 这些条目成为 `extra` 的子条目
+entries:
+  - id: adapter
+    name: adapter-http
+```
+
+重载时所有相关文件会被组合成一次整树 diff；写回时挂载的条目总是路由回
+它们来源的文件（包括生成的 id）。import 环会被记录到 `last_error()` 并
+跳过。
+
+## 动态库插件
+
+启用 `dynamic` feature 后，条目还可以解析为编译成 `cdylib` 库的插件——
+Rust 没有稳定 ABI，因此加载前会做严格的构建指纹校验（cordis-rs 版本、
+精确到 commit hash 的 rustc 版本、目标三元组、panic 策略）：凡不是由
+加载进程自己的工具链构建的库都会被拒绝，而不是引发未定义行为。
+
+插件侧：一个 `crate-type = ["cdylib"]`、带 `dynamic` feature 依赖
+`cordis-loader` 的 crate 实现 `Plugin`，并以导出宏结尾（文件名决定插件
+名）：
+
+```rust,ignore
+// greeter-plugin/src/lib.rs —— 构建产物为 libgreeter.so /
+// libgreeter.dylib / greeter.dll
+use cordis_loader::dynamic::{BoxFuture, Config, Context, Plugin, PluginOutput, Result};
+
+pub struct Greeter;
+
+impl Plugin for Greeter {
+    fn name(&self) -> &str { "greeter" }
+
+    fn apply(&self, _ctx: Context, _config: Config) -> BoxFuture<Result<PluginOutput>> {
+        Box::pin(async { Ok(PluginOutput::none()) })
+    }
+}
+
+cordis_loader::dynamic::export_plugin!(Greeter);
+```
+
+加载侧：把目录挂到注册表上；静态注册表中找不到的名字会从该目录下的
+`lib<name>.so`（macOS 为 `.dylib`，Windows 为 `<name>.dll`）解析：
+
+```rust
+# use cordis_loader::PluginRegistry;
+let registry = PluginRegistry::new().with_dynamic_dirs(["/usr/lib/cordis-plugins"]);
+# assert!(registry.names().any(|name| name == "group"));
+```
+
+每次解析都会让库产出一个挂在全新 handle 上的全新插件实例。panic 会被
+限制在插件侧——`cdylib` 链接了自己的 std，导出宏给每个回调都包了一层
+守卫，在 panic 越过边界之前把它转成错误和兜底值。库在一个进程内绝不
+卸载，替换库文件需要全新进程——这正是 `cordis-cli` 用
+`cordis run --plugin-dir <dir>` 驱动的 HMR 流程：它监视这些目录，库一
+变更就让 worker 热重启（退出码 51）。完整安全模型见 `dynamic` 模块文档。
+
+## 状态机做了什么
+
+- **open** —— 读取（或创建）条目文件，构建条目树，启动每个启用的条目；
+  group 的子条目启动在其 group fiber 的 context 之下，因此销毁 group 会
+  级联。主文件损坏或不可读会让 open 失败，而不是悄悄启动一棵空树。
+- **reload** —— 重新读取文件并协调（与 `update_config`、`dispose` 互斥
+  串行）：新建条目启动，移除的子树停止，移动的条目在新父节点下重启，
+  插件名 / inject 声明 / 启用标志变化的条目以新选项停止再启动，纯配置
+  变化原地 patch——被插件拒绝的 patch 会让 fiber 保留旧配置，并在下一
+  次 reload 时重试。之后会持久化新生成的 id，让下一次 reload 能匹配
+  它们。
+- **dispose** —— 停止每个条目，停止文件监视，并释放 loader 的根级
+  effect（状态监听器和 `loader` 服务）；之后在同一 root 上重新
+  `Loader::open` 依然可用。
+- **self-kill（自杀）** —— 在 loader 操作之外到达 `Disposed` 的 fiber
+  是被它自己的插件杀掉的；loader 会在稍后为该条目持久化
+  `disabled: true`（持久化被推迟到垂死 fiber 的 transition 锁之外）。
+  从文件中删除条目则只是停止它。
+- **inject** —— 条目的 `inject` 列表会与插件自己的声明合并（两者共同
+  把关启动），因此服务的增删会通过核心机制协调条目。import 图必须是
+  树：环与重复挂载同一文件会以不同的诊断记录到 `last_error()`。
+- **update_config** —— 运行时修改配置的入口：更新 fiber 并持久化到
+  文件。
+
+## 事件与写合并
+
+loader 会在根 context 的事件总线上发出 `loader/entry-init`、
+`loader/before-patch`、`loader/after-patch`、`loader/partial-dispose` 和
+`loader/config-update`——每个监听器都会收到受影响的条目，
+`config-update` 还会收到新配置节点。写防抖会合并高频写回：
+
+```rust
+# use cordis_loader::{Loader, LoaderConfig};
+# use std::time::Duration;
+# let root = cordis::Context::new();
+# let config = LoaderConfig::new("cordis.yml").with_write_debounce(Duration::from_millis(300));
+let loader = Loader::open(&root, config)?;
+// 如今 loader.update_config(...) 的调用会在 300ms 的静默后
+// 合并成一次磁盘写入；loader.file().flush_deferred() 可以等它落地。
+# Ok::<(), cordis_loader::LoaderError>(())
+```
+
+## Feature flags
+
+- **`watch`** —— 热重载：把 `LoaderFile` 的防抖监视器接到
+  [`Loader::reload`] 上。重载错误记录在 `last_error()`。
+- **`dynamic`** —— 从动态库插件解析条目（`libloading`）：通过
+  `PluginRegistry::with_dynamic_dirs` 做指纹校验加载，为插件 crate 提供
+  `export_plugin!` 宏，并在插件侧限制 panic。
+
+[`cordis-cli`](https://crates.io/crates/cordis-cli) 运行器在本 crate 之上
+构建了 `cordis run` 命令。
+
+[`Loader::reload`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.reload

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -34,11 +34,16 @@
 //!   for free.
 //! - **Self-kill vs. removal**: a fiber that reaches `Disposed` outside
 //!   loader operation was killed by its own plugin; the loader persists
-//!   `disabled: true` for that entry. Removing an entry from the file just
-//!   stops it.
+//!   `disabled: true` for that entry shortly after, deferred off the dying
+//!   fiber's transition lock. Removing an entry from the file just stops
+//!   it.
 //! - **Write-back**: [`Loader::update_config`] is the runtime entry point —
-//!   it updates the fiber *and* persists the config. Reloads never echo
-//!   back (file-level suspend).
+//!   it updates the fiber *and* persists the config. Reloads apply their
+//!   patches without writing them back; only newly generated ids are
+//!   persisted. `reload`, `update_config`, and `dispose` serialize through
+//!   one operation lock (reentrant from event listeners), so a
+//!   watch-thread reload cannot interleave with a plugin-thread
+//!   `update_config`.
 //!
 //! # Example
 //!

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -274,9 +274,13 @@ impl Loader {
     /// entries restart under their new parent, redefined entries (plugin
     /// name, inject declaration, or enabled flag changed) stop and start
     /// with their new options, and updated entries are patched in place —
-    /// their config-only change never restarts the fiber. While the reload
-    /// runs, the file is suspended, so the patches it causes are not
-    /// written back; generated ids are persisted afterwards.
+    /// their config-only change never restarts the fiber. A patch the
+    /// plugin rejects leaves the fiber on its current config and is
+    /// retried by the next reload. Patches are never written back to the
+    /// file; only newly generated ids are persisted afterwards. The whole
+    /// reconcile runs under the loader's operation lock, serialized
+    /// against [`update_config`](Self::update_config) and
+    /// [`dispose`](Self::dispose).
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
         // Whole-reload exclusion: compose, diff, fiber transitions, and the


### PR DESCRIPTION
## Summary

The four satellite crates (cordis-group, cordis-include, cordis-loader, cordis-cli) had English-only READMEs while the repo root ships bilingual ones. This PR gives each crate a `README.zh-CN.md`, following the root README's bilingual convention:

- language-switcher header in both directions (`**English** | [简体中文](README.zh-CN.md)` and back);
- translated prose **and** code comments (the established root-README style), with compiled examples kept byte-equivalent to the English ones modulo comments;
- terminology aligned with the root Chinese README's existing glossary (条目树 / 注册表 / 写回 / 热重载 / 防抖 / 级联禁用 …);
- content reflects the corrected behaviors from #42 (writer-serialized atomic writes, caller-held suspend guards, serialized loader transitions + patch retry, deferred self-kill persistence, daemon shutdown forwarding, exit code 53, `--plugin-dir`).

The include/group/loader Chinese READMEs carry the same doctested examples as the English ones, so their doctests are wired into CI alongside the English steps (the cli READMEs have no compiled examples). The local gate in AGENTS.md was also already stale — it listed only the two root READMEs while CI tests the crate READMEs too; updated to match CI.

**Stacked on #42** (translations build on its corrected English text) — merge that first.

## Verification

All 10 README doctests run and pass locally with the pinned 1.85 toolchain (root en/zh 9+9; include en/zh 1+1; group en/zh 1+1; loader en/zh 3+3 + 1 `ignore`d block each), plus the usual gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (28 suites), `cargo doc -D warnings`. CI YAML validated.