### PR TITLE
refactor!: remove EventsService::clear(), rename CordisError::context to prefixed_with

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,13 @@ test-only nit).
 
 ## API design
 
-- `EventsService::clear()` is global but hangs off a per-context service: any
+- ~~`EventsService::clear()` is global but hangs off a per-context service: any
   context can wipe every hook in the root, bypassing fiber ownership. Either
   remove it, mark it `#[doc(hidden)]`, or scope it to the calling fiber's
-  hooks. Its global scope and the registration race are now documented on the
-  method (2026-08-18, REV-15); the API design question itself stays open.
+  hooks.~~ Resolved 2026-08-18: removed outright. It was a port addition with
+  no upstream counterpart (vendored cordis 4.x has no `clear`), zero callers,
+  and zero external dependents; test isolation already uses one `Context` per
+  test. If a real need appears, re-add with fiber-scoped semantics.
 - `CordisError::context` prepends context to the message, the opposite of
   `anyhow::Context` (attach a source). The name misleads Rust users; a rename
   such as `prefixed_with` would be honest but is a breaking change.

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,11 @@ test-only nit).
   no upstream counterpart (vendored cordis 4.x has no `clear`), zero callers,
   and zero external dependents; test isolation already uses one `Context` per
   test. If a real need appears, re-add with fiber-scoped semantics.
-- `CordisError::context` prepends context to the message, the opposite of
+- ~~`CordisError::context` prepends context to the message, the opposite of
   `anyhow::Context` (attach a source). The name misleads Rust users; a rename
-  such as `prefixed_with` would be honest but is a breaking change.
+  such as `prefixed_with` would be honest but is a breaking change.~~
+  Resolved 2026-08-18: renamed to `prefixed_with` (also not an upstream API).
+  `caused_by`/`with_source` cover the attach-a-source use case.
 - ~~`Fiber::await_ready` and `Fiber::dispose_async` are transparent
   pass-throughs to their synchronous versions. They exist for upstream
   signature parity but imply cancellable/async semantics that do not exist.~~

--- a/crates/cordis/src/error.rs
+++ b/crates/cordis/src/error.rs
@@ -172,8 +172,12 @@ impl CordisError {
         self.validation.as_ref()
     }
 
-    /// Attach context to an existing error while preserving its code.
-    pub fn context(mut self, context: impl AsRef<str>) -> Self {
+    /// Prepend context to the message while preserving the code.
+    ///
+    /// Named for what it does: the text lands *in front of* the existing
+    /// message (`"{context}: {message}"`). It is not anyhow's `Context` —
+    /// attaching an underlying cause is [`caused_by`](Self::caused_by).
+    pub fn prefixed_with(mut self, context: impl AsRef<str>) -> Self {
         self.message = format!("{}: {}", context.as_ref(), self.message);
         self
     }
@@ -247,6 +251,27 @@ mod tests {
         let attached = CordisError::new(ErrorCode::Event).caused_by(std::io::Error::other("inner"));
         assert_eq!(
             Error::source(&attached).map(ToString::to_string).as_deref(),
+            Some("inner")
+        );
+    }
+
+    #[test]
+    fn prefixed_with_prepends_and_preserves_code() {
+        let error = CordisError::with_message(ErrorCode::Plugin, "plugin failed")
+            .prefixed_with("loading entry")
+            .prefixed_with("entry main");
+        assert_eq!(
+            error.to_string(),
+            "entry main: loading entry: plugin failed"
+        );
+        assert_eq!(error.code(), ErrorCode::Plugin);
+
+        let chained = CordisError::new(ErrorCode::Event)
+            .prefixed_with("emit")
+            .caused_by(std::io::Error::other("inner"));
+        assert_eq!(chained.to_string(), "emit: event listener failed");
+        assert_eq!(
+            Error::source(&chained).map(ToString::to_string).as_deref(),
             Some("inner")
         );
     }

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -587,18 +587,4 @@ impl EventsService {
             async move { result }
         }))
     }
-
-    /// Remove every event hook across the whole root.
-    ///
-    /// The removal is global: hooks live on the root's shared events state,
-    /// so calling this from any context — including a child — drops listeners
-    /// owned by every fiber, bypassing fiber ownership entirely. It races with
-    /// concurrent listener registration: a hook inserted while the clear runs
-    /// may or may not be removed, and either way its `EffectHandle` stays
-    /// registered on the owning fiber — harmless, because the disposer's
-    /// `remove` of an already-cleared hook is a no-op. Positioned for
-    /// diagnostics and tests; normal cleanup should dispose the owning fiber.
-    pub fn clear(&self) {
-        lock(&self.ctx.root.events.state).hooks.clear();
-    }
 }


### PR DESCRIPTION
Closes out the last two open TODO items — both APIs were port additions with no upstream counterpart, zero callers, and zero external dependents (verified against vendored cordis 4.x and crates.io reverse deps), so the cheapest-correct move was acting now while the user base is empty. Targets 0.5.0.

## `EventsService::clear()` — removed

Global hook wipe from any context, bypassing fiber ownership, racing concurrent registration. Upstream has no `clear()` (cleanup goes through fiber disposal, which already removes exactly the owned hooks); in-repo tests isolate with one `Context` per test. `#[doc(hidden)]` would have preserved an untested method for nobody; fiber-scoping is new feature work with no demand behind it. Re-add deliberately if a real need appears.

## `CordisError::context` → `prefixed_with`

The old name prepended text to the message — the opposite reading of `anyhow::Context`, and colliding with the crate's own `Fiber::context()`/`Group::context()` that return the runtime `Context`. `prefixed_with` names the behavior and matches the `with_message`/`with_source`/`caused_by` family; source attachment remains `caused_by`. New unit test covers prefixing, code preservation, and chaining.

Both commits are `refactor!` so release-plz derives 0.5.0. Full gate green locally: fmt, clippy `-D warnings`, 28 test suites, `cargo doc -D warnings`, 10 README doctests.