### PR TITLE
test: cover service module, disposer errors, serial and sync waterfall

### DIFF
--- a/crates/cordis/tests/dispose.rs
+++ b/crates/cordis/tests/dispose.rs
@@ -1,0 +1,80 @@
+use cordis::{
+    Context, CordisError, EffectMeta, ErrorCode, Inject, LoggerType, PluginOutput, Result,
+    plugin_sync,
+};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Upstream parity (dispose.spec 'dispose by plugin' + fiber.spec 'dispose
+/// error'): a disposer that fails must not break teardown — the fiber still
+/// disposes, every other disposer still runs in reverse registration order,
+/// and the failure is routed to the logger instead of propagating.
+#[test]
+fn failing_disposer_is_isolated_and_teardown_completes() -> Result<()> {
+    let root = Context::new();
+    let order = Arc::new(Mutex::new(Vec::new()));
+    let recorded = order.clone();
+    let plugin = plugin_sync::<(), _>("failing", Inject::none(), move |ctx, _| {
+        ctx.effect("boom", || {
+            Err(CordisError::with_message(ErrorCode::Other, "boom"))
+        })?;
+        for value in 1..=3 {
+            let recorded = recorded.clone();
+            ctx.effect_infallible(format!("effect {value}"), move || {
+                recorded.lock().unwrap().push(value);
+            })?;
+        }
+        Ok(PluginOutput::none())
+    });
+
+    let fiber = root.plugin_default(plugin);
+    fiber.try_wait()?;
+    fiber.dispose()?;
+
+    // The failing disposer registered first, so LIFO teardown runs 3, 2, 1,
+    // then the failing one — which must not prevent the others from running.
+    assert_eq!(*order.lock().unwrap(), vec![3, 2, 1]);
+
+    // The failure reached the logger rather than being silently swallowed.
+    let buffer = root.logger_service().buffer();
+    assert!(
+        buffer
+            .iter()
+            .any(|message| message.kind == LoggerType::Error)
+    );
+    Ok(())
+}
+
+/// Upstream parity (dispose.spec 'yield dispose'): adopted effects appear as
+/// a nested diagnostic tree on the owning fiber, are disposed together with
+/// their parent, and double disposal is a no-op.
+#[test]
+fn adopted_effects_form_a_diagnostic_tree() -> Result<()> {
+    let root = Context::new();
+    let inner_calls = Arc::new(AtomicUsize::new(0));
+
+    let outer = root.effect_infallible("outer", || {})?;
+    let inner = root.effect_infallible("inner", {
+        let inner_calls = inner_calls.clone();
+        move || {
+            inner_calls.fetch_add(1, Ordering::SeqCst);
+        }
+    })?;
+    assert_eq!(root.fiber()?.effects().len(), 2);
+
+    outer.adopt(inner)?;
+    assert_eq!(
+        root.fiber()?.effects(),
+        vec![EffectMeta {
+            label: "outer".to_owned(),
+            children: vec![EffectMeta::new("inner")],
+        }]
+    );
+
+    outer.dispose()?;
+    assert_eq!(inner_calls.load(Ordering::SeqCst), 1);
+    outer.dispose()?;
+    assert_eq!(inner_calls.load(Ordering::SeqCst), 1);
+    Ok(())
+}

--- a/crates/cordis/tests/events.rs
+++ b/crates/cordis/tests/events.rs
@@ -217,3 +217,76 @@ fn once_survives_earlier_bail() -> Result<()> {
     assert_eq!(root.events().listener_count("stop"), 0);
     Ok(())
 }
+
+/// Upstream parity (events.spec 'ctx.serial()'): serial dispatch awaits each
+/// listener in registration order and stops at the first bail value, so
+/// listeners after the bail never run.
+#[test]
+fn serial_awaits_listeners_in_order_until_bail() -> Result<()> {
+    let root = Context::new();
+    let order = Arc::new(Mutex::new(Vec::new()));
+    for value in 1..=2 {
+        let order = order.clone();
+        root.on_async("probe", move |_| {
+            let order = order.clone();
+            async move {
+                order.lock().unwrap().push(value);
+                Ok(None)
+            }
+        })?;
+    }
+    let bailing = order.clone();
+    root.on_async("probe", move |_| {
+        let bailing = bailing.clone();
+        async move {
+            bailing.lock().unwrap().push(3);
+            Ok(Some(Value::new(42_u32)))
+        }
+    })?;
+    let skipped = order.clone();
+    root.on_async("probe", move |_| {
+        let skipped = skipped.clone();
+        async move {
+            skipped.lock().unwrap().push(4);
+            Ok(None)
+        }
+    })?;
+
+    let result = block_on(root.serial("probe", []))?
+        .unwrap()
+        .downcast::<u32>()?;
+    assert_eq!(*result, 42);
+    assert_eq!(*order.lock().unwrap(), vec![1, 2, 3]);
+    Ok(())
+}
+
+/// Upstream parity (events.spec 'ctx.waterfall()'): the synchronous waterfall
+/// convenience wrapper composes listeners around an innermost synchronous
+/// callback, matching the async variant's next() chaining.
+#[test]
+fn sync_waterfall_composes_listeners_around_sync_inner() -> Result<()> {
+    let root = Context::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    for _ in 0..2 {
+        let calls = calls.clone();
+        root.on_async("pipeline", move |event| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let value = *event.arg::<u32>(0)?.unwrap();
+                let next = event.next().await?.unwrap().downcast::<u32>()?;
+                Ok(Some(Value::new(value + *next)))
+            }
+        })?;
+    }
+
+    let result = root
+        .waterfall("pipeline", [Value::new(1_u32)], || {
+            Ok(Some(Value::new(2_u32)))
+        })?
+        .unwrap()
+        .downcast::<u32>()?;
+    assert_eq!(*result, 4);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    Ok(())
+}

--- a/crates/cordis/tests/reflect_logger.rs
+++ b/crates/cordis/tests/reflect_logger.rs
@@ -1,6 +1,6 @@
 use cordis::{
-    Accessor, Context, ExporterConfig, LogArg, LoggerIntercept, LoggerLevel, Result, Value,
-    default_format,
+    Accessor, Context, ExporterConfig, Inject, LogArg, LoggerIntercept, LoggerLevel, PluginOutput,
+    Result, Value, default_format, plugin_sync,
 };
 use std::sync::{Arc, Mutex};
 
@@ -70,5 +70,49 @@ fn logger_buffers_exports_formats_and_intercepts() -> Result<()> {
     exporter.dispose()?;
     root.logger().info("not exported", []);
     assert_eq!(captured.lock().unwrap().len(), 4);
+    Ok(())
+}
+
+/// Upstream parity (logger.spec name resolution): an explicit name wins over
+/// the intercept name, which wins over the fiber-derived name, which falls
+/// back to "root".
+#[test]
+fn logger_name_resolution_precedence_chain() -> Result<()> {
+    let root = Context::new();
+
+    // Outside any plugin the fiber-derived name falls back to "root".
+    assert_eq!(root.logger().name, "root");
+    // An explicit name beats everything.
+    assert_eq!(root.named_logger("explicit").name, "explicit");
+
+    // An intercept name beats the fiber-derived name...
+    let intercepted = root.intercept(
+        "logger",
+        LoggerIntercept {
+            name: Some("intercepted".to_owned()),
+            level: None,
+        },
+    );
+    assert_eq!(intercepted.logger().name, "intercepted");
+    // ...but an explicit name still beats the intercept.
+    assert_eq!(intercepted.named_logger("explicit").name, "explicit");
+
+    // Inside a named plugin the default logger uses the hyphenated fiber
+    // name, and the intercept wins there too when present.
+    let names = Arc::new(Mutex::new(Vec::new()));
+    let plugin = plugin_sync::<(), _>("MyDriver", Inject::none(), {
+        let names = names.clone();
+        move |ctx, _| {
+            names.lock().unwrap().push(ctx.logger().name.clone());
+            names
+                .lock()
+                .unwrap()
+                .push(ctx.named_logger("mine").name.clone());
+            Ok(PluginOutput::none())
+        }
+    });
+    let fiber = intercepted.plugin_default(plugin);
+    fiber.try_wait()?;
+    assert_eq!(*names.lock().unwrap(), vec!["intercepted", "mine"]);
     Ok(())
 }

--- a/crates/cordis/tests/service.rs
+++ b/crates/cordis/tests/service.rs
@@ -1,0 +1,148 @@
+use cordis::{
+    Context, FiberState, Inject, PluginOutput, Result, Service, plugin_sync, service_async,
+    service_sync,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+struct Counter {
+    value: AtomicUsize,
+}
+
+impl Service for Counter {
+    const NAME: &'static str = "counter";
+}
+
+/// Upstream parity (service.spec 'apply functional plugin'): a synchronous
+/// class-service plugin registers its service under `Service::NAME`, makes it
+/// available to dependents once active, and removes it with the fiber.
+#[test]
+fn service_sync_registers_and_removes_typed_service() -> Result<()> {
+    let root = Context::new();
+    let plugin = service_sync::<Counter, (), _>("counter-provider", Inject::none(), |_ctx, _| {
+        Ok(Counter {
+            value: AtomicUsize::new(0),
+        })
+    });
+
+    let fiber = root.plugin_default(plugin);
+    fiber.try_wait()?;
+    let service = root.require::<Counter>("counter")?;
+    service.value.fetch_add(1, Ordering::SeqCst);
+    assert_eq!(service.value.load(Ordering::SeqCst), 1);
+
+    fiber.dispose()?;
+    assert!(root.get::<Counter>("counter")?.is_none());
+    Ok(())
+}
+
+/// Upstream parity (service.spec 'pending inject'): an asynchronous
+/// class-service plugin stays Pending until its dependencies arrive, then
+/// constructs and provides the service exactly once.
+#[test]
+fn service_async_defers_until_dependencies_arrive() -> Result<()> {
+    let root = Context::new();
+    let built = Arc::new(AtomicUsize::new(0));
+    let plugin = service_async::<Counter, (), _, _>("counter-async", Inject::new(["database"]), {
+        let built = built.clone();
+        move |_ctx, _| {
+            let built = built.clone();
+            async move {
+                built.fetch_add(1, Ordering::SeqCst);
+                Ok(Counter {
+                    value: AtomicUsize::new(0),
+                })
+            }
+        }
+    });
+
+    let fiber = root.plugin_default(plugin);
+    assert_eq!(fiber.state(), FiberState::Pending);
+    assert_eq!(built.load(Ordering::SeqCst), 0);
+
+    let _database = root.provide("database", 7_u32)?;
+    fiber.try_wait()?;
+    assert_eq!(built.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        root.require::<Counter>("counter")?
+            .value
+            .load(Ordering::SeqCst),
+        0
+    );
+    Ok(())
+}
+
+struct GateService {
+    available: AtomicBool,
+}
+
+impl Service for GateService {
+    const NAME: &'static str = "gate";
+
+    fn is_available(&self) -> bool {
+        self.available.load(Ordering::SeqCst)
+    }
+}
+
+/// Upstream parity (service.spec availability contract): a service whose
+/// `is_available()` predicate is false keeps dependents Pending until the
+/// predicate flips and the change is notified.
+#[test]
+fn availability_predicate_gates_dependents() -> Result<()> {
+    let root = Context::new();
+    let service = Arc::new(GateService {
+        available: AtomicBool::new(false),
+    });
+    let _handle = root.provide_service_arc(service.clone())?;
+
+    let fiber = root.plugin_default(plugin_sync::<(), _>("consumer", Inject::new(["gate"]), {
+        move |ctx, _| {
+            ctx.require::<GateService>("gate")?;
+            Ok(PluginOutput::none())
+        }
+    }));
+    assert_eq!(fiber.state(), FiberState::Pending);
+
+    service.available.store(true, Ordering::SeqCst);
+    root.notify(["gate"]);
+    fiber.try_wait()?;
+    assert_eq!(fiber.state(), FiberState::Active);
+    Ok(())
+}
+
+/// `provide_service_arc` stores the given `Arc` without double-wrapping, so
+/// `require` returns the very same allocation.
+#[test]
+fn provide_service_arc_keeps_identity() -> Result<()> {
+    let root = Context::new();
+    let service = Arc::new(Counter {
+        value: AtomicUsize::new(0),
+    });
+    let _handle = root.provide_service_arc(service.clone())?;
+
+    let fetched = root.require::<Counter>("counter")?;
+    assert!(Arc::ptr_eq(&service, &fetched));
+    Ok(())
+}
+
+/// Upstream parity (invoke.spec intercept merge): `resolve_service_config`
+/// merges intercept entries root-first with the caller-supplied operation, so
+/// a pick-last merge reproduces the upstream leaf/nearest-wins precedence.
+#[test]
+fn resolve_service_config_merges_root_to_leaf() -> Result<()> {
+    let root = Context::new();
+    let child = root.intercept("svc", 1_u32).intercept("svc", 2_u32);
+
+    // No intercepts above the root context: the base passes through.
+    let merged = root.resolve_service_config("svc", 0_u32, |acc, next| acc + *next)?;
+    assert_eq!(merged, 0);
+
+    // Root-first accumulation sees both layers in declaration order.
+    let merged = child.resolve_service_config("svc", 0_u32, |acc, next| acc + *next)?;
+    assert_eq!(merged, 3);
+
+    // A pick-last merge keeps the nearest (leaf) entry.
+    let merged = child.resolve_service_config("svc", 0_u32, |_, next| *next)?;
+    assert_eq!(merged, 2);
+    Ok(())
+}


### PR DESCRIPTION
Upstream-parity integration tests for previously untested core surfaces (based on cordiverse/cordis core tests + vendored @deepseek-ai/cordis 4.0.1):

- **service.rs** (new, 5 tests): Service trait registration/removal, async deferral until deps arrive, availability predicates gating dependents, Arc identity through provide_service_arc, resolve_service_config root-to-leaf merge precedence
- **dispose.rs** (new, 2 tests): failing disposers do not break teardown (LIFO continues, failure logged) — dispose.spec + fiber.spec parity; adopted effects form a diagnostic tree with idempotent double dispose
- **events.rs** (+2): serial ordered bail stops at first Some (events.spec), sync waterfall convenience wrapper composition
- **reflect_logger.rs** (+1): logger name resolution precedence chain explicit > intercept > fiber-derived > root (logger.spec)

Verification gate green: fmt, clippy --all-targets --all-features -D warnings, cargo test --workspace --all-features, cargo doc -D warnings, 8 README doctests.