### PR TITLE
feat: add loader document sources (with_document, update)

### DIFF
--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -90,6 +90,58 @@ Reloads compose all involved files into one tree diff; write-back always
 routes mounted entries back to the file they came from (generated ids
 included). Import cycles are reported via `last_error()` and skipped.
 
+## Document sources
+
+[`LoaderConfig::with_document`] composes from an in-memory document
+instead of reading the entry file, and [`Loader::update`] reconciles a
+fresh composition the same way — the layer-based assembly model:
+compose layers offline, then mount the result. Boot then neither reads
+nor writes the file (concurrent
+boots on one shared draft cannot race, and the directory may stay
+read-only), reloads recompose from the stored document while import
+files are still read, and `update` persists nothing — the file stays a
+pure write-back draft:
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+
+# fn main() -> cordis_loader::Result<()> {
+# let mut registry = PluginRegistry::new();
+# registry.register("worker", || {
+#     plugin_sync::<Node, _>("worker", Inject::default(), |_, _| Ok(PluginOutput::none()))
+# });
+let path = std::env::temp_dir().join(format!("cordis-loader-doc-{}.yml", std::process::id()));
+let _ = std::fs::remove_file(&path);
+let root = cordis::Context::new();
+let loader = Loader::open(
+    &root,
+    LoaderConfig::new(&path).with_registry(registry).with_document(Document::with_entries(
+        vec![EntryOptions::new("worker").with_id("w1")],
+    )),
+)?;
+assert!(!path.exists(), "boot touched the draft");
+
+// Recomposition: full diff → stop → patch → start, no write-back.
+let diff = loader.update(Document::with_entries(vec![
+    EntryOptions::new("worker").with_id("w1").with_config(
+        [("port".to_string(), Node::Int(8080))].into_iter().collect(),
+    ),
+]))?;
+assert_eq!(diff.updated.len(), 1);
+assert!(!path.exists(), "recomposition touched the draft");
+
+// The draft is only touched by write-backs:
+loader.update_config("w1", [("port".to_string(), Node::Int(9090))].into_iter().collect())?;
+assert!(path.exists(), "write-back landed in the draft");
+
+loader.dispose()?;
+let _ = std::fs::remove_file(&path);
+# Ok(())
+# }
+```
+
 ## Dynamic library plugins
 
 With the `dynamic` feature, entries can also resolve to plugins compiled
@@ -155,6 +207,12 @@ changes. See the `dynamic` module docs for the full safety model.
   plugin rejects keeps the fiber on its old config and is retried by the
   next reload. Generated ids are persisted afterwards so the next reload
   matches them.
+- **document sources** — `LoaderConfig::with_document` boots from an
+  in-memory document (the file becomes a pure write-back draft, never a
+  composition input), and `Loader::update` reconciles a fresh composition
+  through the same machinery without write-back — the HMR primitive for
+  layer-based composition. Reloads of a document-backed loader recompose
+  from the stored document; only import files are re-read.
 - **dispose** — stop every entry, stop watching files, and release the
   loader's root-level effects (the status listener and the `loader`
   service); a fresh `Loader::open` on the same root works afterwards.
@@ -202,3 +260,5 @@ The [`cordis-cli`](https://crates.io/crates/cordis-cli) runner builds its
 `cordis run` command on top of this crate.
 
 [`Loader::reload`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.reload
+[`Loader::update`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.update
+[`LoaderConfig::with_document`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.LoaderConfig.html#method.with_document

--- a/crates/cordis-loader/README.zh-CN.md
+++ b/crates/cordis-loader/README.zh-CN.md
@@ -89,6 +89,55 @@ entries:
 它们来源的文件（包括生成的 id）。import 环会被记录到 `last_error()` 并
 跳过。
 
+## 文档组合源
+
+[`LoaderConfig::with_document`] 从内存文档组合，而不是读取条目文件；
+[`Loader::update`] 以同样的方式协调一次全新组合 —— 分层装配模型：
+先离线组合各层，再挂载结果。boot 因此既不读也不写该文件（同一份共享
+草稿上的并发 boot 不会竞态，目录也可以保持只读），reload 从存储的文档
+重新组合（import 文件仍会读取），`update` 不落任何盘 —— 文件只是纯
+写回草稿：
+
+```rust
+use cordis::{plugin_sync, Inject, PluginOutput};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+
+# fn main() -> cordis_loader::Result<()> {
+# let mut registry = PluginRegistry::new();
+# registry.register("worker", || {
+#     plugin_sync::<Node, _>("worker", Inject::default(), |_, _| Ok(PluginOutput::none()))
+# });
+let path = std::env::temp_dir().join(format!("cordis-loader-doc-{}.yml", std::process::id()));
+let _ = std::fs::remove_file(&path);
+let root = cordis::Context::new();
+let loader = Loader::open(
+    &root,
+    LoaderConfig::new(&path).with_registry(registry).with_document(Document::with_entries(
+        vec![EntryOptions::new("worker").with_id("w1")],
+    )),
+)?;
+assert!(!path.exists(), "boot touched the draft");
+
+// 重组合：完整 diff → stop → patch → start，不写回。
+let diff = loader.update(Document::with_entries(vec![
+    EntryOptions::new("worker").with_id("w1").with_config(
+        [("port".to_string(), Node::Int(8080))].into_iter().collect(),
+    ),
+]))?;
+assert_eq!(diff.updated.len(), 1);
+assert!(!path.exists(), "recomposition touched the draft");
+
+// 草稿只在写回时被触碰：
+loader.update_config("w1", [("port".to_string(), Node::Int(9090))].into_iter().collect())?;
+assert!(path.exists(), "write-back landed in the draft");
+
+loader.dispose()?;
+let _ = std::fs::remove_file(&path);
+# Ok(())
+# }
+```
+
 ## 动态库插件
 
 启用 `dynamic` feature 后，条目还可以解析为编译成 `cdylib` 库的插件——
@@ -145,6 +194,10 @@ let registry = PluginRegistry::new().with_dynamic_dirs(["/usr/lib/cordis-plugins
   变化原地 patch——被插件拒绝的 patch 会让 fiber 保留旧配置，并在下一
   次 reload 时重试。之后会持久化新生成的 id，让下一次 reload 能匹配
   它们。
+- **文档组合源** —— `LoaderConfig::with_document` 从内存文档 boot
+  （文件变成纯写回草稿，绝不再作为组合输入），`Loader::update` 用同一
+  套机制协调一次全新组合且不写回 —— 分层组合的 HMR 原语。文档组合源
+  loader 的 reload 从存储的文档重新组合；只有 import 文件会被重读。
 - **dispose** —— 停止每个条目，停止文件监视，并释放 loader 的根级
   effect（状态监听器和 `loader` 服务）；之后在同一 root 上重新
   `Loader::open` 依然可用。
@@ -188,3 +241,5 @@ let loader = Loader::open(&root, config)?;
 构建了 `cordis run` 命令。
 
 [`Loader::reload`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.reload
+[`Loader::update`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.Loader.html#method.update
+[`LoaderConfig::with_document`]: https://docs.rs/cordis-loader/latest/cordis_loader/struct.LoaderConfig.html#method.with_document

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -28,6 +28,15 @@
 //!   changes patch in place via `Fiber::update_value`. A corrupt or
 //!   unreadable main file fails the operation instead of silently booting
 //!   an empty tree (import files keep a tolerant record-and-skip path).
+//! - **Document sources** ([`LoaderConfig::with_document`],
+//!   [`Loader::update`]): compose from an in-memory document instead of the
+//!   entry file. Boot then never reads or writes the file — concurrent
+//!   boots on one shared draft cannot race, and the directory may stay
+//!   read-only — while reloads recompose from the stored document (import
+//!   files are still read). `update` reconciles a fresh composition with
+//!   the same diff → stop → patch → start machinery but no write-back,
+//!   making it the HMR primitive for layer-based composition: a watcher
+//!   recomposes and hands the result over.
 //! - **Inject**: an entry's `inject` list is merged into the plugin's own
 //!   declaration, so the core fiber machinery reconciles entries when
 //!   services come and go — "hot-swapped service restarts its dependents"
@@ -40,9 +49,11 @@
 //! - **Write-back**: [`Loader::update_config`] is the runtime entry point —
 //!   it updates the fiber *and* persists the config. Reloads apply their
 //!   patches without writing them back; only newly generated ids are
-//!   persisted. `reload`, `update_config`, and `dispose` serialize through
-//!   one operation lock (reentrant from event listeners), so a
-//!   watch-thread reload cannot interleave with a plugin-thread
+//!   persisted. For a document-backed loader the entry file is a pure
+//!   write-back draft: rows materialized into it never re-enter the
+//!   composition. `reload`, `update`, `update_config`, and `dispose`
+//!   serialize through one operation lock (reentrant from event listeners),
+//!   so a watch-thread reload cannot interleave with a plugin-thread
 //!   `update_config`.
 //!
 //! # Example

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -21,6 +21,12 @@ pub struct LoaderConfig {
     pub filename: PathBuf,
     /// Document written on first run when the file does not exist yet.
     pub initial: Option<cordis_include::Document>,
+    /// Document composed from instead of reading the entry file. When set,
+    /// the file is never read at boot or reload — it only receives
+    /// write-backs (self-disable persistence, id materialization). Takes
+    /// precedence over [`LoaderConfig::initial`], whose boot-time write it
+    /// also suppresses.
+    pub document: Option<cordis_include::Document>,
     /// Plugin registry used to resolve entry names; defaults to a fresh
     /// [`PluginRegistry`] with only the `group` builtin.
     pub registry: Option<PluginRegistry>,
@@ -35,6 +41,7 @@ impl LoaderConfig {
         Self {
             filename: filename.into(),
             initial: None,
+            document: None,
             registry: None,
             write_debounce: None,
         }
@@ -43,6 +50,21 @@ impl LoaderConfig {
     /// Provide the document written when the file is missing.
     pub fn with_initial(mut self, initial: cordis_include::Document) -> Self {
         self.initial = Some(initial);
+        self
+    }
+
+    /// Compose from the given document instead of reading the entry file.
+    ///
+    /// The loader treats the file as a pure write-back draft: nothing is
+    /// read from or written to it at boot, and reloads recompose from this
+    /// document (import files are still read). This is the composition
+    /// source profile boot needs — the naive "compose → write draft →
+    /// open" races between concurrent boots on one profile (another
+    /// process's draft could land between this one's write and read) and
+    /// requires a writable directory. Replace the source at runtime with
+    /// [`Loader::update`].
+    pub fn with_document(mut self, document: cordis_include::Document) -> Self {
+        self.document = Some(document);
         self
     }
 
@@ -86,14 +108,21 @@ pub(crate) struct LoaderInner {
     registry: Mutex<PluginRegistry>,
     state: Mutex<LoaderState>,
     /// Serializes the loader's state transitions end to end — `reload`,
-    /// `update_config`, `dispose`, and deferred self-kill persistence — so
-    /// file reads, tree diffs, fiber patches, and write-backs always run in
-    /// a consistent order. Without it a watch-thread `reload` can interleave
-    /// with a plugin-thread `update_config` and leave the fiber serving a
-    /// different config than the tree and the file claim, with no later
-    /// event to reconcile the difference. Reentrancy-aware because loader
-    /// event listeners legitimately call back into the loader.
+    /// `update`, `update_config`, `dispose`, and deferred self-kill
+    /// persistence — so file reads, tree diffs, fiber patches, and
+    /// write-backs always run in a consistent order. Without it a
+    /// watch-thread `reload` can interleave with a plugin-thread
+    /// `update_config` and leave the fiber serving a different config than
+    /// the tree and the file claim, with no later event to reconcile the
+    /// difference. Reentrancy-aware because loader event listeners
+    /// legitimately call back into the loader.
     operation: OperationLock,
+    /// Composition source override; `None` for file-backed loaders. Set by
+    /// [`LoaderConfig::with_document`] and replaced by every
+    /// [`Loader::update`]: reloads recompose from it instead of re-reading
+    /// the root file (import files are still read), so rows a write-back
+    /// baked into the draft can never re-enter the composition.
+    document: Mutex<Option<cordis_include::Document>>,
     /// Canonical path -> file of every import currently mounted.
     imports: Mutex<HashMap<PathBuf, LoaderFile>>,
     /// Paths already armed by [`Loader::watch`] (watch feature).
@@ -130,7 +159,10 @@ impl Loader {
     /// offending entry simply has no (or a failed) fiber.
     pub fn open(root: &Context, config: LoaderConfig) -> Result<Loader> {
         let file = LoaderFile::open(&config.filename)?;
-        if !file.path().exists() {
+        // A document-backed loader never writes its draft at boot either:
+        // the root file exists only as a write-back target, so `initial`
+        // (a file-backed concern) is ignored entirely.
+        if config.document.is_none() && !file.path().exists() {
             if let Some(initial) = &config.initial {
                 file.write(initial)?;
             }
@@ -140,13 +172,24 @@ impl Loader {
         // files keep the tolerant record-and-skip path inside `compose`.
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
-        let (composed, _dirty) = compose(
-            &file,
-            &mut imports,
-            &mut HashSet::new(),
-            &mut HashSet::new(),
-            &mut errors,
-        )?;
+        let document = config.document;
+        let (composed, _dirty) = match document.clone() {
+            Some(document) => compose_entries(
+                document.entries,
+                &file,
+                &mut imports,
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut errors,
+            ),
+            None => compose(
+                &file,
+                &mut imports,
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut errors,
+            )?,
+        };
         let inner = Arc::new(LoaderInner {
             root: root.clone(),
             file,
@@ -159,6 +202,7 @@ impl Loader {
                 _keep_alive: Vec::new(),
             }),
             operation: OperationLock::default(),
+            document: Mutex::new(document),
             imports: Mutex::new(imports),
             #[cfg(feature = "watch")]
             watched: Mutex::new(HashSet::new()),
@@ -284,83 +328,93 @@ impl Loader {
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
         // Whole-reload exclusion: compose, diff, fiber transitions, and the
-        // id write-back must not interleave with update_config() or dispose().
+        // id write-back must not interleave with update() or update_config()
+        // or dispose().
         let _operation = inner.operation.guard();
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
-        let (composed, dirty) = match compose(
-            &inner.file,
-            &mut imports,
-            &mut HashSet::new(),
-            &mut HashSet::new(),
-            &mut errors,
-        ) {
-            Ok(composed) => composed,
-            Err(error) => {
-                // The current tree is still the last known-good state. In
-                // particular, do not feed an empty list to `EntryTree`:
-                // that would dispose every running plugin on a transient
-                // parse or I/O failure.
-                self.record_error(&error);
-                return Err(error.into());
-            }
+        let (composed, dirty) = match lock(&inner.document).clone() {
+            // A document-backed loader never re-reads its root file: the
+            // file is a write-back draft, and rows a write-back baked into
+            // it would re-enter the composition and duplicate every insert.
+            Some(document) => compose_entries(
+                document.entries,
+                &inner.file,
+                &mut imports,
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut errors,
+            ),
+            None => match compose(
+                &inner.file,
+                &mut imports,
+                &mut HashSet::new(),
+                &mut HashSet::new(),
+                &mut errors,
+            ) {
+                Ok(composed) => composed,
+                Err(error) => {
+                    // The current tree is still the last known-good state. In
+                    // particular, do not feed an empty list to `EntryTree`:
+                    // that would dispose every running plugin on a transient
+                    // parse or I/O failure.
+                    self.record_error(&error);
+                    return Err(error.into());
+                }
+            },
         };
         for error in errors {
             self.record_error(LoaderError::Include(
                 cordis_include::IncludeError::Message { message: error },
             ));
         }
-        let diff = inner.tree.update(composed)?;
-        *lock(&inner.imports) = imports;
-
-        for removed in &diff.removed {
-            if let Err(error) = stop_entry(inner, &removed.entry) {
-                self.record_error(error);
-            }
-        }
-        for entry in &diff.moved {
-            if let Err(error) = stop_entry(inner, entry) {
-                self.record_error(error);
-            }
-        }
-        for entry in &diff.redefined {
-            if let Err(error) = stop_entry(inner, entry) {
-                self.record_error(error);
-            }
-        }
-        for entry in &diff.updated {
-            if let Err(error) = patch_entry(inner, entry) {
-                self.record_error(error);
-            }
-        }
-        for entry in &diff.created {
-            if let Err(error) = start_entry(inner, entry) {
-                self.record_error(error);
-            }
-        }
-
-        // Restart what this reload stopped, parents first so re-parented
-        // entries find their group fibers: moved entries under their new
-        // parents, redefined entries with their new options, and updated
-        // entries that had no live fiber.
-        let mut restarts: Vec<&Entry> = diff
-            .moved
-            .iter()
-            .chain(&diff.redefined)
-            .chain(diff.updated.iter().filter(|entry| entry.fiber().is_none()))
-            .collect();
-        restarts.sort_by_key(|entry| entry_depth(entry));
-        for entry in restarts {
-            if let Err(error) = start_subtree(inner, entry) {
-                self.record_error(error);
-            }
-        }
+        let diff = reconcile(inner, composed, imports)?;
 
         // Entries created without explicit ids had one generated; persist
         // it to the file that owns them so the next reload can match them.
         if dirty {
             write_back(inner)?;
         }
+        #[cfg(feature = "watch")]
+        self.arm_import_watchers();
+        Ok(diff)
+    }
+
+    /// Recompose from a caller-supplied document — the in-memory twin of
+    /// [`reload`](Self::reload): the same full reconcile (diff → stop →
+    /// patch → start) under the same operation lock, but composed from
+    /// `document` instead of any file, and **without write-back**. A
+    /// recomposition is not a file edit (upstream's `internal/update`
+    /// persists nothing either); ids generated for id-less rows stay in
+    /// memory, so those rows restart on every recomposition — the draft is
+    /// regenerated anyway.
+    ///
+    /// The document also becomes the loader's composition source: later
+    /// reloads recompose from it instead of re-reading the root file
+    /// (import files are still read). This is the core HMR primitive — a
+    /// watcher recomposes fresh layers and hands the result to `update`.
+    pub fn update(&self, document: cordis_include::Document) -> Result<TreeDiff> {
+        let inner = &self.inner;
+        // Same exclusion as reload(): the source swap, tree diff, and fiber
+        // transitions must land as one unit.
+        let _operation = inner.operation.guard();
+        let mut imports = HashMap::new();
+        let mut errors = Vec::new();
+        let (composed, _dirty) = compose_entries(
+            document.entries.clone(),
+            &inner.file,
+            &mut imports,
+            &mut HashSet::new(),
+            &mut HashSet::new(),
+            &mut errors,
+        );
+        for error in errors {
+            self.record_error(LoaderError::Include(
+                cordis_include::IncludeError::Message { message: error },
+            ));
+        }
+        *lock(&inner.document) = Some(document);
+        let diff = reconcile(inner, composed, imports)?;
         #[cfg(feature = "watch")]
         self.arm_import_watchers();
         Ok(diff)
@@ -468,7 +522,7 @@ impl Loader {
     }
 
     fn record_error(&self, error: impl std::fmt::Display) {
-        lock(&self.inner.state).last_error = Some(error.to_string());
+        record_error(&self.inner, &error);
     }
 }
 
@@ -554,6 +608,69 @@ fn emit(inner: &LoaderInner, name: &str, args: Vec<Value>) {
     if let Err(error) = inner.root.events().emit(name, args) {
         lock(&inner.state).last_error = Some(format!("{name} listener failed: {error}"));
     }
+}
+
+/// Record a background error against the loader's state.
+fn record_error(inner: &LoaderInner, error: &dyn std::fmt::Display) {
+    lock(&inner.state).last_error = Some(error.to_string());
+}
+
+/// Apply a freshly composed entry list to tree and fibers: commit the tree
+/// diff, stop removed, moved, and redefined subtrees, patch config-only
+/// updates in place, start created entries, and restart what was stopped
+/// (parents first). Transition errors are recorded and the reconcile
+/// continues — the tree is the source of truth and the next pass retries.
+fn reconcile(
+    inner: &LoaderInner,
+    composed: Vec<EntryOptions>,
+    imports: HashMap<PathBuf, LoaderFile>,
+) -> Result<TreeDiff> {
+    let diff = inner.tree.update(composed)?;
+    *lock(&inner.imports) = imports;
+
+    for removed in &diff.removed {
+        if let Err(error) = stop_entry(inner, &removed.entry) {
+            record_error(inner, &error);
+        }
+    }
+    for entry in &diff.moved {
+        if let Err(error) = stop_entry(inner, entry) {
+            record_error(inner, &error);
+        }
+    }
+    for entry in &diff.redefined {
+        if let Err(error) = stop_entry(inner, entry) {
+            record_error(inner, &error);
+        }
+    }
+    for entry in &diff.updated {
+        if let Err(error) = patch_entry(inner, entry) {
+            record_error(inner, &error);
+        }
+    }
+    for entry in &diff.created {
+        if let Err(error) = start_entry(inner, entry) {
+            record_error(inner, &error);
+        }
+    }
+
+    // Restart what this pass stopped, parents first so re-parented entries
+    // find their group fibers: moved entries under their new parents,
+    // redefined entries with their new options, and updated entries that
+    // had no live fiber.
+    let mut restarts: Vec<&Entry> = diff
+        .moved
+        .iter()
+        .chain(&diff.redefined)
+        .chain(diff.updated.iter().filter(|entry| entry.fiber().is_none()))
+        .collect();
+    restarts.sort_by_key(|entry| entry_depth(entry));
+    for entry in restarts {
+        if let Err(error) = start_subtree(inner, entry) {
+            record_error(inner, &error);
+        }
+    }
+    Ok(diff)
 }
 
 /// Start one entry's fiber beneath its parent group's context.
@@ -778,11 +895,10 @@ fn import_canonical(inner: &LoaderInner, entry: &Entry) -> PathBuf {
 /// composed top-level entries and whether any file carried entries without
 /// ids (whose generated ids need persisting).
 ///
-/// `active` holds the files on the current import chain (cycle detection);
-/// `mounted` holds every file mounted anywhere in this compose. The entry
-/// tree keys entries by globally unique id, so the import graph must be a
-/// tree: real cycles and diamonds (the same file mounted twice) are both
-/// reported and their reference dropped, but with distinct diagnoses.
+/// Reading the file passed directly to this call is not recoverable here:
+/// callers loading the main file propagate the error, while callers
+/// mounting an import catch it above themselves and retain the tolerant
+/// skip path.
 fn compose(
     file: &LoaderFile,
     imports: &mut HashMap<PathBuf, LoaderFile>,
@@ -790,15 +906,41 @@ fn compose(
     mounted: &mut HashSet<PathBuf>,
     errors: &mut Vec<String>,
 ) -> cordis_include::Result<(Vec<EntryOptions>, bool)> {
-    // Reading the file passed directly to this call is not recoverable here:
-    // callers loading the main file propagate the error, while callers
-    // mounting an import catch it below and retain the tolerant skip path.
     let document = file.read()?;
-    let mut entries = Vec::with_capacity(document.entries.len());
-    let mut dirty = document.entries.iter().any(|options| options.id.is_none());
-    for mut options in document.entries {
+    Ok(compose_entries(
+        document.entries,
+        file,
+        imports,
+        active,
+        mounted,
+        errors,
+    ))
+}
+
+/// Mount import subtrees under base rows supplied in memory — the entries
+/// half of [`compose`], used by document-backed composition sources
+/// ([`LoaderConfig::with_document`], [`Loader::update`]). `base` resolves
+/// relative import urls. Infallible: import failures follow the tolerant
+/// record-and-skip path.
+///
+/// `active` holds the files on the current import chain (cycle detection);
+/// `mounted` holds every file mounted anywhere in this compose. The entry
+/// tree keys entries by globally unique id, so the import graph must be a
+/// tree: real cycles and diamonds (the same file mounted twice) are both
+/// reported and their reference dropped, but with distinct diagnoses.
+fn compose_entries(
+    entries: Vec<EntryOptions>,
+    base: &LoaderFile,
+    imports: &mut HashMap<PathBuf, LoaderFile>,
+    active: &mut HashSet<PathBuf>,
+    mounted: &mut HashSet<PathBuf>,
+    errors: &mut Vec<String>,
+) -> (Vec<EntryOptions>, bool) {
+    let mut composed = Vec::with_capacity(entries.len());
+    let mut dirty = entries.iter().any(|options| options.id.is_none());
+    for mut options in entries {
         if let Some(url) = options.import_url().map(str::to_owned) {
-            let path = import_path(file, &url);
+            let path = import_path(base, &url);
             let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
             if !active.insert(canonical.clone()) {
                 errors.push(format!("import cycle detected at {}", path.display()));
@@ -837,16 +979,16 @@ fn compose(
                 Err(error) => errors.push(format!(
                     "cannot open import {} ({}: {error})",
                     path.display(),
-                    file.path().display()
+                    base.path().display()
                 )),
             }
             // A file is "active" only while its own subtree composes, so
             // sibling imports of different files never look like cycles.
             active.remove(&canonical);
         }
-        entries.push(options);
+        composed.push(options);
     }
-    Ok((entries, dirty))
+    (composed, dirty)
 }
 
 /// Route `internal/status` disposals: a fiber that reached `Disposed`

--- a/crates/cordis-loader/tests/document.rs
+++ b/crates/cordis-loader/tests/document.rs
@@ -1,0 +1,419 @@
+//! Document-backed composition sources: `LoaderConfig::with_document` and
+//! `Loader::update` — boot from an in-memory document whose entry file is
+//! only ever a write-back draft, and the in-memory recomposition primitive.
+
+use cordis::{Context, Fiber, Inject, PluginHandle, PluginOutput, plugin_sync};
+use cordis_include::{Document, EntryOptions, Node};
+use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn temp_path(stem: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "cordis-loader-doc-test-{stem}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("cordis.yml")
+}
+
+fn cleanup(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}
+
+/// A plugin that records starts.
+fn counting_plugin(name: &'static str, starts: Arc<AtomicUsize>) -> PluginHandle {
+    plugin_sync::<Node, _>(name, Inject::default(), move |_ctx, _config| {
+        starts.fetch_add(1, Ordering::SeqCst);
+        Ok(PluginOutput::none())
+    })
+}
+
+fn counting_registry(starts: &Arc<AtomicUsize>) -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+    let starts = starts.clone();
+    registry.register("worker", move || counting_plugin("worker", starts.clone()));
+    registry
+}
+
+#[test]
+fn open_composes_from_the_document_and_never_touches_the_file() {
+    // The draft directory does not even exist: document-backed boot neither
+    // reads nor writes anything, so read-only (or missing) directories work.
+    let dir = std::env::temp_dir().join(format!(
+        "cordis-loader-doc-test-missing-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    let path = dir.join("nested").join("cordis.yml");
+
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+
+    let entry = loader.tree().resolve("w1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    assert!(!dir.exists(), "boot created the draft directory");
+    assert!(loader.last_error().is_none());
+
+    loader.dispose().unwrap();
+    assert!(!dir.exists());
+}
+
+#[test]
+fn with_document_wins_over_initial_and_suppresses_its_write() {
+    let path = temp_path("precedence");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("from-document"),
+            ]))
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("from-initial"),
+            ])),
+    )
+    .unwrap();
+
+    assert!(loader.tree().resolve("from-document").is_some());
+    assert!(loader.tree().resolve("from-initial").is_none());
+    assert!(
+        !path.exists(),
+        "initial write must not happen for documents"
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn write_back_lands_in_the_draft_file() {
+    let path = temp_path("writeback");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+
+    // update_config is the write-back moment: the draft is created holding
+    // the composed tree with the new config.
+    loader
+        .update_config("w1", Node::from_iter([("port".to_string(), Node::Int(2))]))
+        .unwrap();
+    assert!(path.exists(), "write-back must land in the draft");
+    let reread = loader.file().read().unwrap();
+    assert_eq!(reread.entries.len(), 1);
+    assert_eq!(reread.entries[0].id.as_deref(), Some("w1"));
+    assert_eq!(
+        reread.entries[0].config,
+        Some(Node::from_iter([("port".to_string(), Node::Int(2))]))
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn document_backed_reload_ignores_the_draft_file() {
+    let path = temp_path("draft-ignore");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+                EntryOptions::new("worker").with_id("w2"),
+            ])),
+    )
+    .unwrap();
+
+    // Pollute the draft exactly the way a loader write-back would: composed
+    // rows (and a disable) baked into the root file must never re-enter the
+    // composition or affect the mounted tree.
+    let draft = "entries:\n  - id: rogue\n    name: worker\n  - id: w1\n    name: worker\n    disabled: true\n";
+    std::fs::write(&path, draft).unwrap();
+
+    let diff = loader.reload().unwrap();
+    assert!(diff.created.is_empty() && diff.removed.is_empty());
+    assert!(
+        loader.tree().resolve("rogue").is_none(),
+        "draft row mounted"
+    );
+    let w1 = loader.tree().resolve("w1").unwrap();
+    assert!(w1.fiber().is_some(), "draft disable leaked into the tree");
+    assert!(!w1.options().disabled);
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        draft,
+        "reload rewrote the draft"
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn update_reconciles_without_write_back() {
+    let path = temp_path("update");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker")
+                    .with_id("w2")
+                    .with_config(Node::from_iter([("port".to_string(), Node::Int(1))])),
+                EntryOptions::new("group")
+                    .with_id("g")
+                    .with_group(vec![EntryOptions::new("worker").with_id("w1")]),
+            ])),
+    )
+    .unwrap();
+    let w2_before = loader.tree().resolve("w2").unwrap().fiber().unwrap();
+
+    // Recomposition: w2 config-only (patch in place), w3 and an id-less row
+    // created, the g/w1 subtree removed. The id-less row makes the pass
+    // dirty, but a recomposition is not a file edit — nothing is written.
+    let diff = loader
+        .update(Document::with_entries(vec![
+            EntryOptions::new("worker")
+                .with_id("w2")
+                .with_config(Node::from_iter([("port".to_string(), Node::Int(2))])),
+            EntryOptions::new("worker").with_id("w3"),
+            EntryOptions::new("worker"),
+        ]))
+        .unwrap();
+
+    assert!(diff.updated.iter().any(|entry| entry.id() == "w2"));
+    assert_eq!(diff.created.len(), 2, "w3 and the id-less row");
+    assert!(diff.removed.iter().any(|removed| removed.entry.id() == "g"));
+    // Config-only change: same fiber, patched in place.
+    let w2 = loader.tree().resolve("w2").unwrap();
+    assert!(w2.fiber().unwrap().ptr_eq(&w2_before));
+    for id in ["w2", "w3"] {
+        loader
+            .tree()
+            .resolve(id)
+            .unwrap()
+            .fiber()
+            .unwrap()
+            .try_wait()
+            .unwrap();
+    }
+    // Two starts at open (w1, w2), two more from the update (w3, id-less),
+    // and one apply re-run for w2's in-place patch (same fiber — the ptr_eq
+    // above) — not a stop-and-start cycle, which would need no extra apply.
+    assert_eq!(starts.load(Ordering::SeqCst), 5);
+    assert!(loader.tree().resolve("w1").is_none());
+    assert!(
+        !path.exists(),
+        "dirty rows must stay in memory — no write-back"
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn update_replaces_the_composition_source_for_later_reloads() {
+    let path = temp_path("source");
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+    assert!(path.exists(), "file-backed boot still writes initial");
+
+    // update() makes the document the composition source: a later reload
+    // recomposes from it instead of re-reading the file (which still says w1).
+    loader
+        .update(Document::with_entries(vec![
+            EntryOptions::new("worker").with_id("w2"),
+        ]))
+        .unwrap();
+    loader.reload().unwrap();
+    assert!(loader.tree().resolve("w1").is_none());
+    let w2 = loader.tree().resolve("w2").unwrap();
+    w2.fiber().unwrap().try_wait().unwrap();
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn update_mounts_import_rows() {
+    let path = temp_path("import-row");
+    let services = path.with_file_name("services.yml");
+    std::fs::write(&services, "entries:\n  - id: s1\n    name: worker\n").unwrap();
+    let starts = Arc::new(AtomicUsize::new(0));
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(counting_registry(&starts))
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("m1"),
+            ])),
+    )
+    .unwrap();
+
+    // A composition can insert an import row; its file mounts as a subtree.
+    loader
+        .update(Document::with_entries(vec![
+            EntryOptions::new("worker").with_id("m1"),
+            EntryOptions::new("import")
+                .with_id("imp")
+                .with_config(Node::from_iter([(
+                    "url".to_string(),
+                    "services.yml".into(),
+                )])),
+        ]))
+        .unwrap();
+    let s1 = loader.tree().resolve("imp:s1").unwrap();
+    s1.fiber().unwrap().try_wait().unwrap();
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+    assert!(loader.last_error().is_none());
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+#[test]
+fn concurrent_document_boots_never_write_the_shared_draft() {
+    // The naive "compose → write draft → open" races between concurrent
+    // boots: another process's draft can land between this one's write and
+    // read, and this boot mounts a composition it never made. Document
+    // boots never read or write the draft, so every loader sees exactly its
+    // own document.
+    let path = temp_path("race");
+    let handles: Vec<_> = (0..8)
+        .map(|index| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                let starts = Arc::new(AtomicUsize::new(0));
+                let root = Context::new();
+                let loader = Loader::open(
+                    &root,
+                    LoaderConfig::new(&path)
+                        .with_registry(counting_registry(&starts))
+                        .with_document(Document::with_entries(vec![
+                            EntryOptions::new("worker").with_id(format!("w{index}")),
+                        ])),
+                )
+                .unwrap();
+                let own = format!("w{index}");
+                let entry = loader.tree().resolve(&own).unwrap();
+                entry.fiber().unwrap().try_wait().unwrap();
+                assert_eq!(loader.tree().entries().len(), 1, "mounted a foreign row");
+                assert!(!path.exists(), "a boot wrote the shared draft");
+                loader.dispose().unwrap();
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().expect("concurrent boot thread");
+    }
+    assert!(!path.exists());
+    cleanup(&path);
+}
+
+#[test]
+fn recomposition_drops_a_self_kill_disable_written_to_the_draft() {
+    let path = temp_path("selfkill-drop");
+    let victim_fiber: Arc<Mutex<Option<Fiber>>> = Arc::new(Mutex::new(None));
+    let mut registry = PluginRegistry::new();
+    registry.register("victim", {
+        let victim_fiber = victim_fiber.clone();
+        move || {
+            let victim_fiber = victim_fiber.clone();
+            plugin_sync::<Node, _>("victim", Inject::default(), move |ctx, _config| {
+                *victim_fiber.lock().unwrap() = Some(ctx.fiber()?);
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(registry)
+            .with_document(Document::with_entries(vec![
+                EntryOptions::new("victim").with_id("v1"),
+            ])),
+    )
+    .unwrap();
+    let entry = loader.tree().resolve("v1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+
+    // The plugin tears itself down: the disable persists into the draft
+    // (write-back), deferred off the dying fiber's transition lock.
+    victim_fiber
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap()
+        .dispose()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if entry.fiber().is_none()
+            && std::fs::read_to_string(&path)
+                .unwrap_or_default()
+                .contains("disabled: true")
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "self-kill persistence never landed"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // A fresh recomposition deliberately drops the disable: the patch
+    // composition tree is short-lived, and the draft is never an input.
+    loader
+        .update(Document::with_entries(vec![
+            EntryOptions::new("victim").with_id("v1"),
+        ]))
+        .unwrap();
+    let revived = loader.tree().resolve("v1").unwrap();
+    revived.fiber().unwrap().try_wait().unwrap();
+    assert!(!revived.options().disabled);
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}


### PR DESCRIPTION
## Summary

Two primitives for layer-based composition (bundle/profile boot), per the porting design: mechanisms live in `cordis-loader`, policy (flags, profile resolution, layer ordering) stays with the future CLI. Independent of #51 (touches a different crate; both can land in either order).

## What's included

- **`LoaderConfig::with_document(Document)`** — boot composes from an in-memory document instead of reading the entry file. The file is never read or written at boot — it only receives write-backs (self-disable persistence, id materialization through `update_config`) — so concurrent boots on one shared draft cannot race (the naive "compose → write draft → open" had a window where another process's draft landed between this one's write and read), and the directory may stay read-only or missing entirely. Takes precedence over `with_initial` and suppresses its boot-time write.
- **`Loader::update(Document) -> TreeDiff`** — the in-memory twin of `reload`: the same full reconcile (diff → stop → patch → start) under the same operation lock, composed from the argument instead of any file, **without write-back** (upstream's `internal/update` persists nothing either; ids generated for id-less rows stay in memory, so those rows restart on every recomposition). The document also becomes the loader's composition source — later `reload`s recompose from it while import files are still read. This is the HMR primitive: a watcher recomposes fresh layers and hands the result to `update`.
- `compose` split into a file-reading half and `compose_entries` (base rows supplied in memory, shared by `with_document` and `update`); reload/update share an extracted `reconcile` helper. Import rows inside a composition mount as usual (a patch can insert an import row).

## Draft semantics (pinned by tests)

The entry file of a document-backed loader is a pure write-back draft: rows materialized into it never re-enter the composition, and a self-kill `disabled: true` is deliberately dropped by the next recomposition — the patch composition tree is short-lived, mirroring upstream rewriting the profile root to a constant on every boot.

## Tests

9 new tests in `crates/cordis-loader/tests/document.rs`: open from a document (missing draft directory), `with_document` over `with_initial` precedence, write-back lands in the draft, reload ignores draft pollution (foreign row + disable never re-enter), update reconcile semantics (config-only patched in place on the same fiber, dirty rows stay in memory), composition-source replacement for later reloads, import rows inside an update, 8-way concurrent boot on one shared draft with zero writes, and self-kill disable dropped on recomposition. Full verification gate run against the pinned 1.85 toolchain: fmt, clippy `-D warnings`, workspace tests, doc, README doctests (EN + zh-CN, both carrying a new compiled document-sources example).