### PR TITLE
Address P3 review findings (REV-20260818-12..15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    # Weekly, Monday 03:00 UTC: catch advisories published between releases.
+    - cron: "0 3 * * 1"
 
 permissions:
   contents: read
@@ -33,6 +36,22 @@ jobs:
 
       - name: Run tests
         run: cargo test --locked --workspace --all-features
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies for RUSTSEC advisories
+        run: cargo audit --deny warnings
 
   test:
     name: Test stable (${{ matrix.os }})

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,8 @@ test-only nit).
 - `EventsService::clear()` is global but hangs off a per-context service: any
   context can wipe every hook in the root, bypassing fiber ownership. Either
   remove it, mark it `#[doc(hidden)]`, or scope it to the calling fiber's
-  hooks.
+  hooks. Its global scope and the registration race are now documented on the
+  method (2026-08-18, REV-15); the API design question itself stays open.
 - `CordisError::context` prepends context to the message, the opposite of
   `anyhow::Context` (attach a source). The name misleads Rust users; a rename
   such as `prefixed_with` would be honest but is a breaking change.

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -588,8 +588,16 @@ impl EventsService {
         }))
     }
 
-    /// Remove every event hook. Primarily useful for diagnostics/tests; normal
-    /// cleanup should dispose the owning fiber.
+    /// Remove every event hook across the whole root.
+    ///
+    /// The removal is global: hooks live on the root's shared events state,
+    /// so calling this from any context — including a child — drops listeners
+    /// owned by every fiber, bypassing fiber ownership entirely. It races with
+    /// concurrent listener registration: a hook inserted while the clear runs
+    /// may or may not be removed, and either way its `EffectHandle` stays
+    /// registered on the owning fiber — harmless, because the disposer's
+    /// `remove` of an already-cleared hook is a no-op. Positioned for
+    /// diagnostics and tests; normal cleanup should dispose the owning fiber.
     pub fn clear(&self) {
         lock(&self.ctx.root.events.state).hooks.clear();
     }

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -373,7 +373,11 @@ impl EventsService {
 
     fn dispatch(&self, mode: DispatchMode, event: &Event) -> Vec<Callback> {
         // Upstream gates this meta-event on listener presence; skip the
-        // argument construction entirely when nobody listens.
+        // argument construction entirely when nobody listens. The meta-event
+        // itself is always emitted — never dispatched through the observed
+        // mode — so meta-listeners cannot short-circuit each other, and its
+        // errors are dropped so observation cannot fail the dispatch.
+        // `internal/` names are exempt to keep meta-listeners from recursing.
         if !event.name().starts_with("internal/") && self.listener_count("internal/dispatch") > 0 {
             let _ = self.emit(
                 "internal/dispatch",
@@ -426,6 +430,17 @@ impl EventsService {
     }
 
     /// Emit synchronously, returning the first listener error.
+    ///
+    /// Like every dispatch mode, this first fires the `internal/dispatch`
+    /// meta-event with `(mode, name, args)` when anyone listens. Meta-listeners
+    /// always run with `emit` semantics — synchronously, one after another,
+    /// none skipped, none able to short-circuit the rest — regardless of the
+    /// mode being observed: the mode reaches them as data only, and errors
+    /// they return are discarded. That is deliberate — an observer must not
+    /// change what it observes; routing by mode would let one meta-listener's
+    /// bail mute the others or a meta-listener failure fail the observed
+    /// dispatch. Events whose name starts with `internal/` fire no
+    /// meta-event, so meta-listeners cannot recurse.
     pub fn emit(
         &self,
         name: impl Into<String>,
@@ -452,6 +467,9 @@ impl EventsService {
     }
 
     /// Run all listeners concurrently and aggregate failures.
+    ///
+    /// `internal/dispatch` meta-listeners for this event still run with
+    /// [`emit`](Self::emit) semantics; see there.
     pub async fn parallel(
         &self,
         name: impl Into<String>,
@@ -487,6 +505,9 @@ impl EventsService {
     }
 
     /// Run listeners in order, awaiting each, until one bails.
+    ///
+    /// `internal/dispatch` meta-listeners for this event still run with
+    /// [`emit`](Self::emit) semantics; see there.
     pub async fn serial(
         &self,
         name: impl Into<String>,
@@ -503,6 +524,9 @@ impl EventsService {
     }
 
     /// Synchronous ordered bail dispatch.
+    ///
+    /// `internal/dispatch` meta-listeners for this event still run with
+    /// [`emit`](Self::emit) semantics; see there.
     pub fn bail(
         &self,
         name: impl Into<String>,
@@ -519,6 +543,9 @@ impl EventsService {
     }
 
     /// Compose listeners around an innermost asynchronous callback.
+    ///
+    /// `internal/dispatch` meta-listeners for this event still run with
+    /// [`emit`](Self::emit) semantics; see there.
     pub async fn waterfall_async<F, Fut>(
         &self,
         name: impl Into<String>,

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -652,14 +652,39 @@ impl Fiber {
     /// there is nothing to wait for: the method polls the current state and
     /// never suspends. `Ok` is returned only when `Active`; a startup failure
     /// is rethrown; `Pending` (dependencies missing), in-flight, and
-    /// `Disposed` fibers yield an error rather than a false success. Safe to
-    /// call from lifecycle callbacks.
+    /// `Disposed` fibers yield an error rather than a false success. A
+    /// `Pending` plugin fiber names the injected services that have not
+    /// resolved yet in its error, when the probe can run. Safe to call from
+    /// lifecycle callbacks.
     pub fn try_wait(&self) -> Result<Fiber> {
         match self.state() {
             FiberState::Active => Ok(self.clone()),
             FiberState::Failed => Err(self
                 .error()
                 .unwrap_or_else(|| CordisError::new(ErrorCode::Plugin))),
+            FiberState::Pending => {
+                // Root fibers have an empty inject and every Context dropped
+                // leaves no root to probe; both fall back to the plain message.
+                // The probe holds the reflect state lock only briefly — the
+                // same one reconcile's dependency_epoch takes — so this stays
+                // callable from lifecycle callbacks.
+                let missing = match (self.inner.plugin.is_some(), self.inner.root.upgrade()) {
+                    (true, Some(root)) => match self.context() {
+                        Some(ctx) => root.missing_dependencies(&ctx, &self.inner.inject),
+                        None => Vec::new(),
+                    },
+                    _ => Vec::new(),
+                };
+                let message = if missing.is_empty() {
+                    "fiber is not ready (state: Pending)".to_owned()
+                } else {
+                    format!(
+                        "fiber is not ready (state: Pending; missing services: {})",
+                        missing.join(", ")
+                    )
+                };
+                Err(CordisError::with_message(ErrorCode::Other, message))
+            }
             state => Err(CordisError::with_message(
                 ErrorCode::Other,
                 format!("fiber is not ready (state: {state:?})"),

--- a/crates/cordis/src/reflect.rs
+++ b/crates/cordis/src/reflect.rs
@@ -589,6 +589,22 @@ impl RootInner {
         Some(epoch)
     }
 
+    /// Names from `inject` that currently resolve to nothing, in declaration
+    /// order. The per-name probe is [`dependency_epoch`](Self::dependency_epoch)
+    /// without the early `?` exit, so it only ever holds the reflect state lock
+    /// briefly and is safe wherever that function is.
+    pub(crate) fn missing_dependencies(&self, ctx: &Context, inject: &Inject) -> Vec<String> {
+        inject
+            .iter()
+            .filter(|dependency| {
+                self.reflect
+                    .implementation_epoch(ctx, &dependency.name)
+                    .is_none()
+            })
+            .map(|dependency| dependency.name.clone())
+            .collect()
+    }
+
     pub(crate) fn notify_service(&self, name: &str, scope: Isolation) -> Vec<Fiber> {
         let mut refreshed = Vec::new();
         for fiber in self.registry.fibers_injecting(name) {

--- a/crates/cordis/tests/lifecycle.rs
+++ b/crates/cordis/tests/lifecycle.rs
@@ -526,6 +526,46 @@ fn wait_reports_pending_as_not_ready() -> Result<()> {
     Ok(())
 }
 
+/// A Pending fiber's try_wait() error names the injected services that have
+/// not resolved yet, and stops failing once they arrive.
+#[test]
+fn pending_try_wait_names_missing_services() -> Result<()> {
+    let root = Context::new();
+    let fiber = root.plugin_default(plugin_sync::<(), _>(
+        "needy",
+        Inject::new(["missing-svc"]),
+        |_, _| Ok(PluginOutput::default()),
+    ));
+    assert_eq!(fiber.state(), FiberState::Pending);
+    let error = fiber.try_wait().unwrap_err().to_string();
+    assert_eq!(
+        error,
+        "fiber is not ready (state: Pending; missing services: missing-svc)"
+    );
+
+    let _service = root.provide("missing-svc", 7_u32)?;
+    fiber.try_wait()?;
+    Ok(())
+}
+
+/// With some dependencies already provided, the try_wait() error lists only
+/// the still-unresolved names.
+#[test]
+fn pending_try_wait_lists_only_unresolved_services() -> Result<()> {
+    let root = Context::new();
+    let fiber = root.plugin_default(plugin_sync::<(), _>(
+        "partly",
+        Inject::new(["present-svc", "absent-svc"]),
+        |_, _| Ok(PluginOutput::default()),
+    ));
+    let _present = root.provide("present-svc", 1_u32)?;
+    assert_eq!(fiber.state(), FiberState::Pending);
+    let error = fiber.try_wait().unwrap_err().to_string();
+    assert!(error.contains("absent-svc"), "error was: {error}");
+    assert!(!error.contains("present-svc"), "error was: {error}");
+    Ok(())
+}
+
 /// Regression: restart() on the root fiber disposed every root-owned effect
 /// (including all top-level plugin parent effects) and left the root stuck in
 /// Pending while reporting success. It must fail without side effects.


### PR DESCRIPTION
Four P3 findings from the 2026-08-18 review, one commit each.

| Finding | Verdict | Handling |
|---|---|---|
| REV-20260818-12 | Confirmed | **Fixed** — Pending `try_wait` errors name the missing services |
| REV-20260818-14 | Confirmed | **Fixed** — CI gains a cargo audit job |
| REV-20260818-13 | Mechanism real, impact minimal | **Docs only**, no semantic change |
| REV-20260818-15 | Not a bug (window has no observable effect) | **Docs only** for `clear()` |

## REV-12 — name missing services in Pending `try_wait` errors

`Fiber::try_wait()` on a dependency-starved fiber used to report only `fiber is not ready (state: Pending)`. It now probes each injected service and reports `fiber is not ready (state: Pending; missing services: a, b)` via a new `RootInner::missing_dependencies` helper — the same per-name probe `dependency_epoch` does, without the early exit. The probe takes the reflect state lock only briefly and follows the existing transition → reflect order, so `try_wait` stays safe to call from lifecycle callbacks. Root fibers, roots whose contexts have all dropped, and Pending fibers whose dependencies all resolve keep the plain message; the error code stays `ErrorCode::Other`.

## REV-14 — cargo audit in CI

New `audit` job in `ci.yml`: prebuilt `cargo-audit` from `taiki-e/install-action@v2` (no compile time, no new repository dependencies), running `cargo audit --deny warnings` on push/PR plus a weekly Monday 03:00 UTC schedule so advisories published between releases surface on their own.

## REV-13 — `internal/dispatch` meta-event semantics (docs only)

`internal/dispatch` listeners always execute with `emit` semantics — synchronous, sequential, none skipped, errors discarded — regardless of whether the observed dispatch is parallel/serial/bail/waterfall; the mode reaches them as data only. Documented on `emit` with cross-references from the other four dispatch entry points and the rationale in `dispatch()`. Deliberately not routed by mode: that would let one meta-listener's bail mute the others or a meta-listener failure fail the observed dispatch — an observer must not change what it observes. `internal/` names fire no meta-event, so no recursion.

## REV-15 — `EventsService::clear()` docs

Documented on the method: the removal is root-global (any context drops every fiber's hooks, bypassing fiber ownership), it races concurrent registration (a hook inserted in the window may or may not be cleared; its `EffectHandle` stays registered on the owning fiber, whose disposer removing an already-cleared hook is a harmless no-op), and it is positioned for diagnostics/tests. The TODO.md entry is annotated as documented (2026-08-18); the API design question (remove / `#[doc(hidden)]` / fiber-scoped) stays open.