### PR TITLE
feat: add cordis-include patch module (apply, compose, provenance, dumps)

### DIFF
--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -60,6 +60,36 @@ entries:
           host: ${{ env.HOST }}
 ```
 
+## Patch lists
+
+Entry lists compose from *patch* files — bare top-level YAML arrays of
+[`PatchOptions`] rows (`id`-targeted overrides and `insert` lists), the
+bundle/profile assembly model. [`apply_entry_patches`] is the one
+application routine every consumer shares; [`compose_layers`] flattens all
+layers into a single call (the same single call a boot performs);
+[`render_config_dump`] prints the composition grouped by source under
+`# ==` provenance comments:
+
+```rust
+use cordis_include::{compose_layers, EntryOptions, Node, PatchOptions};
+# fn main() {
+let bundle = vec![PatchOptions {
+    insert: Some(vec![EntryOptions::new("adapter-http")
+        .with_id("http")
+        .with_config(Node::from_iter([("port".to_string(), 8080.into())]))]),
+    ..Default::default()
+}];
+let user = vec![PatchOptions {
+    id: Some("http".into()),
+    disabled: Some(true),
+    ..Default::default()
+}];
+let entries = compose_layers(&[bundle, user], |_| {});
+assert_eq!(entries.len(), 1);
+assert!(entries[0].disabled);
+# }
+```
+
 ## Feature flags
 
 - **`watch`** — debounced file watching through [`notify`](https://crates.io/crates/notify).
@@ -75,3 +105,7 @@ lifecycle.
 
 [`LoaderFile`]: https://docs.rs/cordis-include/latest/cordis_include/struct.LoaderFile.html
 [`PluginResolver`]: https://docs.rs/cordis-include/latest/cordis_include/trait.PluginResolver.html
+[`PatchOptions`]: https://docs.rs/cordis-include/latest/cordis_include/struct.PatchOptions.html
+[`apply_entry_patches`]: https://docs.rs/cordis-include/latest/cordis_include/fn.apply_entry_patches.html
+[`compose_layers`]: https://docs.rs/cordis-include/latest/cordis_include/fn.compose_layers.html
+[`render_config_dump`]: https://docs.rs/cordis-include/latest/cordis_include/fn.render_config_dump.html

--- a/crates/cordis-include/README.zh-CN.md
+++ b/crates/cordis-include/README.zh-CN.md
@@ -57,6 +57,34 @@ entries:
           host: ${{ env.HOST }}
 ```
 
+## 补丁列表
+
+条目列表由*补丁*文件组合而来 —— 裸顶层数组的 [`PatchOptions`] 行
+（按 `id` 定向的覆盖与 `insert` 插入列表），即 bundle/profile 的装配模型。
+[`apply_entry_patches`] 是所有消费方共用的唯一应用例程；[`compose_layers`]
+把所有层拍平成单次调用（与 boot 执行的同一次调用）；[`render_config_dump`]
+按来源分组打印组合结果，并附 `# ==` 溯源注释：
+
+```rust
+use cordis_include::{compose_layers, EntryOptions, Node, PatchOptions};
+# fn main() {
+let bundle = vec![PatchOptions {
+    insert: Some(vec![EntryOptions::new("adapter-http")
+        .with_id("http")
+        .with_config(Node::from_iter([("port".to_string(), 8080.into())]))]),
+    ..Default::default()
+}];
+let user = vec![PatchOptions {
+    id: Some("http".into()),
+    disabled: Some(true),
+    ..Default::default()
+}];
+let entries = compose_layers(&[bundle, user], |_| {});
+assert_eq!(entries.len(), 1);
+assert!(entries[0].disabled);
+# }
+```
+
 ## Feature flags
 
 - **`watch`** — 通过 [`notify`](https://crates.io/crates/notify) 实现防抖文件
@@ -71,3 +99,7 @@ entries:
 
 [`LoaderFile`]: https://docs.rs/cordis-include/latest/cordis_include/struct.LoaderFile.html
 [`PluginResolver`]: https://docs.rs/cordis-include/latest/cordis_include/trait.PluginResolver.html
+[`PatchOptions`]: https://docs.rs/cordis-include/latest/cordis_include/struct.PatchOptions.html
+[`apply_entry_patches`]: https://docs.rs/cordis-include/latest/cordis_include/fn.apply_entry_patches.html
+[`compose_layers`]: https://docs.rs/cordis-include/latest/cordis_include/fn.compose_layers.html
+[`render_config_dump`]: https://docs.rs/cordis-include/latest/cordis_include/fn.render_config_dump.html

--- a/crates/cordis-include/src/lib.rs
+++ b/crates/cordis-include/src/lib.rs
@@ -52,6 +52,13 @@
 //! is handed to a plugin ([`Entry::resolved_config`]); the file itself keeps
 //! the template text. There is no expression evaluation.
 //!
+//! # Patch lists
+//!
+//! Entry lists compose from *patch* files — bare top-level YAML arrays of
+//! [`PatchOptions`] rows (`id`-targeted overrides and `insert` lists), the
+//! bundle/profile assembly model. See the [`patch`] module for the apply,
+//! composition, provenance, and dump mechanisms.
+//!
 //! # Suspension
 //!
 //! Two suspend counters break the reload feedback loop: a file-level guard
@@ -76,6 +83,7 @@ pub mod file;
 pub mod interpolate;
 pub mod node;
 pub mod options;
+pub mod patch;
 pub mod resolver;
 pub mod tree;
 #[cfg(feature = "watch")]
@@ -85,7 +93,12 @@ pub use entry::{Entry, EntrySuspendGuard};
 pub use error::{IncludeError, Result};
 pub use file::{Document, FileFormat, FileSuspendGuard, LoaderFile};
 pub use node::{Node, NodeMap};
-pub use options::{EntryOptions, IMPORT_NAME};
+pub use options::{EntryOptions, GROUP_NAME, IMPORT_NAME};
+pub use patch::{
+    DumpLayer, PatchOptions, Provenance, apply_entry_patches, compose_layers,
+    compose_with_provenance, load_optional_patches, load_overlay_patches, render_config_dump,
+    render_dump,
+};
 pub use resolver::PluginResolver;
 pub use tree::{EntryTree, RemovedEntry, TreeDiff};
 #[cfg(feature = "watch")]

--- a/crates/cordis-include/src/options.rs
+++ b/crates/cordis-include/src/options.rs
@@ -12,6 +12,10 @@ fn is_false(value: &bool) -> bool {
 /// (`name: import` with `config: { url: "…" }`).
 pub const IMPORT_NAME: &str = "import";
 
+/// Entry name of the built-in group plugin: a row named `group` (or any row
+/// with children) is a group.
+pub const GROUP_NAME: &str = "group";
+
 /// One entry in a config file: a plugin instance plus its group position.
 ///
 /// The declared field order is the serialization order (`id` and `name`

--- a/crates/cordis-include/src/patch.rs
+++ b/crates/cordis-include/src/patch.rs
@@ -1,0 +1,541 @@
+//! Patch algebra for entry lists: the composition mechanism behind bundles
+//! and profiles.
+//!
+//! A *patch list* is a bare top-level YAML array of [`PatchOptions`] rows.
+//! Each row either inserts entries (`insert`) or overrides an existing entry
+//! by `id`. [`apply_entry_patches`] is THE patch semantics — the one routine
+//! every consumer (mounting, recomposition, offline config dumps) funnels
+//! through, so a dump can never drift from what boots.
+//!
+//! Two contracts are load-bearing:
+//!
+//! - **Detachment.** Inputs are never modified and the result shares nothing
+//!   with them — even with no patches the returned list is a fresh copy.
+//!   Recomposition must always restart from the original patch data; feeding
+//!   a materialized composition back in would bake earlier patches into the
+//!   base and make a removed or changed patch impossible to revert.
+//! - **Single flatten.** Layer lists ([`compose_layers`],
+//!   [`compose_with_provenance`]) are flattened into ONE
+//!   [`apply_entry_patches`] call — the same single call a boot makes, not
+//!   one call per layer. The single-pass id index is built once (base rows
+//!   plus inserted rows as the same pass adds them) and never sees rows a
+//!   plain `config` replacement introduced inside a group; a per-layer
+//!   composition would rebuild the index between layers and let later layers
+//!   patch rows boot never mounts.
+//!
+//! Patch-file IO follows the fail-loud contract: a *named* overlay
+//! ([`load_overlay_patches`]) must exist — its absence is a
+//! misconfiguration — while an *optional* user layer
+//! ([`load_optional_patches`]) treats a missing file as "no layer". A
+//! present-but-broken file (unreadable, unparsable, not a top-level array,
+//! an entry that is not a mapping) always fails loud: a patch file that
+//! cannot apply must never be silently skipped.
+
+use crate::error::{IncludeError, Result};
+use crate::node::Node;
+use crate::options::{EntryOptions, GROUP_NAME};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// One patch row: insert entries, or override an existing entry by id.
+///
+/// Every field is optional; rows are struct-typed where upstream's JS patches
+/// could carry any field. Unknown keys are kept in [`PatchOptions::extra`]
+/// (round-trip and diagnostics) and warn-skipped at application time.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PatchOptions {
+    /// Target entry id. With `insert` it names the group to insert into;
+    /// without `insert` it selects the entry to override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Entries to insert: appended to the target group's children when `id`
+    /// names a group, to the top level otherwise. `Some(vec![])` still takes
+    /// the insert branch (upstream truthiness); only `None` means "not an
+    /// insert".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub insert: Option<Vec<EntryOptions>>,
+    /// Guard on the target: when present and non-empty it must equal the
+    /// target's `name` or the patch warns and skips. It is never written
+    /// back — a guard, not an override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Whole replacement of the target's `config` (a replacement, not a
+    /// merge).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<Node>,
+    /// Replacement of the target's `disabled` flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    /// Replacement of the target's `inject` list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inject: Option<Vec<String>>,
+    /// Unknown keys, preserved in file order. Applying a patch warns and
+    /// skips them: upstream JS patches could override any field, but the
+    /// Rust entry has no slot for them (`group` is the children list, not
+    /// upstream's marker; `intercept`/`isolate` are not ported).
+    #[serde(flatten)]
+    pub extra: IndexMap<String, Node>,
+}
+
+/// Whether an entry is a group.
+///
+/// Upstream marks groups with an explicit `group: true` flag; this port
+/// infers them structurally: the built-in group plugin by name, or any entry
+/// with children. The name arm keeps inserts working on a declared group
+/// that momentarily has no rows (upstream's `target.config = []` branch).
+fn is_group(entry: &EntryOptions) -> bool {
+    entry.name == GROUP_NAME || !entry.group.is_empty()
+}
+
+/// Child positions leading from the root list to one entry.
+type EntryPath = Vec<usize>;
+
+/// Index one entry (and, for groups, its subtree) at `path`.
+fn index_entry(entry: &EntryOptions, path: &[usize], index: &mut HashMap<String, EntryPath>) {
+    if let Some(id) = entry.id.as_deref().filter(|id| !id.is_empty()) {
+        index.insert(id.to_owned(), path.to_vec());
+    }
+    if is_group(entry) {
+        for (position, child) in entry.group.iter().enumerate() {
+            let mut child_path = path.to_vec();
+            child_path.push(position);
+            index_entry(child, &child_path, index);
+        }
+    }
+}
+
+/// Borrow the entry a path addresses. Paths are built from the live
+/// structure and never outlive the mutations that created them.
+fn resolve<'a>(data: &'a [EntryOptions], path: &[usize]) -> &'a EntryOptions {
+    let mut entry = &data[path[0]];
+    for &position in &path[1..] {
+        entry = &entry.group[position];
+    }
+    entry
+}
+
+/// Mutably borrow the entry a path addresses.
+fn resolve_mut<'a>(data: &'a mut [EntryOptions], path: &[usize]) -> &'a mut EntryOptions {
+    let mut entry = &mut data[path[0]];
+    for &position in &path[1..] {
+        entry = &mut entry.group[position];
+    }
+    entry
+}
+
+/// Warn about inserted rows without ids: they cannot be matched by later
+/// layers and are deleted and recreated (fiber restart) on every
+/// recomposition.
+fn warn_unindexed(entries: &[EntryOptions], warn: &mut impl FnMut(&str)) {
+    for entry in entries {
+        if entry.id.as_deref().is_none_or(str::is_empty) {
+            warn(
+                "patch insert: entry has no id; later layers cannot patch it and it restarts on every recomposition",
+            );
+        }
+        warn_unindexed(&entry.group, warn);
+    }
+}
+
+/// Apply patch rows to an entry list — THE patch semantics of this crate,
+/// shared by mounting, recomposition, and offline config tooling so a dump
+/// can never drift from what boots.
+///
+/// Semantics (a direct port of upstream `applyEntryPatches`):
+///
+/// - The result is fully detached from both inputs, even when `patches` is
+///   empty. Recomposition must always restart from the original patch data.
+/// - The id index is built once from `data` (recursing into groups) and
+///   extended only by `insert` rows as they are added, so a later patch in
+///   the same list can target a row an earlier patch inserted — and rows
+///   that appear any other way (inside a replaced `config`, say) stay
+///   invisible to it.
+/// - `insert` with `id` appends to that group's children (the target must
+///   be a group); `insert` without `id` appends to the top level.
+/// - Non-insert patches require `id`. `name`, when present and non-empty,
+///   must equal the target's name. `config`, `disabled`, and `inject`
+///   replace the target's fields wholesale.
+/// - A patch that matches nothing — missing id, unknown target, name
+///   mismatch, non-group insert target — warns through `warn` and is
+///   skipped, never an error: one overlay shared across surfaces does not
+///   have to match every tree.
+/// - Override keys with no Rust slot (`group`, `intercept`, `isolate`,
+///   anything unknown) warn and are skipped.
+///
+/// # Example
+///
+/// ```
+/// use cordis_include::{apply_entry_patches, EntryOptions, Node, PatchOptions};
+///
+/// let base = vec![EntryOptions::new("adapter-http").with_id("http")];
+/// let patches = vec![PatchOptions {
+///     id: Some("http".into()),
+///     config: Some(Node::from_iter([(
+///         "port".to_string(),
+///         Node::Int(8080),
+///     )])),
+///     ..Default::default()
+/// }];
+/// let composed = apply_entry_patches(&base, &patches, |_| {});
+/// assert_eq!(composed[0].config.as_ref().unwrap()["port"], Node::Int(8080));
+/// // The input stays untouched: recomposition restarts from the originals.
+/// assert!(base[0].config.is_none());
+/// ```
+pub fn apply_entry_patches(
+    data: &[EntryOptions],
+    patches: &[PatchOptions],
+    mut warn: impl FnMut(&str),
+) -> Vec<EntryOptions> {
+    let mut data = data.to_vec();
+    if patches.is_empty() {
+        return data;
+    }
+    let mut index: HashMap<String, EntryPath> = HashMap::new();
+    for (position, entry) in data.iter().enumerate() {
+        index_entry(entry, &[position], &mut index);
+    }
+    for patch in patches {
+        // `Some(..)` takes the insert branch even for an empty list —
+        // upstream's truthiness check on the insert field.
+        if let Some(insert) = patch.insert.as_ref() {
+            warn_unindexed(insert, &mut warn);
+            match patch.id.as_deref().filter(|id| !id.is_empty()) {
+                Some(id) => {
+                    let Some(path) = index.get(id) else {
+                        warn(&format!("patch insert: entry {id:?} not found"));
+                        continue;
+                    };
+                    let path = path.clone();
+                    let target = resolve(&data, &path);
+                    if !is_group(target) {
+                        warn(&format!("patch insert: entry {id:?} is not a group"));
+                        continue;
+                    }
+                    let start = target.group.len();
+                    resolve_mut(&mut data, &path)
+                        .group
+                        .extend(insert.iter().cloned());
+                    for (offset, entry) in insert.iter().enumerate() {
+                        let mut child_path = path.clone();
+                        child_path.push(start + offset);
+                        index_entry(entry, &child_path, &mut index);
+                    }
+                }
+                None => {
+                    let start = data.len();
+                    data.extend(insert.iter().cloned());
+                    for (offset, entry) in insert.iter().enumerate() {
+                        index_entry(entry, &[start + offset], &mut index);
+                    }
+                }
+            }
+            continue;
+        }
+
+        let Some(id) = patch.id.as_deref().filter(|id| !id.is_empty()) else {
+            warn("patch: id is required for non-insert patches");
+            continue;
+        };
+        let Some(path) = index.get(id) else {
+            warn(&format!("patch: entry {id:?} not found"));
+            continue;
+        };
+        let path = path.clone();
+        let target_name = resolve(&data, &path).name.clone();
+        if let Some(name) = patch.name.as_deref().filter(|name| !name.is_empty()) {
+            if name != target_name {
+                warn(&format!(
+                    "patch: name mismatch for {id:?} (expected {target_name:?}, got {name:?}), skipping"
+                ));
+                continue;
+            }
+        }
+        let target = resolve_mut(&mut data, &path);
+        if let Some(config) = patch.config.as_ref() {
+            target.config = Some(config.clone());
+        }
+        if let Some(disabled) = patch.disabled {
+            target.disabled = disabled;
+        }
+        if let Some(inject) = patch.inject.as_ref() {
+            target.inject = inject.clone();
+        }
+        if !patch.extra.is_empty() {
+            let keys: Vec<&str> = patch.extra.keys().map(String::as_str).collect();
+            warn(&format!(
+                "patch: skipping unsupported override key(s) [{}] on entry {id:?}",
+                keys.join(", ")
+            ));
+        }
+    }
+    data
+}
+
+/// Compose patch layers into the effective entry list over an empty root.
+///
+/// **All layers flatten into a single [`apply_entry_patches`] call** — the
+/// same single call a boot makes, never one call per layer. The single-pass
+/// id index never sees rows a plain `config` replacement introduced inside a
+/// group, so a later layer targeting such a row warns and misses; composing
+/// layer-by-layer would rebuild the index between layers and produce a tree
+/// boot never mounts. Composers must keep this shape.
+///
+/// # Example
+///
+/// ```
+/// use cordis_include::{compose_layers, EntryOptions, PatchOptions};
+///
+/// let bundle = vec![PatchOptions {
+///     insert: Some(vec![EntryOptions::new("adapter-http").with_id("http")]),
+///     ..Default::default()
+/// }];
+/// let user = vec![PatchOptions {
+///     id: Some("http".into()),
+///     disabled: Some(true),
+///     ..Default::default()
+/// }];
+/// let entries = compose_layers(&[bundle, user], |_| {});
+/// assert_eq!(entries.len(), 1);
+/// assert!(entries[0].disabled);
+/// ```
+pub fn compose_layers(layers: &[Vec<PatchOptions>], warn: impl FnMut(&str)) -> Vec<EntryOptions> {
+    let flattened: Vec<PatchOptions> = layers.iter().flatten().cloned().collect();
+    apply_entry_patches(&[], &flattened, warn)
+}
+
+/// One labeled patch layer, for provenance-aware composition and dumps.
+#[derive(Debug, Clone, Copy)]
+pub struct DumpLayer<'a> {
+    /// Source label shown in dump comments and warning attributions
+    /// (a file basename or path).
+    pub label: &'a str,
+    /// The layer's patches, in application order.
+    pub patches: &'a [PatchOptions],
+}
+
+/// Where one composed row came from: its origin layer and every later layer
+/// that changed it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Provenance {
+    /// The label of the layer that contributed the row.
+    pub origin: String,
+    /// Labels of the layers that patched it, in application order.
+    pub patched_by: Vec<String>,
+}
+
+/// Compose layers exactly as [`compose_layers`] does (single flatten over
+/// `base`) while tracking, per row, which layer contributed it and which
+/// layers changed it.
+///
+/// Provenance uses upstream's prefix-snapshot diff: snapshot *k* applies
+/// layers 1..*k* over the same base, and a row is compared positionally
+/// against the previous snapshot — the patch algorithm only rewrites rows in
+/// place or appends, so a top-level index identifies one row across
+/// snapshots, and a layer whose addition changed the row (config
+/// replacement, disable, group insert) is listed as having patched it.
+/// Appended rows carry the appending layer as their origin.
+///
+/// Skipped-patch warnings are attributed to layers the same way: earlier
+/// layers' patches see an identical preceding state in every snapshot that
+/// includes them, so each snapshot's warning list extends the previous one
+/// and the new tail belongs to the added layer. `warn` receives each tail
+/// line prefixed with `[label]`.
+///
+/// Patches are never mutated (application clones into the result), so the
+/// same layer slices are safely reused across snapshots.
+pub fn compose_with_provenance(
+    base: &[EntryOptions],
+    base_label: &str,
+    layers: &[DumpLayer<'_>],
+    mut warn: impl FnMut(&str),
+) -> (Vec<EntryOptions>, Vec<Provenance>) {
+    let mut provenance = vec![
+        Provenance {
+            origin: base_label.to_owned(),
+            patched_by: Vec::new(),
+        };
+        base.len()
+    ];
+    let mut previous = base.to_vec();
+    let mut previous_warnings: Vec<String> = Vec::new();
+    for (count, layer) in layers.iter().enumerate() {
+        let flattened: Vec<PatchOptions> = layers[..=count]
+            .iter()
+            .flat_map(|layer| layer.patches.iter().cloned())
+            .collect();
+        let mut warnings: Vec<String> = Vec::new();
+        let snapshot = apply_entry_patches(base, &flattened, |line| warnings.push(line.to_owned()));
+        for line in warnings.iter().skip(previous_warnings.len()) {
+            warn(&format!("[{}] {}", layer.label, line));
+        }
+        for (position, entry) in snapshot.iter().enumerate() {
+            if position >= previous.len() {
+                provenance.push(Provenance {
+                    origin: layer.label.to_owned(),
+                    patched_by: Vec::new(),
+                });
+            } else if entry != &previous[position] {
+                provenance[position].patched_by.push(layer.label.to_owned());
+            }
+        }
+        previous = snapshot;
+        previous_warnings = warnings;
+    }
+    (previous, provenance)
+}
+
+/// Render composed rows as one loadable YAML document, grouped under a
+/// `# == origin[, patched by …]` comment per contiguous run of rows with the
+/// same source. `${{ env.NAME }}` templates print verbatim, unevaluated.
+///
+/// Entry fields serialize in the crate's stable order
+/// (`id`, `name`, `disabled`, `inject`, `group`, `config`); config leaves
+/// are delegated to the serde YAML emitter.
+pub fn render_dump(composed: &[EntryOptions], provenance: &[Provenance]) -> Result<String> {
+    let mut sections: Vec<String> = Vec::new();
+    let mut group: Vec<&EntryOptions> = Vec::new();
+    let mut current: Option<String> = None;
+    for (entry, record) in composed.iter().zip(provenance) {
+        let label = if record.patched_by.is_empty() {
+            record.origin.clone()
+        } else {
+            format!(
+                "{}, patched by {}",
+                record.origin,
+                record.patched_by.join(", ")
+            )
+        };
+        if current.as_deref() != Some(label.as_str()) {
+            flush_group(&mut sections, &group, current.take())?;
+            current = Some(label);
+            group.clear();
+        }
+        group.push(entry);
+    }
+    flush_group(&mut sections, &group, current)?;
+    Ok(sections.join("\n") + "\n")
+}
+
+/// Serialize one contiguous group under its label comment.
+fn flush_group(
+    sections: &mut Vec<String>,
+    group: &[&EntryOptions],
+    label: Option<String>,
+) -> Result<()> {
+    if group.is_empty() {
+        return Ok(());
+    }
+    let label = label.expect("a non-empty group always has a label");
+    let text = serde_yaml_ng::to_string(&group).map_err(|error| IncludeError::Parse {
+        format: "yaml",
+        source: Box::new(error),
+    })?;
+    sections.push(format!("# == {label}\n{}", text.trim_end()));
+    Ok(())
+}
+
+/// Compose layers over `base` and render the dump in one step — the offline
+/// twin of [`compose_with_provenance`] plus [`render_dump`]. See those for
+/// the single-flatten, provenance, and warning-attribution contracts.
+///
+/// # Example
+///
+/// ```
+/// use cordis_include::{render_config_dump, DumpLayer, EntryOptions, PatchOptions};
+///
+/// let base = [EntryOptions::new("./noop").with_id("shared")];
+/// let overlay = [PatchOptions {
+///     id: Some("shared".into()),
+///     disabled: Some(true),
+///     ..Default::default()
+/// }];
+/// let layers = [DumpLayer {
+///     label: "overlay.yml",
+///     patches: &overlay,
+/// }];
+/// let dump = render_config_dump(&base, "base.yml", &layers, |_| {}).unwrap();
+/// assert!(dump.contains("# == base.yml, patched by overlay.yml"), "{dump}");
+/// ```
+pub fn render_config_dump(
+    base: &[EntryOptions],
+    base_label: &str,
+    layers: &[DumpLayer<'_>],
+    warn: impl FnMut(&str),
+) -> Result<String> {
+    let (composed, provenance) = compose_with_provenance(base, base_label, layers, warn);
+    render_dump(&composed, &provenance)
+}
+
+/// Load an optional patch-list file: a top-level YAML array of patch rows.
+/// A missing file means "no layer" (`Ok(None)`); any other read failure, a
+/// parse failure, a non-array document, or a non-mapping entry is a hard
+/// error — a present patch file that cannot apply is a misconfiguration and
+/// must fail loud, never be silently skipped.
+pub fn load_optional_patches(path: impl AsRef<Path>) -> Result<Option<Vec<PatchOptions>>> {
+    let path = path.as_ref();
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(IncludeError::Message {
+                message: format!("failed to read patches {}: {error}", path.display()),
+            });
+        }
+    };
+    Ok(Some(parse_patch_list(path, &content, "patches")?))
+}
+
+/// Load a required overlay patch list — a bundle's `cordis.patch.yml` or a
+/// `--patch` overlay. Same file format as [`load_optional_patches`], but a
+/// missing file is a hard error: the caller *named* this file, so its
+/// absence is a misconfiguration, not "no overlay".
+pub fn load_overlay_patches(path: impl AsRef<Path>) -> Result<Vec<PatchOptions>> {
+    let path = path.as_ref();
+    let content = fs::read_to_string(path).map_err(|error| IncludeError::Message {
+        message: format!("failed to read overlay {}: {error}", path.display()),
+    })?;
+    parse_patch_list(path, &content, "overlay")
+}
+
+/// Parse one patch list: a bare top-level YAML array of [`PatchOptions`]
+/// rows, each a mapping.
+fn parse_patch_list(path: &Path, content: &str, label: &str) -> Result<Vec<PatchOptions>> {
+    let parsed = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(content).map_err(|error| {
+        IncludeError::Message {
+            message: format!("failed to parse {label} {}: {error}", path.display()),
+        }
+    })?;
+    let Some(rows) = parsed.as_sequence() else {
+        return Err(IncludeError::Message {
+            message: format!(
+                "{label} {} must be a top-level YAML array of loader patch entries",
+                path.display()
+            ),
+        });
+    };
+    let mut patches = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
+        if !row.is_mapping() {
+            return Err(IncludeError::Message {
+                message: format!(
+                    "{label} entry {} in {} must be a mapping (a loader patch entry)",
+                    index + 1,
+                    path.display()
+                ),
+            });
+        }
+        let patch: PatchOptions =
+            serde_yaml_ng::from_value(row.clone()).map_err(|error| IncludeError::Message {
+                message: format!(
+                    "failed to parse {label} entry {} in {}: {error}",
+                    index + 1,
+                    path.display()
+                ),
+            })?;
+        patches.push(patch);
+    }
+    Ok(patches)
+}

--- a/crates/cordis-include/tests/patch.rs
+++ b/crates/cordis-include/tests/patch.rs
@@ -1,0 +1,802 @@
+//! Patch algebra: apply semantics, patch-file IO fail-loud contracts, layer
+//! composition (single flatten), provenance, and dump rendering — the port
+//! of upstream's include patch machinery and its app-boot test face.
+
+use cordis_include::{
+    DumpLayer, EntryOptions, IncludeError, Node, PatchOptions, Provenance, apply_entry_patches,
+    compose_layers, compose_with_provenance, load_optional_patches, load_overlay_patches,
+    render_config_dump, render_dump,
+};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A warning sink collectable after the call.
+fn warning_sink() -> (Rc<std::cell::RefCell<Vec<String>>>, impl FnMut(&str)) {
+    let lines = Rc::new(std::cell::RefCell::new(Vec::new()));
+    let sink = {
+        let lines = lines.clone();
+        move |line: &str| lines.borrow_mut().push(line.to_owned())
+    };
+    (lines, sink)
+}
+
+/// Parse a patch list from YAML text (the file shape, without the file).
+fn patches(text: &str) -> Vec<PatchOptions> {
+    serde_yaml_ng::from_str(text).expect("valid patch list")
+}
+
+/// An entry with id and name.
+fn entry(id: &str, name: &str) -> EntryOptions {
+    EntryOptions::new(name).with_id(id)
+}
+
+/// The object config of a patch row.
+fn patch_config_of(patch: &PatchOptions) -> &cordis_include::NodeMap {
+    patch
+        .config
+        .as_ref()
+        .and_then(Node::as_object)
+        .expect("config object")
+}
+
+/// A unique temp file path for patch-list IO tests.
+fn temp_path(stem: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "cordis-include-patch-test-{stem}-{}-{nanos}.yml",
+        std::process::id()
+    ))
+}
+
+fn config_of(entry: &EntryOptions) -> &cordis_include::NodeMap {
+    entry
+        .config
+        .as_ref()
+        .and_then(Node::as_object)
+        .expect("config object")
+}
+
+// ---------------------------------------------------------------- apply ---
+
+#[test]
+fn overrides_replace_config_wholesale_and_flip_flags() {
+    let base = vec![entry("a", "adapter").with_config(Node::from_iter([
+        ("v".to_string(), Node::Int(1)),
+        ("keep".to_string(), Node::Bool(true)),
+    ]))];
+    let composed = apply_entry_patches(
+        &base,
+        &patches(
+            "\
+- id: a
+  config:
+    v: 2
+- id: a
+  disabled: true
+- id: a
+  inject: [database]
+",
+        ),
+        |_| {},
+    );
+    assert_eq!(composed.len(), 1);
+    // `config` is a whole replacement, not a merge.
+    assert_eq!(
+        composed[0].config,
+        Some(Node::from_iter([("v".to_string(), Node::Int(2))]))
+    );
+    assert!(composed[0].disabled);
+    assert_eq!(composed[0].inject, ["database"]);
+}
+
+#[test]
+fn insert_without_id_appends_to_top_level_and_is_immediately_indexed() {
+    let composed = apply_entry_patches(
+        &[],
+        &patches(
+            "\
+- insert:
+    - id: x
+      name: pkg-x
+      config:
+        a: 1
+- id: x
+  config:
+    a: 2
+",
+        ),
+        |_| {},
+    );
+    // A later patch in the same list targets the row the earlier one
+    // inserted — without immediate indexing, inserted rows are unpatchable.
+    assert_eq!(
+        composed,
+        vec![entry("x", "pkg-x").with_config(Node::from_iter([("a".to_string(), Node::Int(2))]))]
+    );
+}
+
+#[test]
+fn insert_into_group_children_and_indexing_recurses_into_them() {
+    let base = vec![entry("g", "group")];
+    let composed = apply_entry_patches(
+        &base,
+        &patches(
+            "\
+- id: g
+  insert:
+    - id: child
+      name: pkg-c
+      group:
+        - id: grandchild
+          name: pkg-gc
+- id: grandchild
+  disabled: true
+",
+        ),
+        |_| {},
+    );
+    let child = &composed[0].group[0];
+    assert_eq!(child.id.as_deref(), Some("child"));
+    // The inserted row's own group children are indexed too.
+    assert!(child.group[0].disabled);
+}
+
+#[test]
+fn insert_with_id_requires_a_group_target() {
+    let base = vec![
+        entry("g", "group").with_group(vec![entry("c0", "pkg")]),
+        // Declared group with no rows yet — still an insert target.
+        entry("empty", "group"),
+        entry("plain", "adapter"),
+    ];
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &base,
+        &patches(
+            "\
+- id: g
+  insert:
+    - id: c1
+      name: pkg
+- id: empty
+  insert:
+    - id: e1
+      name: pkg
+- id: plain
+  insert:
+    - id: p1
+      name: pkg
+- id: absent
+  insert:
+    - id: z1
+      name: pkg
+",
+        ),
+        sink,
+    );
+    assert_eq!(composed[0].group.len(), 2);
+    assert_eq!(
+        composed[1].group.len(),
+        1,
+        "childless group accepts inserts"
+    );
+    assert!(composed[2].group.is_empty(), "non-group rejects inserts");
+    assert_eq!(
+        lines.borrow().to_vec(),
+        [
+            "patch insert: entry \"plain\" is not a group",
+            "patch insert: entry \"absent\" not found",
+        ],
+    );
+}
+
+#[test]
+fn name_is_a_guard_not_an_override() {
+    let base = vec![entry("a", "adapter")];
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &base,
+        &patches(
+            "\
+- id: a
+  name: adapter
+  disabled: true
+- id: a
+  name: other-plugin
+  inject: [wrong]
+- id: a
+  name: ''
+  inject: [empty-guard]
+",
+        ),
+        sink,
+    );
+    // Matching guard applies; mismatched guard warns and skips; an empty
+    // guard string is no guard at all (upstream truthiness).
+    assert!(composed[0].disabled);
+    assert_eq!(composed[0].inject, ["empty-guard"]);
+    assert_eq!(composed[0].name, "adapter");
+    assert_eq!(
+        lines.borrow().to_vec(),
+        ["patch: name mismatch for \"a\" (expected \"adapter\", got \"other-plugin\"), skipping"],
+    );
+}
+
+#[test]
+fn misses_and_missing_ids_warn_and_skip() {
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &[entry("a", "adapter")],
+        &patches(
+            "\
+- config: {}
+- id: missing
+  config: {}
+",
+        ),
+        sink,
+    );
+    assert_eq!(composed, vec![entry("a", "adapter")]);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        [
+            "patch: id is required for non-insert patches",
+            "patch: entry \"missing\" not found",
+        ],
+    );
+}
+
+#[test]
+fn group_and_unknown_override_keys_warn_and_skip() {
+    let base = vec![entry("a", "adapter").with_group(vec![entry("keep", "pkg")])];
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &base,
+        &patches(
+            "\
+- id: a
+  group:
+    - id: injected
+      name: pkg
+- id: a
+  intercept: database
+  isolate: true
+",
+        ),
+        sink,
+    );
+    // `group` is the children list here, not upstream's marker; overriding
+    // it is not equivalent, so it (and any unknown key) warns and skips.
+    assert_eq!(composed[0].group, vec![entry("keep", "pkg")]);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        [
+            "patch: skipping unsupported override key(s) [group] on entry \"a\"",
+            "patch: skipping unsupported override key(s) [intercept, isolate] on entry \"a\"",
+        ],
+    );
+}
+
+#[test]
+fn insert_rows_without_ids_warn() {
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &[],
+        &patches(
+            "\
+- insert:
+    - name: no-id
+      group:
+        - name: nested-no-id
+",
+        ),
+        sink,
+    );
+    assert_eq!(composed.len(), 1);
+    assert_eq!(composed[0].group.len(), 1);
+    let lines = lines.borrow().to_vec();
+    assert_eq!(lines.len(), 2, "{lines:?}");
+    assert!(lines[0].contains("has no id"), "{lines:?}");
+    assert!(lines[1].contains("has no id"), "{lines:?}");
+}
+
+#[test]
+fn empty_insert_list_still_takes_the_insert_branch() {
+    // Upstream truthiness: `insert: []` is an insert; on a non-group target
+    // it still warns (and does nothing), rather than falling through to the
+    // override branch.
+    let (lines, sink) = warning_sink();
+    let composed = apply_entry_patches(
+        &[entry("plain", "adapter")],
+        &patches("- id: plain\n  insert: []\n"),
+        sink,
+    );
+    assert_eq!(composed, vec![entry("plain", "adapter")]);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        ["patch insert: entry \"plain\" is not a group"],
+    );
+}
+
+#[test]
+fn empty_patch_list_returns_a_detached_copy() {
+    let base = vec![entry("a", "adapter")];
+    let mut composed = apply_entry_patches(&base, &[], |_| {});
+    assert_eq!(composed, base);
+    // The result shares nothing with the input: mutating it cannot leak
+    // back into the base a later recomposition would start from.
+    composed[0].name = "changed".into();
+    assert_eq!(base[0].name, "adapter");
+}
+
+#[test]
+fn recomposition_from_original_data_reverts_removed_patches() {
+    // The detachment contract: patching or mounting shared entry objects
+    // would bake earlier values into the cached parse, so a removed or
+    // changed patch could never be reverted. Inputs are immutable here —
+    // pin that recomposition from the same originals stays exact.
+    let base = vec![entry("a", "adapter")];
+    let layer_a = patches("- id: a\n  disabled: true\n");
+    let layer_b = patches("- id: a\n  config:\n    v: 1\n");
+
+    let with_both =
+        apply_entry_patches(&base, &[layer_a.clone(), layer_b.clone()].concat(), |_| {});
+    assert!(with_both[0].disabled);
+    assert_eq!(
+        with_both[0].config,
+        Some(Node::from_iter([("v".to_string(), Node::Int(1))]))
+    );
+
+    let with_a_only = apply_entry_patches(&base, &layer_a, |_| {});
+    assert!(with_a_only[0].disabled, "removing layer b reverts only b");
+    assert!(with_a_only[0].config.is_none(), "layer b's write is gone");
+
+    // Inputs were never touched: the patch rows still hold their inserts.
+    assert!(layer_b[0].config.is_some());
+    assert!(base[0].config.is_none());
+}
+
+// -------------------------------------------------------------- compose ---
+
+#[test]
+fn compose_layers_applies_over_an_empty_root_and_reports_skips() {
+    let (lines, sink) = warning_sink();
+    let entries = compose_layers(
+        &[
+            patches("- insert:\n    - id: x\n      name: pkg-x\n      config:\n        a: 1\n"),
+            patches("- id: x\n  config:\n    a: 2\n- id: missing\n  config: {}\n"),
+        ],
+        sink,
+    );
+    assert_eq!(
+        entries,
+        vec![entry("x", "pkg-x").with_config(Node::from_iter([("a".to_string(), Node::Int(2))]))]
+    );
+    let lines = lines.borrow().to_vec();
+    assert!(
+        lines.iter().any(|line| line.contains("\"missing\"")),
+        "{lines:?}"
+    );
+}
+
+#[test]
+fn single_flatten_never_sees_rows_a_config_replacement_introduced() {
+    // The corner case that makes single-flattening load-bearing upstream: a
+    // group's `config` replacement can introduce entry-shaped rows, and the
+    // single-pass id index never sees them, so a later layer targeting such
+    // a row warns and misses. Composing layer-by-layer would rebuild the
+    // index between layers and patch a row a single-call composition (and
+    // therefore a boot) never touches. Here the port's mapping: upstream
+    // stores group children in `config`; this crate stores plugin config
+    // there and children in `group`, so the introduction happens through a
+    // plain config replacement all the same.
+    let base = vec![entry("g", "group")];
+    let layer_a = patches(
+        "\
+- id: g
+  config:
+    - id: child
+      name: pkg
+      config:
+        v: 1
+",
+    );
+    let layer_b = patches("- id: child\n  config:\n    v: 2\n");
+
+    let (lines, sink) = warning_sink();
+    let entries = apply_entry_patches(&base, &[layer_a, layer_b].concat(), sink);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        ["patch: entry \"child\" not found"],
+    );
+    // The skipped layer did not touch the row it could not see.
+    let introduced = entries[0].config.as_ref().and_then(Node::as_array).unwrap();
+    let child = introduced[0].as_object().unwrap();
+    assert_eq!(child["config"]["v"], Node::Int(1));
+}
+
+#[test]
+fn layers_patch_rows_earlier_layers_inserted() {
+    // The positive control for the index's reach: inserted rows (and rows
+    // inserted into groups) are indexed immediately.
+    let entries = compose_layers(
+        &[
+            patches("- insert:\n    - id: x\n      name: pkg\n"),
+            patches("- id: x\n  disabled: true\n"),
+        ],
+        |_| {},
+    );
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0].disabled);
+}
+
+// ------------------------------------------------------------------ IO ---
+
+#[test]
+fn optional_patches_treat_a_missing_file_as_no_layer() {
+    assert_eq!(
+        load_optional_patches(temp_path("absent")).unwrap(),
+        None,
+        "missing file means no layer"
+    );
+}
+
+#[test]
+fn optional_patches_parse_lists_and_preserve_unknown_keys() {
+    let path = temp_path("parse");
+    std::fs::write(
+        &path,
+        "\
+- id: agent-loop
+  config:
+    model: ${{ env.MODEL }}
+- insert:
+    - id: llm
+      name: pkg-llm
+- id: odd
+  intercept: database
+",
+    )
+    .unwrap();
+    let patches = load_optional_patches(&path)
+        .unwrap()
+        .expect("present layer");
+    assert_eq!(patches.len(), 3);
+    assert_eq!(patches[0].id.as_deref(), Some("agent-loop"));
+    // Templates stay literal — they belong to the entry's own evaluation.
+    assert_eq!(
+        patch_config_of(&patches[0])["model"],
+        "${{ env.MODEL }}".into()
+    );
+    assert_eq!(
+        patches[1].insert.as_ref().unwrap()[0].id.as_deref(),
+        Some("llm")
+    );
+    assert_eq!(
+        patches[2].extra.get("intercept"),
+        Some(&Node::String("database".to_string()))
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn optional_patches_fail_loud_on_every_breakage() {
+    // A present patch file that cannot apply is a misconfiguration and must
+    // fail loud — never be silently skipped.
+    let dir = temp_path("unreadable");
+    std::fs::create_dir_all(&dir).unwrap(); // a directory: present, unreadable as a file
+    assert!(matches!(
+        load_optional_patches(&dir),
+        Err(IncludeError::Message { .. })
+    ));
+    let message = load_optional_patches(&dir).unwrap_err().to_string();
+    assert!(message.starts_with("failed to read patches "), "{message}");
+
+    let cases = [
+        ("invalid: [unclosed\n", "failed to parse patches "),
+        (
+            "id: not-a-list\n",
+            "must be a top-level YAML array of loader patch entries",
+        ),
+        (
+            "- just-a-string\n",
+            "must be a mapping (a loader patch entry)",
+        ),
+        (
+            "- id: x\n  disabled: not-a-bool\n",
+            "failed to parse patches entry 1 in ",
+        ),
+    ];
+    for (index, (text, expected)) in cases.iter().enumerate() {
+        let path = temp_path(&format!("broken-{index}"));
+        std::fs::write(&path, text).unwrap();
+        let error = load_optional_patches(&path).unwrap_err().to_string();
+        assert!(error.contains(expected), "case {index}: {error}");
+        let _ = std::fs::remove_file(&path);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn overlay_patches_fail_loud_when_missing_and_parse_when_present() {
+    let error = load_overlay_patches(temp_path("overlay-absent"))
+        .unwrap_err()
+        .to_string();
+    assert!(error.starts_with("failed to read overlay "), "{error}");
+
+    let path = temp_path("overlay-ok");
+    std::fs::write(&path, "- insert:\n    - id: a\n      name: pkg\n").unwrap();
+    let patches = load_overlay_patches(&path).unwrap();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(
+        patches[0].insert.as_ref().unwrap()[0].id.as_deref(),
+        Some("a")
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+// --------------------------------------------------------- provenance ---
+
+/// The upstream dump spec base: two rows, one with a config the surface
+/// layer rewrites and one untouched.
+fn dump_base() -> Vec<EntryOptions> {
+    vec![
+        entry("shared", "./noop.mjs").with_config(Node::from_iter([
+            ("value".to_string(), "base".into()),
+            ("key".to_string(), "${{ env.DSH_DUMP_SPEC }}".into()),
+        ])),
+        entry("untouched", "./noop.mjs"),
+    ]
+}
+
+#[test]
+fn provenance_tracks_origin_and_patching_layers() {
+    let surface = patches(
+        "\
+- id: shared
+  config:
+    value: surface
+    key: ${{ env.DSH_DUMP_SPEC }}
+- insert:
+    - id: surface-extra
+      name: ./noop.mjs
+",
+    );
+    let user = patches("- id: surface-extra\n  config:\n    value: user\n");
+    let layers = [
+        DumpLayer {
+            label: "surface.yml",
+            patches: &surface,
+        },
+        DumpLayer {
+            label: "user.yml",
+            patches: &user,
+        },
+    ];
+    let (composed, provenance) = compose_with_provenance(&dump_base(), "base.yml", &layers, |_| {});
+    assert_eq!(
+        provenance,
+        vec![
+            Provenance {
+                origin: "base.yml".into(),
+                patched_by: vec!["surface.yml".into()]
+            },
+            Provenance {
+                origin: "base.yml".into(),
+                patched_by: vec![]
+            },
+            Provenance {
+                origin: "surface.yml".into(),
+                patched_by: vec!["user.yml".into()]
+            },
+        ],
+    );
+    assert_eq!(
+        composed[0].config,
+        Some(Node::from_iter([
+            ("value".to_string(), "surface".into()),
+            ("key".to_string(), "${{ env.DSH_DUMP_SPEC }}".into()),
+        ]))
+    );
+    assert_eq!(
+        composed[2].config,
+        Some(Node::from_iter([("value".to_string(), "user".into())]))
+    );
+}
+
+#[test]
+fn warnings_are_attributed_to_their_layer_by_prefix_tail() {
+    let overlay = patches(
+        "\
+- id: only-on-another-surface
+  config:
+    value: ignored
+- id: shared
+  config:
+    value: patched
+",
+    );
+    let layers = [DumpLayer {
+        label: "overlay.yml",
+        patches: &overlay,
+    }];
+    let (lines, sink) = warning_sink();
+    let (composed, _) = compose_with_provenance(&dump_base(), "base.yml", &layers, sink);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        ["[overlay.yml] patch: entry \"only-on-another-surface\" not found"],
+    );
+    // Composition keeps going past the skipped patch.
+    assert_eq!(config_of(&composed[0])["value"], "patched".into());
+}
+
+#[test]
+fn provenance_single_flatten_matches_the_composition_boot_performs() {
+    // Upstream config-dump parity case: layer a's plain config replacement
+    // introduces an entry-shaped row the single-pass index never sees, so
+    // layer b's patch on it warns (attributed to b) and the row stays as
+    // layer a wrote it — b never appears as a patcher of the group row.
+    let base = vec![entry("g", "group")];
+    let layer_a = patches(
+        "\
+- id: g
+  config:
+    - id: child
+      name: pkg
+      config:
+        v: 1
+",
+    );
+    let layer_b = patches("- id: child\n  config:\n    v: 2\n");
+    let layers = [
+        DumpLayer {
+            label: "a.yml",
+            patches: &layer_a,
+        },
+        DumpLayer {
+            label: "b.yml",
+            patches: &layer_b,
+        },
+    ];
+    let (lines, sink) = warning_sink();
+    let (composed, provenance) = compose_with_provenance(&base, "base.yml", &layers, sink);
+    assert_eq!(
+        lines.borrow().to_vec(),
+        ["[b.yml] patch: entry \"child\" not found"]
+    );
+    let introduced = composed[0]
+        .config
+        .as_ref()
+        .and_then(Node::as_array)
+        .unwrap();
+    assert_eq!(
+        introduced[0].as_object().unwrap()["config"]["v"],
+        Node::Int(1)
+    );
+    assert_eq!(
+        provenance,
+        vec![Provenance {
+            origin: "base.yml".into(),
+            patched_by: vec!["a.yml".into()]
+        }],
+    );
+}
+
+// ----------------------------------------------------------- rendering ---
+
+#[test]
+fn dump_renders_grouped_sections_and_round_trips() {
+    let surface = patches(
+        "\
+- id: shared
+  config:
+    value: surface
+    key: ${{ env.DSH_DUMP_SPEC }}
+- insert:
+    - id: surface-extra
+      name: ./noop.mjs
+",
+    );
+    let user = patches("- id: surface-extra\n  config:\n    value: user\n");
+    let layers = [
+        DumpLayer {
+            label: "surface.yml",
+            patches: &surface,
+        },
+        DumpLayer {
+            label: "user.yml",
+            patches: &user,
+        },
+    ];
+    let (composed, _) = compose_with_provenance(&dump_base(), "base.yml", &layers, |_| {});
+    let dump = render_dump(
+        &composed,
+        &[
+            Provenance {
+                origin: "base.yml".into(),
+                patched_by: vec!["surface.yml".into()],
+            },
+            Provenance {
+                origin: "base.yml".into(),
+                patched_by: vec![],
+            },
+            Provenance {
+                origin: "surface.yml".into(),
+                patched_by: vec!["user.yml".into()],
+            },
+        ],
+    )
+    .unwrap();
+
+    // Comments do not break loadability: the dump parses as one document
+    // equal to what a boot would mount.
+    let parsed: Vec<EntryOptions> = serde_yaml_ng::from_str(&dump).unwrap();
+    assert_eq!(parsed, composed);
+
+    // Templates print verbatim, unevaluated.
+    assert!(dump.contains("key: ${{ env.DSH_DUMP_SPEC }}"), "{dump}");
+    // Source separators: origin file plus every layer that changed the row;
+    // an inserted row carries the inserting layer as its origin.
+    assert!(
+        dump.contains("# == base.yml, patched by surface.yml"),
+        "{dump}"
+    );
+    assert!(dump.contains("# == base.yml\n- id: untouched"), "{dump}");
+    assert!(
+        dump.contains("# == surface.yml, patched by user.yml\n- id: surface-extra"),
+        "{dump}"
+    );
+    assert!(
+        dump.find("# == base.yml, patched by surface.yml")
+            < dump.find("# == base.yml\n- id: untouched"),
+        "{dump}"
+    );
+}
+
+#[test]
+fn dump_groups_contiguous_rows_under_one_separator() {
+    let dump = render_config_dump(&dump_base(), "base.yml", &[], |_| {}).unwrap();
+    assert_eq!(dump.matches("# == base.yml").count(), 1);
+    assert!(dump.contains("# == base.yml\n- id: shared"), "{dump}");
+    // The whole document stays loadable.
+    let parsed: Vec<EntryOptions> = serde_yaml_ng::from_str(&dump).unwrap();
+    assert_eq!(parsed, dump_base());
+}
+
+#[test]
+fn dump_via_convenience_matches_the_split_form() {
+    let overlay = patches("- id: shared\n  disabled: true\n");
+    let layers = [DumpLayer {
+        label: "overlay.yml",
+        patches: &overlay,
+    }];
+    let (composed, provenance) = compose_with_provenance(&dump_base(), "base.yml", &layers, |_| {});
+    let split = render_dump(&composed, &provenance).unwrap();
+    let direct = render_config_dump(&dump_base(), "base.yml", &layers, |_| {}).unwrap();
+    assert_eq!(split, direct);
+    assert!(
+        split.contains("# == base.yml, patched by overlay.yml"),
+        "{split}"
+    );
+}
+
+#[test]
+fn dump_renders_group_children_and_entry_field_order() {
+    let base = vec![entry("srv", "group").with_group(vec![
+        entry("adapter-http", "adapter-http").with_config(Node::from_iter([
+            ("port".to_string(), Node::Int(8080)),
+        ])),
+    ])];
+    let dump = render_config_dump(&base, "cordis.yml", &[], |_| {}).unwrap();
+    let parsed: Vec<EntryOptions> = serde_yaml_ng::from_str(&dump).unwrap();
+    assert_eq!(parsed, base);
+    // Field order id/name first, config last — stable in dumps.
+    let id_pos = dump.find("id: srv").expect("id present");
+    let name_pos = dump.find("name: group").expect("name present");
+    let config_pos = dump.rfind("config:").expect("config present");
+    assert!(id_pos < name_pos && name_pos < config_pos, "{dump}");
+}


### PR DESCRIPTION
## Summary

Port the include patch algebra — the composition mechanism upstream dsh shares between boot and `--dump-config` — into `cordis-include` as a new `patch` module. Pure addition, no change to existing behavior: the mechanism layer (patch algebra, provenance export, fail-loud patch-file IO) lives in `cordis-include`; policy (flags, profile resolution, layer ordering) stays with the future CLI.

## What's included

- **`PatchOptions`** — the patch row: `id`-targeted overrides (`config` whole-replacement, `disabled`, `inject`), `insert` lists, `name` as a match guard (never an override). Unknown keys round-trip through `extra` and warn-skip at apply time (`group`, `intercept`, `isolate`, …).
- **`apply_entry_patches`** — THE patch semantics, shared by every consumer: detach-only (the result shares nothing with the inputs, even with no patches), one id index extended by inserts as the same pass adds them, warn-and-skip on every miss. Insert rows without ids warn: they cannot be patched by later layers and restart on every recomposition.
- **`compose_layers`** — all layers flatten into ONE application (the same single call a boot performs, never one call per layer). This is documented as an API contract: the single-pass id index never sees rows a plain `config` replacement introduced inside a group.
- **`compose_with_provenance` + `render_dump` / `render_config_dump`** — upstream's prefix-snapshot diff for origin/patched-by labels, per-layer warning attribution (each snapshot's warning list extends the previous one; the new tail belongs to the added layer), and grouped `# ==` sections that stay one loadable YAML document. `${{ env.X }}` templates print verbatim, unevaluated.
- **`load_overlay_patches` / `load_optional_patches`** — bare top-level-array parsing with the fail-loud contract: a named overlay must exist (missing = hard error), an optional user layer treats missing as "no layer", and a present-but-broken file (unreadable / unparsable / non-array / non-mapping entry) always errors.
- `GROUP_NAME` const alongside `IMPORT_NAME`.

## Porting notes

Upstream stores group children in the `config` array with a `group: true` marker; this crate keeps plugin config in `config` and children in `group`. The settled mapping: group predicate is `name == "group" || !group.is_empty()` (keeps inserts working on a declared-but-childless group), and `group` override patches warn-skip — children replacement is not upstream's marker toggle. The single-flatten corner case is pinned by tests at both the apply and provenance levels, mirroring upstream's `config-dump.spec.ts`.

## Tests

25 new tests in `crates/cordis-include/tests/patch.rs`, aligned with upstream's `config-dump.spec.ts` / `user-patches.spec.ts` / `profile.spec.ts` face: apply semantics (whole-replacement config, name guard, immediate insert indexing, group targets), recomposition-from-originals revert pin, IO fail-loud matrix, single-flatten blindness, provenance labeling, dump round-trips. Full verification gate run against the pinned 1.85 toolchain: fmt, clippy `-D warnings`, workspace tests, doc, README doctests (EN + zh-CN, both carrying a new compiled patch-lists example).