### PR TITLE
feat!: !!js expression evaluator and disabled expression slot (W3-2)

### DIFF
--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -56,12 +56,21 @@ expression nodes ([`Node`]) that round-trip verbatim, unevaluated:
 entries:
   - id: srv
     name: group
-    group:
-      - name: adapter-http
-        config:
-          port: 8080
-          host: ${{ env.HOST }}
+  - id: gated
+    name: adapter-http
+    disabled: !!js process.platform === 'win32'
+    config:
+      port: 8080
+      host: ${{ env.HOST }}
+      mode: !!js process.env.DSH_MODE || 'default'
 ```
+
+At hand-off ([`Entry::resolved_config`]) every `!!js` expression evaluates
+through the [`expr`] subset — the `process.*` references the shipped
+bundles use; expressions touching injected context (`ctx.*`,
+`dshHomePath(…)`) fail with a clear subset error. The `disabled` field
+takes the same `!!js` form: the raw text round-trips through the file
+and [`Entry::resolved_disabled`] evaluates it at activation.
 
 ## Patch lists
 
@@ -89,7 +98,7 @@ let user = vec![PatchOptions {
 }];
 let entries = compose_layers(&[bundle, user], |_| {});
 assert_eq!(entries.len(), 1);
-assert!(entries[0].disabled);
+assert!(entries[0].disabled.is_disabled());
 # }
 ```
 
@@ -112,5 +121,8 @@ lifecycle.
 [`apply_entry_patches`]: https://docs.rs/cordis-include/latest/cordis_include/fn.apply_entry_patches.html
 [`compose_layers`]: https://docs.rs/cordis-include/latest/cordis_include/fn.compose_layers.html
 [`render_config_dump`]: https://docs.rs/cordis-include/latest/cordis_include/fn.render_config_dump.html
+[`Entry::resolved_config`]: https://docs.rs/cordis-include/latest/cordis_include/struct.Entry.html#method.resolved_config
+[`Entry::resolved_disabled`]: https://docs.rs/cordis-include/latest/cordis_include/struct.Entry.html#method.resolved_disabled
+[`expr`]: https://docs.rs/cordis-include/latest/cordis_include/expr/index.html
 
 [`Node`]: https://docs.rs/cordis-include/latest/cordis_include/enum.Node.html

--- a/crates/cordis-include/README.zh-CN.md
+++ b/crates/cordis-include/README.zh-CN.md
@@ -52,12 +52,20 @@ assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
 entries:
   - id: srv
     name: group
-    group:
-      - name: adapter-http
-        config:
-          port: 8080
-          host: ${{ env.HOST }}
+  - id: gated
+    name: adapter-http
+    disabled: !!js process.platform === 'win32'
+    config:
+      port: 8080
+      host: ${{ env.HOST }}
+      mode: !!js process.env.DSH_MODE || 'default'
 ```
+
+交接时（[`Entry::resolved_config`]）每个 `!!js` 表达式经由 [`expr`]
+子集求值 —— 即出厂 bundle 用到的 `process.*` 引用；引用注入上下文
+（`ctx.*`、`dshHomePath(…)`）的表达式会带着清晰的子集外错误失败。
+`disabled` 字段接受同样的 `!!js` 形式：原文在文件中原样往返，
+[`Entry::resolved_disabled`] 在条目激活时求值。
 
 ## 补丁列表
 
@@ -83,7 +91,7 @@ let user = vec![PatchOptions {
 }];
 let entries = compose_layers(&[bundle, user], |_| {});
 assert_eq!(entries.len(), 1);
-assert!(entries[0].disabled);
+assert!(entries[0].disabled.is_disabled());
 # }
 ```
 
@@ -105,5 +113,8 @@ assert!(entries[0].disabled);
 [`apply_entry_patches`]: https://docs.rs/cordis-include/latest/cordis_include/fn.apply_entry_patches.html
 [`compose_layers`]: https://docs.rs/cordis-include/latest/cordis_include/fn.compose_layers.html
 [`render_config_dump`]: https://docs.rs/cordis-include/latest/cordis_include/fn.render_config_dump.html
+[`Entry::resolved_config`]: https://docs.rs/cordis-include/latest/cordis_include/struct.Entry.html#method.resolved_config
+[`Entry::resolved_disabled`]: https://docs.rs/cordis-include/latest/cordis_include/struct.Entry.html#method.resolved_disabled
+[`expr`]: https://docs.rs/cordis-include/latest/cordis_include/expr/index.html
 
 [`Node`]: https://docs.rs/cordis-include/latest/cordis_include/enum.Node.html

--- a/crates/cordis-include/src/entry.rs
+++ b/crates/cordis-include/src/entry.rs
@@ -1,9 +1,10 @@
 //! In-memory entry nodes: identity, runtime state, and ancestor walks.
 
-use crate::error::Result;
+use crate::error::{IncludeError, Result};
+use crate::expr::evaluate_node;
 use crate::interpolate::interpolate_node;
 use crate::lock;
-use crate::options::EntryOptions;
+use crate::options::{Disabled, EntryOptions};
 use cordis::Fiber;
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 
@@ -103,11 +104,13 @@ impl Entry {
         self.state().options.config.clone()
     }
 
-    /// The config with `${{ env.NAME }}` templates expanded, ready to be
-    /// handed to a plugin as `cordis_rs::Value::new(node)`.
+    /// The config with `${{ env.NAME }}` templates expanded and every
+    /// `!!js` expression node evaluated, ready to be handed to a plugin
+    /// as `cordis_rs::Value::new(node)`. An out-of-subset expression
+    /// (for example one referencing `ctx.*`) fails here.
     pub fn resolved_config(&self) -> Result<Option<crate::node::Node>> {
         match self.config() {
-            Some(node) => interpolate_node(&node).map(Some),
+            Some(node) => evaluate_node(&interpolate_node(&node)?).map(Some),
             None => Ok(None),
         }
     }
@@ -164,18 +167,59 @@ impl Entry {
         parts.join(":")
     }
 
-    /// Whether this entry is itself flagged as disabled.
+    /// The entry's own disable slot, statically viewed: [`Disabled::Flag`]
+    /// yields the flag, an unevaluated expression does not disable. The
+    /// options snapshot ([`Entry::options`]) carries the raw slot for
+    /// write-back.
     pub fn disabled(&self) -> bool {
-        self.state().options.disabled
+        self.state().options.disabled.is_disabled()
     }
 
-    /// Whether the entry and every ancestor are enabled. A disabled group
-    /// cascades to its whole subtree.
+    /// The entry's own disable state with its `!!js` expression evaluated:
+    /// the expression must evaluate to a boolean, or the error propagates.
+    pub fn resolved_disabled(&self) -> Result<bool> {
+        let disabled = self.state().options.disabled.clone();
+        match disabled {
+            Disabled::Flag(flag) => Ok(flag),
+            Disabled::Expr(source) => match crate::expr::evaluate(&source)? {
+                crate::node::Node::Bool(flag) => Ok(flag),
+                other => Err(IncludeError::JsExpression {
+                    message: format!(
+                        "the disabled expression must evaluate to a boolean, found {}",
+                        crate::yaml::node_kind(&other)
+                    ),
+                    expression: source,
+                }),
+            },
+        }
+    }
+
+    /// Whether this entry and every ancestor are statically enabled. A
+    /// disabled group cascades to its whole subtree. `!!js` expressions
+    /// are *not* evaluated here — an unevaluated expression does not
+    /// disable; use [`Entry::resolved_enabled`] for the evaluated
+    /// decision.
     pub fn enabled(&self) -> bool {
         if self.is_root() {
             return true;
         }
         !self.disabled() && self.parent().is_none_or(|parent| parent.enabled())
+    }
+
+    /// Whether this entry and every ancestor are enabled once their
+    /// `!!js` expressions are evaluated (a disabled group cascades to
+    /// its whole subtree). The first evaluation failure propagates.
+    pub fn resolved_enabled(&self) -> Result<bool> {
+        if self.is_root() {
+            return Ok(true);
+        }
+        if self.resolved_disabled()? {
+            return Ok(false);
+        }
+        match self.parent() {
+            Some(parent) => parent.resolved_enabled(),
+            None => Ok(true),
+        }
     }
 
     /// The fiber started for this entry, if any (set by the loader layer).

--- a/crates/cordis-include/src/error.rs
+++ b/crates/cordis-include/src/error.rs
@@ -57,6 +57,15 @@ pub enum IncludeError {
         /// The unsupported expression.
         expression: String,
     },
+    /// A `!!js` expression failed to parse or falls outside the supported
+    /// subset ([`crate::expr`]).
+    JsExpression {
+        /// The raw expression text.
+        expression: String,
+        /// What went wrong: a syntax problem, an operator or reference
+        /// outside the subset, or an unusable result.
+        message: String,
+    },
     /// A `${{` template was never closed with `}}`.
     Unterminated {
         /// The input containing the dangling `${{`.
@@ -107,6 +116,10 @@ impl fmt::Display for IncludeError {
             Self::UnknownExpression { expression } => {
                 write!(f, "unsupported template expression `{expression}`")
             }
+            Self::JsExpression {
+                expression,
+                message,
+            } => write!(f, "!!js expression `{expression}` failed: {message}"),
             Self::Unterminated { input } => {
                 write!(f, "unterminated template `${{{{`}} in `{input}`")
             }

--- a/crates/cordis-include/src/expr.rs
+++ b/crates/cordis-include/src/expr.rs
@@ -1,0 +1,917 @@
+//! The `!!js` expression subset evaluated at config hand-off.
+//!
+//! Upstream evaluates `!!js` scalars with real JavaScript against the
+//! loader context. The expressions that actually appear in the shipped
+//! bundles only reference `process.*`, so this module evaluates that
+//! subset synchronously — at the same hand-off point as the
+//! `${{ env.NAME }}` interpolation ([`crate::interpolate`]) — with a
+//! hand-written lexer and parser. Expressions referencing injected
+//! context (`ctx.*`, `dshHomePath(…)`) are deferred to the owning
+//! plugin's lazy evaluation and fail here with a clear subset error.
+//!
+//! Supported syntax (JavaScript precedence):
+//!
+//! - the ternary `cond ? then : else`
+//! - `??`, `||`, `&&` with JavaScript truthiness (empty strings and zero
+//!   are falsy); like JavaScript, `??` may not be mixed with `||`/`&&`
+//!   without parentheses
+//! - strict equality `===` / `!==` (loose `==`/`!=` is outside the subset)
+//! - unary `!`
+//! - string literals in single or double quotes, decimal integers and
+//!   floats, `true`/`false`/`null`/`undefined`
+//! - member access limited to `process.platform`, `process.env.NAME`
+//!   (unset variables are `undefined`), and `process.cwd()`
+//!
+//! Values are [`Node`]s directly; `null` and `undefined` both map to
+//! [`Node::Null`], which is also what `??` triggers on.
+
+use crate::error::{IncludeError, Result};
+use crate::node::{Node, NodeMap};
+
+/// Evaluate one `!!js` expression, reading environment variables from the
+/// process environment.
+///
+/// # Errors
+///
+/// Syntax errors, operators or references outside the supported subset,
+/// and an unreadable working directory (for `process.cwd()`) fail with
+/// [`IncludeError::JsExpression`].
+pub fn evaluate(source: &str) -> Result<Node> {
+    evaluate_with(source, &|name| std::env::var(name).ok())
+}
+
+/// Evaluate one `!!js` expression against a caller-supplied environment
+/// lookup, which maps a variable name to its value (`None` when unset).
+pub fn evaluate_with(source: &str, env: &dyn Fn(&str) -> Option<String>) -> Result<Node> {
+    let mut evaluator = Evaluator { source, env };
+    let ast = evaluator.parse()?;
+    evaluator.value(&ast)
+}
+
+/// Recursively evaluate every [`Node::Expr`] in a value tree, leaving all
+/// other nodes untouched — the expression twin of
+/// [`crate::interpolate::interpolate_node`], applied when config is
+/// handed to a plugin.
+pub fn evaluate_node(node: &Node) -> Result<Node> {
+    evaluate_node_with(node, &|name| std::env::var(name).ok())
+}
+
+/// [`evaluate_node`] with a caller-supplied environment lookup.
+pub fn evaluate_node_with(node: &Node, env: &dyn Fn(&str) -> Option<String>) -> Result<Node> {
+    match node {
+        Node::Expr(source) => evaluate_with(source, env),
+        Node::Array(items) => items
+            .iter()
+            .map(|item| evaluate_node_with(item, env))
+            .collect::<Result<Vec<_>>>()
+            .map(Node::Array),
+        Node::Object(map) => {
+            let mut evaluated = NodeMap::new();
+            for (key, value) in map {
+                evaluated.insert(key.clone(), evaluate_node_with(value, env)?);
+            }
+            Ok(Node::Object(evaluated))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+// ---------------------------------------------------------------- lexer ---
+
+/// One lexical token; spans are unnecessary because errors name the
+/// offending text.
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    /// An operator or punctuation this subset supports (`??`, `===`, `(`…).
+    Punct(&'static str),
+    /// A quoted string literal, unescaped.
+    Str(String),
+    /// A decimal integer literal.
+    Int(i64),
+    /// A decimal float literal.
+    Float(f64),
+    /// An identifier or keyword.
+    Ident(String),
+    /// Loose equality (`==` / `!=`), rejected by the parser with a
+    /// targeted message.
+    LooseEq(&'static str),
+    /// An operator JavaScript has and this subset does not (`+`, `<`…).
+    Unsupported(String),
+}
+
+/// Split `source` into tokens.
+fn lex(source: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut rest = source;
+    while let Some(character) = rest.chars().next() {
+        if character.is_whitespace() {
+            rest = &rest[character.len_utf8()..];
+            continue;
+        }
+        // Multi-character operators must win over their prefixes (`===`
+        // before `==` before `!`).
+        let (token, width): (Token, usize) = if rest.starts_with("===") {
+            (Token::Punct("==="), 3)
+        } else if rest.starts_with("!==") {
+            (Token::Punct("!=="), 3)
+        } else if rest.starts_with("??") {
+            (Token::Punct("??"), 2)
+        } else if rest.starts_with("||") {
+            (Token::Punct("||"), 2)
+        } else if rest.starts_with("&&") {
+            (Token::Punct("&&"), 2)
+        } else if rest.starts_with("==") {
+            (Token::LooseEq("=="), 2)
+        } else if rest.starts_with("!=") {
+            (Token::LooseEq("!="), 2)
+        } else if matches!(character, '?' | ':' | '!' | '(' | ')' | '.') {
+            let punct = match character {
+                '?' => "?",
+                ':' => ":",
+                '!' => "!",
+                '(' => "(",
+                ')' => ")",
+                _ => ".",
+            };
+            (Token::Punct(punct), punct.len())
+        } else if character == '\'' || character == '"' {
+            match lex_string(rest) {
+                Some((text, width)) => (Token::Str(text), width),
+                None => (Token::Unsupported(rest.to_owned()), rest.len()),
+            }
+        } else if character.is_ascii_digit() {
+            lex_number(rest)
+        } else if character.is_ascii_alphabetic() || character == '_' || character == '$' {
+            let ident = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '$')
+                .collect::<String>();
+            let width = ident.len();
+            (Token::Ident(ident), width)
+        } else {
+            // Anything else is JavaScript this subset does not take.
+            (
+                Token::Unsupported(character.to_string()),
+                character.len_utf8(),
+            )
+        };
+        rest = &rest[width..];
+        tokens.push(token);
+    }
+    tokens
+}
+
+/// One quoted string literal with JS-style escapes; `None` when the
+/// string is unterminated. Returns the unescaped text and the consumed
+/// width.
+fn lex_string(rest: &str) -> Option<(String, usize)> {
+    let quote = rest.chars().next()?;
+    let mut text = String::new();
+    let mut width = quote.len_utf8();
+    let mut chars = rest[width..].chars();
+    while let Some(character) = chars.next() {
+        width += character.len_utf8();
+        if character == quote {
+            return Some((text, width));
+        }
+        if character == '\n' {
+            return None;
+        }
+        if character == '\\' {
+            let escaped = chars.next()?;
+            width += escaped.len_utf8();
+            text.push(match escaped {
+                'n' => '\n',
+                't' => '\t',
+                'r' => '\r',
+                '0' => '\0',
+                // Unknown escapes collapse to the escaped character, like
+                // JavaScript string literals.
+                other => other,
+            });
+        } else {
+            text.push(character);
+        }
+    }
+    None
+}
+
+/// One decimal number: integer when it fits `i64` and has no fraction or
+/// exponent, float otherwise.
+fn lex_number(rest: &str) -> (Token, usize) {
+    fn digits(slice: &str) -> usize {
+        slice
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .map(char::len_utf8)
+            .sum()
+    }
+    let mut width = digits(rest);
+    let mut is_float = false;
+    if rest[width..].starts_with('.') && rest[width + 1..].starts_with(|c: char| c.is_ascii_digit())
+    {
+        is_float = true;
+        width += 1 + digits(&rest[width + 1..]);
+    }
+    if let Some(tail) = rest[width..].strip_prefix(['e', 'E']) {
+        let signed = tail.strip_prefix(['+', '-']).unwrap_or(tail);
+        let exponent = digits(signed);
+        if exponent > 0 {
+            is_float = true;
+            width += 1 + (tail.len() - signed.len()) + exponent;
+        }
+    }
+    let text = &rest[..width];
+    if !is_float {
+        if let Ok(int) = text.parse::<i64>() {
+            return (Token::Int(int), width);
+        }
+    }
+    match text.parse::<f64>() {
+        Ok(float) => (Token::Float(float), width),
+        Err(_) => (Token::Unsupported(text.to_owned()), width),
+    }
+}
+
+// ----------------------------------------------------------------- ast ---
+
+/// One parsed expression.
+enum Ast {
+    /// A literal value.
+    Literal(Node),
+    /// `process.platform`.
+    Platform,
+    /// `process.env.NAME`.
+    Env(String),
+    /// `process.cwd()`.
+    Cwd,
+    /// `!expr`.
+    Not(Box<Ast>),
+    /// `left ?? right`.
+    Coalesce(Box<Ast>, Box<Ast>),
+    /// `left || right`.
+    Or(Box<Ast>, Box<Ast>),
+    /// `left && right`.
+    And(Box<Ast>, Box<Ast>),
+    /// `left === right` (or `!==` with `negated`).
+    StrictEq {
+        left: Box<Ast>,
+        right: Box<Ast>,
+        negated: bool,
+    },
+    /// `condition ? then : alternative`.
+    Ternary {
+        condition: Box<Ast>,
+        then: Box<Ast>,
+        alternative: Box<Ast>,
+    },
+}
+
+/// Which coalescing/logical operators one parenthesized region used, to
+/// reject JavaScript's illegal `??` / `||` / `&&` mixes.
+#[derive(Default)]
+struct Mixing {
+    saw_coalesce: bool,
+    saw_logical: bool,
+}
+
+/// Parser plus evaluator state: the raw source (for error context) and
+/// the environment lookup.
+struct Evaluator<'a> {
+    source: &'a str,
+    env: &'a dyn Fn(&str) -> Option<String>,
+}
+
+impl Evaluator<'_> {
+    fn error(&self, message: impl Into<String>) -> IncludeError {
+        IncludeError::JsExpression {
+            expression: self.source.to_owned(),
+            message: message.into(),
+        }
+    }
+
+    /// Parse the whole source into one expression.
+    fn parse(&mut self) -> Result<Ast> {
+        let tokens = lex(self.source);
+        let mut parser = Parser {
+            tokens: &tokens,
+            position: 0,
+            evaluator: self,
+        };
+        let mut mixing = Mixing::default();
+        let ast = parser.ternary(&mut mixing)?;
+        match parser.peek() {
+            None => Ok(ast),
+            Some(token) => Err(parser.unexpected(token)),
+        }
+    }
+
+    /// Evaluate a parsed expression to a node.
+    fn value(&self, ast: &Ast) -> Result<Node> {
+        match ast {
+            Ast::Literal(node) => Ok(node.clone()),
+            Ast::Platform => Ok(Node::String(platform().to_owned())),
+            Ast::Env(name) => Ok(match (self.env)(name) {
+                Some(value) => Node::String(value),
+                // `undefined`, like `null`, maps to the null node — the
+                // value `??` triggers on.
+                None => Node::Null,
+            }),
+            Ast::Cwd => match std::env::current_dir() {
+                Ok(dir) => Ok(Node::String(dir.to_string_lossy().into_owned())),
+                Err(error) => Err(self.error(format!("process.cwd() failed: {error}"))),
+            },
+            Ast::Not(inner) => Ok(Node::Bool(!truthy(&self.value(inner)?))),
+            Ast::Coalesce(left, right) => {
+                let left = self.value(left)?;
+                if left.is_null() {
+                    self.value(right)
+                } else {
+                    Ok(left)
+                }
+            }
+            Ast::Or(left, right) => {
+                let left = self.value(left)?;
+                if truthy(&left) {
+                    Ok(left)
+                } else {
+                    self.value(right)
+                }
+            }
+            Ast::And(left, right) => {
+                let left = self.value(left)?;
+                if truthy(&left) {
+                    self.value(right)
+                } else {
+                    Ok(left)
+                }
+            }
+            Ast::StrictEq {
+                left,
+                right,
+                negated,
+            } => {
+                let equal = strict_eq(&self.value(left)?, &self.value(right)?);
+                Ok(Node::Bool(if *negated { !equal } else { equal }))
+            }
+            Ast::Ternary {
+                condition,
+                then,
+                alternative,
+            } => {
+                if truthy(&self.value(condition)?) {
+                    self.value(then)
+                } else {
+                    self.value(alternative)
+                }
+            }
+        }
+    }
+}
+
+/// Node's platform name, matching `process.platform` in JavaScript.
+fn platform() -> &'static str {
+    match std::env::consts::OS {
+        "windows" => "win32",
+        "macos" => "darwin",
+        other => other,
+    }
+}
+
+/// JavaScript truthiness over the value domain: `null`, booleans, zero
+/// numbers, and empty strings are falsy.
+fn truthy(node: &Node) -> bool {
+    match node {
+        Node::Null => false,
+        Node::Bool(value) => *value,
+        Node::Int(value) => *value != 0,
+        Node::UInt(value) => *value != 0,
+        Node::Float(value) => *value != 0.0 && !value.is_nan(),
+        Node::String(value) => !value.is_empty(),
+        Node::Expr(_) | Node::Array(_) | Node::Object(_) => true,
+    }
+}
+
+/// JavaScript `===` over the value domain: numbers compare numerically
+/// across the tree's Int/Float split, everything else only within its
+/// own kind.
+fn strict_eq(left: &Node, right: &Node) -> bool {
+    let numeric = |node: &Node| match node {
+        Node::Int(value) => Some(*value as f64),
+        Node::UInt(value) => Some(*value as f64),
+        Node::Float(value) => Some(*value),
+        _ => None,
+    };
+    match (numeric(left), numeric(right)) {
+        (Some(left), Some(right)) => left == right,
+        (None, None) => left == right,
+        _ => false,
+    }
+}
+
+// --------------------------------------------------------------- parser ---
+
+/// Cursor over the token slice; errors carry the evaluator's source.
+struct Parser<'a, 'b> {
+    tokens: &'a [Token],
+    position: usize,
+    evaluator: &'b Evaluator<'a>,
+}
+
+impl Parser<'_, '_> {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.position)
+    }
+
+    /// Consume `punct` when it is next, reporting whether it was.
+    fn eat(&mut self, punct: &str) -> bool {
+        if matches!(self.peek(), Some(Token::Punct(found)) if *found == punct) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume `punct` or fail with a `found`-aware message.
+    fn expect(&mut self, punct: &str) -> Result<()> {
+        if self.eat(punct) {
+            Ok(())
+        } else {
+            Err(self
+                .evaluator
+                .error(format!("expected `{punct}`{}", self.found_suffix())))
+        }
+    }
+
+    /// Consume one identifier, or fail.
+    fn expect_ident(&mut self) -> Result<String> {
+        match self.peek() {
+            Some(Token::Ident(name)) => {
+                let name = name.clone();
+                self.position += 1;
+                Ok(name)
+            }
+            _ => Err(self
+                .evaluator
+                .error(format!("expected a name{}", self.found_suffix()))),
+        }
+    }
+
+    /// ``, found `??`'' style context for error messages.
+    fn found_suffix(&self) -> String {
+        match self.peek() {
+            Some(token) => format!(", found {}", describe(token)),
+            None => String::new(),
+        }
+    }
+
+    fn unexpected(&self, token: &Token) -> IncludeError {
+        match token {
+            Token::LooseEq(op) => self.evaluator.error(format!(
+                "loose equality `{op}` is outside the supported expression subset (use {})",
+                if *op == "==" { "`===`" } else { "`!==`" }
+            )),
+            Token::Unsupported(text) => self.evaluator.error(format!(
+                "`{text}` is outside the supported expression subset"
+            )),
+            other => self
+                .evaluator
+                .error(format!("unexpected {}", describe(other))),
+        }
+    }
+
+    /// `cond ? then : alternative` — the lowest precedence, right-
+    /// associative in both branches.
+    fn ternary(&mut self, mixing: &mut Mixing) -> Result<Ast> {
+        let condition = self.logical(mixing)?;
+        if !self.eat("?") {
+            return Ok(condition);
+        }
+        // The branches are fresh mixing regions, like parenthesized
+        // subexpressions.
+        let then = self.ternary(&mut Mixing::default())?;
+        self.expect(":")?;
+        let alternative = self.ternary(&mut Mixing::default())?;
+        Ok(Ast::Ternary {
+            condition: Box::new(condition),
+            then: Box::new(then),
+            alternative: Box::new(alternative),
+        })
+    }
+
+    /// `??` / `||` (same precedence, left-associative). JavaScript makes
+    /// mixing `??` with `||`/`&&` in one region a syntax error; so does
+    /// the subset.
+    fn logical(&mut self, mixing: &mut Mixing) -> Result<Ast> {
+        let mut left = self.and_(mixing)?;
+        loop {
+            if self.eat("??") {
+                mixing.saw_coalesce = true;
+                left = Ast::Coalesce(Box::new(left), Box::new(self.and_(mixing)?));
+            } else if self.eat("||") {
+                mixing.saw_logical = true;
+                left = Ast::Or(Box::new(left), Box::new(self.and_(mixing)?));
+            } else {
+                if mixing.saw_coalesce && mixing.saw_logical {
+                    return Err(self.evaluator.error(
+                        "cannot mix `??` with `||`/`&&` without parentheses (JavaScript syntax error)",
+                    ));
+                }
+                return Ok(left);
+            }
+        }
+    }
+
+    /// `&&`, above `||`/`??` like JavaScript.
+    fn and_(&mut self, mixing: &mut Mixing) -> Result<Ast> {
+        let mut left = self.equality()?;
+        while self.eat("&&") {
+            mixing.saw_logical = true;
+            left = Ast::And(Box::new(left), Box::new(self.equality()?));
+        }
+        Ok(left)
+    }
+
+    /// `===` / `!==`.
+    fn equality(&mut self) -> Result<Ast> {
+        let mut left = self.unary()?;
+        loop {
+            let negated = if self.eat("===") {
+                false
+            } else if self.eat("!==") {
+                true
+            } else {
+                return Ok(left);
+            };
+            left = Ast::StrictEq {
+                left: Box::new(left),
+                right: Box::new(self.unary()?),
+                negated,
+            };
+        }
+    }
+
+    /// Unary `!`.
+    fn unary(&mut self) -> Result<Ast> {
+        if self.eat("!") {
+            return Ok(Ast::Not(Box::new(self.unary()?)));
+        }
+        self.primary()
+    }
+
+    /// Literals, parenthesized expressions, and `process.*` references.
+    fn primary(&mut self) -> Result<Ast> {
+        let Some(token) = self.peek().cloned() else {
+            return Err(self.evaluator.error("unexpected end of expression"));
+        };
+        self.position += 1;
+        match token {
+            Token::Punct("(") => {
+                let inner = self.ternary(&mut Mixing::default())?;
+                self.expect(")")?;
+                Ok(inner)
+            }
+            Token::Str(text) => Ok(Ast::Literal(Node::String(text))),
+            Token::Int(value) => Ok(Ast::Literal(Node::Int(value))),
+            Token::Float(value) => Ok(Ast::Literal(Node::Float(value))),
+            Token::Ident(name) => self.ident(name),
+            other => Err(self.unexpected(&other)),
+        }
+    }
+
+    /// Keywords, then the `process.*` member subset; every other
+    /// identifier is outside the subset (injected-context expressions
+    /// evaluate lazily in the owning plugin, not here).
+    fn ident(&mut self, name: String) -> Result<Ast> {
+        match name.as_str() {
+            "true" => Ok(Ast::Literal(Node::Bool(true))),
+            "false" => Ok(Ast::Literal(Node::Bool(false))),
+            "null" | "undefined" => Ok(Ast::Literal(Node::Null)),
+            "process" => self.process_member(),
+            other => Err(self.evaluator.error(format!(
+                "`{other}` is outside the supported expression subset: at config hand-off only \
+                 `process.platform`, `process.env.NAME`, and `process.cwd()` are available \
+                 (injected-context expressions such as `ctx.*` or `dshHomePath(…)` evaluate \
+                 lazily in the owning plugin)"
+            ))),
+        }
+    }
+
+    /// `process.platform` / `process.env.NAME` / `process.cwd()` — the
+    /// only member chains the subset carries.
+    fn process_member(&mut self) -> Result<Ast> {
+        self.expect(".")?;
+        let member = self.expect_ident()?;
+        match member.as_str() {
+            "platform" => Ok(Ast::Platform),
+            "cwd" => {
+                self.expect("(")?;
+                self.expect(")")?;
+                Ok(Ast::Cwd)
+            }
+            "env" => {
+                self.expect(".")?;
+                let name = self.expect_ident()?;
+                Ok(Ast::Env(name))
+            }
+            other => Err(self.evaluator.error(format!(
+                "`process.{other}` is outside the supported expression subset"
+            ))),
+        }
+    }
+}
+
+/// A token's name for error messages.
+fn describe(token: &Token) -> String {
+    match token {
+        Token::Punct(punct) => format!("`{punct}`"),
+        Token::Str(_) => "a string literal".to_owned(),
+        Token::Int(_) => "an integer".to_owned(),
+        Token::Float(_) => "a float".to_owned(),
+        Token::Ident(name) => format!("`{name}`"),
+        Token::LooseEq(op) => format!("`{op}`"),
+        Token::Unsupported(text) => format!("`{text}`"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An environment lookup over fixed pairs.
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let pairs = pairs
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
+            .collect::<Vec<_>>();
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        }
+    }
+
+    fn eval(source: &str, pairs: &[(&str, &str)]) -> Node {
+        evaluate_with(source, &env(pairs)).expect("evaluation")
+    }
+
+    fn error(source: &str) -> String {
+        evaluate_with(source, &|_| None)
+            .expect_err("evaluation must fail")
+            .to_string()
+    }
+
+    // --- the shipped environment-conditioned samples, one by one ---
+
+    #[test]
+    fn bare_env_fetch_yields_the_string_or_null() {
+        assert_eq!(
+            eval(
+                "process.env.DSH_TOOLS_MODE",
+                &[("DSH_TOOLS_MODE", "bundled")]
+            ),
+            Node::String("bundled".to_owned())
+        );
+        assert_eq!(eval("process.env.DSH_TOOLS_MODE", &[]), Node::Null);
+    }
+
+    #[test]
+    fn platform_comparisons_follow_the_host() {
+        let expected = std::env::consts::OS == "windows";
+        assert_eq!(
+            eval("process.platform === 'win32'", &[]),
+            Node::Bool(expected)
+        );
+        assert_eq!(
+            eval("process.platform !== 'win32'", &[]),
+            Node::Bool(!expected)
+        );
+        assert_eq!(
+            eval("process.platform", &[]),
+            Node::String(platform().to_owned())
+        );
+    }
+
+    #[test]
+    fn cwd_is_the_process_working_directory() {
+        let expected = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(eval("process.cwd()", &[]), Node::String(expected));
+    }
+
+    #[test]
+    fn coalesce_falls_back_on_unset_only() {
+        let url = "https://otlp.invalid/v1/logs";
+        let source = "process.env.DSH_TELEMETRY_OTLP_URL ?? 'https://otlp.invalid/v1/logs'";
+        assert_eq!(
+            eval(source, &[("DSH_TELEMETRY_OTLP_URL", url)]),
+            Node::String(url.to_owned())
+        );
+        assert_eq!(eval(source, &[]), Node::String(url.to_owned()));
+        // `??` triggers on null/undefined only — an empty string passes.
+        assert_eq!(
+            eval("process.env.X ?? 'fallback'", &[("X", "")]),
+            Node::String(String::new())
+        );
+    }
+
+    #[test]
+    fn or_falls_back_on_all_falsy_values() {
+        assert_eq!(
+            eval("process.env.DSH_TELEMETRY_MODE || 'DISABLED'", &[]),
+            Node::String("DISABLED".to_owned())
+        );
+        assert_eq!(
+            eval(
+                "process.env.DSH_TELEMETRY_MODE || 'DISABLED'",
+                &[("DSH_TELEMETRY_MODE", "")]
+            ),
+            Node::String("DISABLED".to_owned())
+        );
+        assert_eq!(
+            eval(
+                "process.env.DSH_TELEMETRY_MODE || 'DISABLED'",
+                &[("DSH_TELEMETRY_MODE", "full")]
+            ),
+            Node::String("full".to_owned())
+        );
+    }
+
+    #[test]
+    fn permission_mode_sample_through_the_ternary() {
+        let source = "(process.env.DSH_PERMISSION_MODE ?? 'workspace-write') === 'danger-full-access' ? 'never' : 'ask'";
+        assert_eq!(eval(source, &[]), Node::String("ask".to_owned()));
+        assert_eq!(
+            eval(source, &[("DSH_PERMISSION_MODE", "danger-full-access")]),
+            Node::String("never".to_owned())
+        );
+        // The coalesce fallback feeds the comparison.
+        assert_eq!(
+            eval(source, &[("DSH_PERMISSION_MODE", "workspace-write")]),
+            Node::String("ask".to_owned())
+        );
+    }
+
+    // --- operator semantics ---
+
+    #[test]
+    fn numbers_evaluate_across_the_int_float_split() {
+        assert_eq!(eval("1 === 1.0", &[]), Node::Bool(true));
+        assert_eq!(eval("'1' === 1", &[]), Node::Bool(false));
+        assert_eq!(eval("null === undefined", &[]), Node::Bool(true));
+        assert_eq!(eval("3080", &[]), Node::Int(3080));
+        assert_eq!(eval("1.5", &[]), Node::Float(1.5));
+        assert_eq!(eval("1e3", &[]), Node::Float(1000.0));
+    }
+
+    #[test]
+    fn unary_not_uses_javascript_truthiness() {
+        assert_eq!(eval("!''", &[]), Node::Bool(true));
+        assert_eq!(eval("!0", &[]), Node::Bool(true));
+        assert_eq!(eval("!null", &[]), Node::Bool(true));
+        assert_eq!(eval("!undefined", &[]), Node::Bool(true));
+        assert_eq!(eval("!'x'", &[]), Node::Bool(false));
+        assert_eq!(eval("!process.env.MISSING", &[]), Node::Bool(true));
+    }
+
+    #[test]
+    fn logical_operators_keep_value_semantics() {
+        assert_eq!(eval("false && 'x'", &[]), Node::Bool(false));
+        assert_eq!(eval("'' && 'x'", &[]), Node::String(String::new()));
+        assert_eq!(eval("true && 'x'", &[]), Node::String("x".to_owned()));
+        assert_eq!(eval("'a' || 'b'", &[]), Node::String("a".to_owned()));
+        // && binds tighter than ||, like JavaScript.
+        assert_eq!(
+            eval("false || 'yes' && 'no'", &[]),
+            Node::String("no".to_owned())
+        );
+    }
+
+    #[test]
+    fn nested_ternaries_and_parens() {
+        assert_eq!(
+            eval("true ? false ? 'a' : 'b' : 'c'", &[]),
+            Node::String("b".to_owned())
+        );
+        assert_eq!(
+            eval("(true ? false : true) ? 'a' : 'b'", &[]),
+            Node::String("b".to_owned())
+        );
+    }
+
+    #[test]
+    fn double_quoted_strings_and_escapes() {
+        assert_eq!(
+            eval(r#""double 'quoted'""#, &[]),
+            Node::String("double 'quoted'".to_owned())
+        );
+        assert_eq!(
+            eval(r"'line\nbreak'", &[]),
+            Node::String("line\nbreak".to_owned())
+        );
+        assert_eq!(
+            eval(r#""tab\there""#, &[]),
+            Node::String("tab\there".to_owned())
+        );
+    }
+
+    #[test]
+    fn coalesce_may_not_mix_with_logical_operators() {
+        // JavaScript rejects these without parentheses; so does the subset.
+        assert!(error("process.env.X ?? 'a' || 'b'").contains("mix"));
+        assert!(error("process.env.X ?? 'a' && 'b'").contains("mix"));
+        assert!(error("true || false ?? null").contains("mix"));
+        // Parenthesized regions are separate and fine.
+        assert_eq!(
+            eval("(process.env.X ?? 'a') || 'b'", &[]),
+            Node::String("a".to_owned())
+        );
+    }
+
+    // --- out-of-subset references fail with a clear message ---
+
+    #[test]
+    fn injected_context_references_are_outside_the_subset() {
+        for source in [
+            "ctx.webStartup.trustedHosts",
+            "ctx.webRuntime.trustedHosts",
+            "ctx.headlessStartup.task",
+            "ctx.webStartup.port ?? 3080",
+            "ctx.webStartup.host ?? '127.0.0.1'",
+            "dshHomePath('storages')",
+            "dshHomePath('sessions')",
+        ] {
+            let message = error(source);
+            assert!(message.contains("subset"), "{source}: {message}");
+            assert!(message.contains("process.cwd"), "{source}: {message}");
+        }
+    }
+
+    #[test]
+    fn other_javascript_is_outside_the_subset() {
+        assert!(error("process.foo").contains("subset"));
+        assert!(error("process.env").contains("expected"));
+        assert!(error("process.cwd").contains("expected"));
+        assert!(error("1 == 1").contains("loose equality"));
+        assert!(error("1 != 1").contains("loose equality"));
+        assert!(error("'a' + 'b'").contains("subset"));
+        assert!(error("1 < 2").contains("subset"));
+        assert!(error("typeof 'x'").contains("subset"));
+        assert!(error("env.HOME").contains("subset"));
+    }
+
+    #[test]
+    fn syntax_errors_are_reported() {
+        assert!(error("'unterminated").contains("subset"));
+        assert!(error("process.platform ===").contains("unexpected end"));
+        assert!(error("true ? 'a'").contains("expected `:`"));
+        assert!(error("(true").contains("expected `)`"));
+        assert!(error("true false").contains("unexpected"));
+    }
+
+    #[test]
+    fn evaluate_reads_the_process_environment() {
+        // A name nothing sets: `undefined`, which `??` replaces.
+        let source = "process.env.CORDIS_EXPR_TEST_UNSET_7f3a ?? 'fallback'";
+        assert_eq!(
+            evaluate(source).unwrap(),
+            Node::String("fallback".to_owned())
+        );
+        // The working directory through the public entry point.
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(evaluate("process.cwd()").unwrap(), Node::String(cwd));
+    }
+
+    #[test]
+    fn evaluate_node_recurses_the_tree() {
+        let node = Node::from_iter([
+            ("mode".to_owned(), Node::Expr("process.env.MODE".to_owned())),
+            (
+                "nested".to_owned(),
+                Node::Array(vec![
+                    Node::Expr("process.platform === 'win32'".to_owned()),
+                    Node::String("kept".to_owned()),
+                ]),
+            ),
+        ]);
+        let evaluated =
+            evaluate_node_with(&node, &|name| (name == "MODE").then(|| "fast".to_owned())).unwrap();
+        let map = evaluated.as_object().unwrap();
+        assert_eq!(map["mode"], Node::String("fast".to_owned()));
+        assert_eq!(
+            map["nested"].as_array().unwrap()[0],
+            Node::Bool(std::env::consts::OS == "windows")
+        );
+        assert_eq!(
+            map["nested"].as_array().unwrap()[1],
+            Node::String("kept".to_owned())
+        );
+    }
+}

--- a/crates/cordis-include/src/lib.rs
+++ b/crates/cordis-include/src/lib.rs
@@ -52,8 +52,12 @@
 //! is handed to a plugin ([`Entry::resolved_config`]); the file itself keeps
 //! the template text. `!!js` scalars parse through the crate's own YAML
 //! dialect (the [`yaml`] module) and round-trip as expression nodes
-//! ([`Node::Expr`]), still unevaluated — evaluation of the expression
-//! subset is the loader's hand-off job.
+//! ([`Node::Expr`]). At the same hand-off point every expression evaluates
+//! through the [`expr`] subset — the `process.*` references the shipped
+//! bundles use; injected-context expressions (`ctx.*`, `dshHomePath(…)`)
+//! fail with a clear subset error. The `disabled` field takes the same
+//! `!!js` form (see [`Disabled`]), evaluated at activation through
+//! [`Entry::resolved_disabled`].
 //!
 //! # Patch lists
 //!
@@ -86,6 +90,7 @@
 
 pub mod entry;
 pub mod error;
+pub mod expr;
 pub mod file;
 pub mod interpolate;
 pub mod node;
@@ -99,9 +104,10 @@ pub mod yaml;
 
 pub use entry::{Entry, EntrySuspendGuard};
 pub use error::{IncludeError, Result};
+pub use expr::{evaluate, evaluate_node};
 pub use file::{Document, FileFormat, FileSuspendGuard, LoaderFile};
 pub use node::{Node, NodeMap};
-pub use options::{EntryOptions, GROUP_NAME, IMPORT_NAME};
+pub use options::{Disabled, EntryOptions, GROUP_NAME, IMPORT_NAME};
 pub use patch::{
     DumpLayer, PatchOptions, Provenance, apply_entry_patches, compose_layers,
     compose_with_provenance, load_optional_patches, load_overlay_patches, render_config_dump,

--- a/crates/cordis-include/src/options.rs
+++ b/crates/cordis-include/src/options.rs
@@ -3,9 +3,111 @@
 use crate::node::Node;
 use serde::{Deserialize, Serialize};
 
-/// Whether a boolean is `false` (used by `skip_serializing_if`).
-fn is_false(value: &bool) -> bool {
-    !*value
+/// One entry's disable state: a static flag or a `!!js` expression
+/// evaluated at activation, with the raw text kept for write-back.
+///
+/// The YAML dialect maps `disabled: true` to [`Disabled::Flag`] and
+/// `disabled: !!js <expr>` to [`Disabled::Expr`]; the expression stays
+/// unevaluated in the tree and only takes effect through
+/// [`crate::Entry::resolved_disabled`]. The serde (JSON) path has no
+/// `!!js`, so a flag serializes as a boolean and an expression as its
+/// raw string.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Disabled {
+    /// Statically on/off. The default is off.
+    Flag(bool),
+    /// `disabled: !!js <expr>` — the raw expression, evaluated when the
+    /// entry is activated ([`crate::expr::evaluate`]).
+    Expr(String),
+}
+
+impl Default for Disabled {
+    fn default() -> Self {
+        Self::Flag(false)
+    }
+}
+
+impl Disabled {
+    /// Whether this statically disables the entry. An unevaluated
+    /// expression does not: see [`crate::Entry::resolved_disabled`].
+    pub fn is_disabled(&self) -> bool {
+        matches!(self, Self::Flag(true))
+    }
+
+    /// The raw `!!js` expression text, when the slot holds one.
+    pub fn as_expr(&self) -> Option<&str> {
+        match self {
+            Self::Expr(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Whether the slot is the default (off), used by `skip_serializing_if`.
+fn disabled_is_default(value: &Disabled) -> bool {
+    matches!(value, Disabled::Flag(false))
+}
+
+impl Serialize for Disabled {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Flag(flag) => serializer.serialize_bool(*flag),
+            Self::Expr(source) => serializer.serialize_str(source),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Disabled {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct DisabledVisitor;
+
+        impl serde::de::Visitor<'_> for DisabledVisitor {
+            type Value = Disabled;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a boolean or a `!!js` expression string")
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, value: bool) -> Result<Disabled, E> {
+                Ok(Disabled::Flag(value))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Disabled, E> {
+                Ok(Disabled::Expr(value.to_owned()))
+            }
+
+            fn visit_string<E: serde::de::Error>(self, value: String) -> Result<Disabled, E> {
+                Ok(Disabled::Expr(value))
+            }
+        }
+
+        deserializer.deserialize_any(DisabledVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The serde (JSON) path: flags are booleans, expressions are their raw
+    /// text — JSON has no `!!js`, so a string round-trips the expression.
+    #[test]
+    fn disabled_serde_json_round_trips() {
+        let options: EntryOptions =
+            serde_json::from_str(r#"{"name":"n","disabled":true}"#).unwrap();
+        assert_eq!(options.disabled, Disabled::Flag(true));
+        let options: EntryOptions =
+            serde_json::from_str(r#"{"name":"n","disabled":"process.platform"}"#).unwrap();
+        assert_eq!(
+            options.disabled,
+            Disabled::Expr("process.platform".to_owned())
+        );
+        let text = serde_json::to_string(&options).unwrap();
+        assert_eq!(text, r#"{"name":"n","disabled":"process.platform"}"#);
+        // The default flag is omitted entirely.
+        let text = serde_json::to_string(&EntryOptions::new("n")).unwrap();
+        assert_eq!(text, r#"{"name":"n"}"#);
+    }
 }
 
 /// Entry name that mounts another config file as a subtree
@@ -35,9 +137,11 @@ pub struct EntryOptions {
     /// Plugin name used to resolve the plugin implementation.
     #[serde(default)]
     pub name: String,
-    /// Whether the entry (and transitively its subtree) is disabled.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub disabled: bool,
+    /// Whether the entry (and transitively its subtree) is disabled: a
+    /// static flag, or a `!!js` expression evaluated at activation whose
+    /// raw text round-trips through the file.
+    #[serde(default, skip_serializing_if = "disabled_is_default")]
+    pub disabled: Disabled,
     /// Names of services that must be active before this entry starts.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inject: Vec<String>,
@@ -76,9 +180,10 @@ impl EntryOptions {
         self
     }
 
-    /// Mark the entry (and its subtree) as disabled.
+    /// Set the static disable flag (see [`EntryOptions::disabled`]; use the
+    /// field directly for a `!!js` expression).
     pub fn with_disabled(mut self, disabled: bool) -> Self {
-        self.disabled = disabled;
+        self.disabled = Disabled::Flag(disabled);
         self
     }
 

--- a/crates/cordis-include/src/patch.rs
+++ b/crates/cordis-include/src/patch.rs
@@ -33,7 +33,7 @@
 
 use crate::error::{IncludeError, Result};
 use crate::node::Node;
-use crate::options::{EntryOptions, GROUP_NAME};
+use crate::options::{Disabled, EntryOptions, GROUP_NAME};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -258,7 +258,10 @@ pub fn apply_entry_patches(
             target.config = Some(config.clone());
         }
         if let Some(disabled) = patch.disabled {
-            target.disabled = disabled;
+            // Patches carry an already-evaluated boolean; they overwrite
+            // any expression the target declared (later activation
+            // re-evaluates nothing).
+            target.disabled = Disabled::Flag(disabled);
         }
         if let Some(inject) = patch.inject.as_ref() {
             target.inject = inject.clone();
@@ -299,7 +302,7 @@ pub fn apply_entry_patches(
 /// }];
 /// let entries = compose_layers(&[bundle, user], |_| {});
 /// assert_eq!(entries.len(), 1);
-/// assert!(entries[0].disabled);
+/// assert!(entries[0].disabled.is_disabled());
 /// ```
 pub fn compose_layers(layers: &[Vec<PatchOptions>], warn: impl FnMut(&str)) -> Vec<EntryOptions> {
     let flattened: Vec<PatchOptions> = layers.iter().flatten().cloned().collect();

--- a/crates/cordis-include/src/yaml.rs
+++ b/crates/cordis-include/src/yaml.rs
@@ -23,7 +23,7 @@
 use crate::Document;
 use crate::error::{IncludeError, Result};
 use crate::node::{Node, NodeMap};
-use crate::options::EntryOptions;
+use crate::options::{Disabled, EntryOptions};
 use crate::patch::PatchOptions;
 
 /// The full tag URI js-yaml's `!!js` resolves to.
@@ -633,7 +633,7 @@ fn parse_f64(scalar: &str) -> Option<f64> {
 }
 
 /// A human name for a node kind, for conversion diagnostics.
-fn node_kind(node: &Node) -> &'static str {
+pub(crate) fn node_kind(node: &Node) -> &'static str {
     match node {
         Node::Null => "null",
         Node::Bool(_) => "a boolean",
@@ -749,15 +749,13 @@ fn entry_from_node(node: Node) -> Result<EntryOptions> {
             }
             "disabled" => {
                 entry.disabled = match value {
-                    Node::Bool(flag) => flag,
-                    Node::Expr(_) => {
-                        return Err(yaml_error(
-                            "disabled: !!js expressions are not supported yet",
-                        ));
-                    }
+                    Node::Bool(flag) => Disabled::Flag(flag),
+                    // The raw text round-trips; evaluation happens at
+                    // activation (Entry::resolved_disabled).
+                    Node::Expr(raw) => Disabled::Expr(raw),
                     other => {
                         return Err(yaml_error(format!(
-                            "disabled: expected a boolean, found {}",
+                            "disabled: expected a boolean or a !!js expression, found {}",
                             node_kind(&other)
                         )));
                     }
@@ -816,12 +814,17 @@ pub(crate) fn patch_from_node(node: Node) -> Result<PatchOptions> {
             "name" => patch.name = optional_string(value, "name")?,
             "config" => patch.config = optional_config(value),
             "disabled" => {
+                // The patch override needs an already-evaluated boolean:
+                // patches apply at composition time, before any activation
+                // could evaluate an expression. Entry rows carry the
+                // expression slot instead.
                 patch.disabled = match value {
                     Node::Null => None,
                     Node::Bool(flag) => Some(flag),
                     Node::Expr(_) => {
                         return Err(yaml_error(
-                            "disabled: !!js expressions are not supported yet",
+                            "disabled: !!js expressions are not supported in patches; put the \
+                             expression on the entry itself",
                         ));
                     }
                     other => {
@@ -943,8 +946,16 @@ fn entry_to_node(entry: &EntryOptions) -> Node {
         map.insert("id".to_owned(), Node::String(id.clone()));
     }
     map.insert("name".to_owned(), Node::String(entry.name.clone()));
-    if entry.disabled {
-        map.insert("disabled".to_owned(), Node::Bool(true));
+    match &entry.disabled {
+        // The default flag is omitted; an expression writes its `!!js`
+        // form back for the next boot to re-evaluate.
+        Disabled::Flag(true) => {
+            map.insert("disabled".to_owned(), Node::Bool(true));
+        }
+        Disabled::Expr(raw) => {
+            map.insert("disabled".to_owned(), Node::Expr(raw.clone()));
+        }
+        Disabled::Flag(false) => {}
     }
     if !entry.inject.is_empty() {
         map.insert(
@@ -1325,14 +1336,51 @@ mod tests {
         let error = parse_entry_list("- disabled: maybe\n")
             .unwrap_err()
             .to_string();
-        assert!(error.contains("disabled: expected a boolean"), "{error}");
-        let error = parse_entry_list("- disabled: !!js process.platform\n")
-            .unwrap_err()
-            .to_string();
         assert!(
-            error.contains("disabled: !!js expressions are not supported yet"),
+            error.contains("disabled: expected a boolean or a !!js expression"),
             "{error}"
         );
+        // Patches need an evaluated boolean; entry rows carry expressions.
+        let error = crate::yaml::patch_list_from_node(
+            parse_node("- id: x\n  disabled: !!js process.platform\n").unwrap(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("disabled: !!js expressions are not supported in patches"),
+            "{error}"
+        );
+    }
+
+    /// `disabled` round-trips through both slot forms: the expression's
+    /// raw text survives parse → emit → parse, and the plain flag stays a
+    /// flag (omitted when off).
+    #[test]
+    fn disabled_expressions_round_trip() {
+        let source = "- id: x\n  name: n\n  disabled: !!js process.platform === 'win32'\n";
+        let entries = parse_entry_list(source).unwrap();
+        assert_eq!(
+            entries[0].disabled,
+            Disabled::Expr("process.platform === 'win32'".to_owned())
+        );
+        let text = emit_entry_list(&entries);
+        assert!(
+            text.contains("disabled: !!js process.platform === 'win32'\n"),
+            "{text}"
+        );
+        assert_eq!(parse_entry_list(&text).unwrap(), entries);
+
+        let entries = parse_entry_list("- name: n\n  disabled: true\n").unwrap();
+        assert_eq!(entries[0].disabled, Disabled::Flag(true));
+        let text = emit_entry_list(&entries);
+        assert!(text.contains("disabled: true\n"), "{text}");
+        assert_eq!(parse_entry_list(&text).unwrap(), entries);
+
+        // The off flag is omitted on write.
+        let entries = parse_entry_list("- name: n\n").unwrap();
+        assert_eq!(entries[0].disabled, Disabled::Flag(false));
+        let text = emit_entry_list(&entries);
+        assert!(!text.contains("disabled"), "{text}");
     }
 
     #[test]
@@ -1452,40 +1500,53 @@ mod tests {
     }
 
     /// A bundle-shaped fixture: every field shape the shipped patch files
-    /// use (`id`, `name`, `inject`, `config`, `!!js`), node-level
-    /// round-tripped (the `disabled: !!js` form needs the typed slot the
-    /// next stage adds, so it stays at node level for now).
+    /// use (`id`, `name`, `inject`, `disabled`, `config`, `!!js`),
+    /// round-tripped through the entry list and the patch list.
     #[test]
     fn bundle_shaped_fixture_round_trips() {
-        let fixture = "\
+        let entries = parse_entry_list(
+            "\
 - id: base-sandbox
   name: '@dsh/base'
   inject: [database]
+  disabled: !!js process.platform === 'darwin'
   config:
     level: !!js process.env.DSH_LOG_LEVEL || 'info'
     retries: 3
     nested:
       keep: true
+",
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].disabled,
+            Disabled::Expr("process.platform === 'darwin'".to_owned())
+        );
+        let text = emit_entry_list(&entries);
+        assert_eq!(parse_entry_list(&text).unwrap(), entries, "{text}");
+        assert!(
+            text.contains("disabled: !!js process.platform === 'darwin'"),
+            "{text}"
+        );
+
+        let patches = crate::yaml::patch_list_from_node(
+            parse_node(
+                "\
+- id: base-sandbox
+  config:
+    level: !!js process.env.DSH_LOG_LEVEL || 'info'
 - insert:
     - id: web-app
       name: '@dsh/web-app'
       config:
         theme: dark
         gate: !!js process.platform === 'darwin'
-";
-        let node = parse_node(fixture).unwrap();
-        let emitted = {
-            let mut out = String::new();
-            emit_node(&node, 0, "", &mut out);
-            out
-        };
-        assert_eq!(parse_node(&emitted).unwrap(), node, "{emitted}");
-        assert!(
-            emitted.contains("!!js process.platform === 'darwin'"),
-            "{emitted}"
-        );
-
-        let patches = crate::yaml::patch_list_from_node(parse_node(fixture).unwrap()).unwrap();
+",
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert_eq!(patches.len(), 2);
         assert_eq!(
             patches[1].insert.as_ref().unwrap()[0].id.as_deref(),

--- a/crates/cordis-include/tests/patch.rs
+++ b/crates/cordis-include/tests/patch.rs
@@ -89,7 +89,7 @@ fn overrides_replace_config_wholesale_and_flip_flags() {
         composed[0].config,
         Some(Node::from_iter([("v".to_string(), Node::Int(2))]))
     );
-    assert!(composed[0].disabled);
+    assert!(composed[0].disabled.is_disabled());
     assert_eq!(composed[0].inject, ["database"]);
 }
 
@@ -142,7 +142,7 @@ fn insert_into_group_children_and_indexing_recurses_into_them() {
     let child = &composed[0].group[0];
     assert_eq!(child.id.as_deref(), Some("child"));
     // The inserted row's own group children are indexed too.
-    assert!(child.group[0].disabled);
+    assert!(child.group[0].disabled.is_disabled());
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn name_is_a_guard_not_an_override() {
     );
     // Matching guard applies; mismatched guard warns and skips; an empty
     // guard string is no guard at all (upstream truthiness).
-    assert!(composed[0].disabled);
+    assert!(composed[0].disabled.is_disabled());
     assert_eq!(composed[0].inject, ["empty-guard"]);
     assert_eq!(composed[0].name, "adapter");
     assert_eq!(
@@ -345,14 +345,17 @@ fn recomposition_from_original_data_reverts_removed_patches() {
 
     let with_both =
         apply_entry_patches(&base, &[layer_a.clone(), layer_b.clone()].concat(), |_| {});
-    assert!(with_both[0].disabled);
+    assert!(with_both[0].disabled.is_disabled());
     assert_eq!(
         with_both[0].config,
         Some(Node::from_iter([("v".to_string(), Node::Int(1))]))
     );
 
     let with_a_only = apply_entry_patches(&base, &layer_a, |_| {});
-    assert!(with_a_only[0].disabled, "removing layer b reverts only b");
+    assert!(
+        with_a_only[0].disabled.is_disabled(),
+        "removing layer b reverts only b"
+    );
     assert!(with_a_only[0].config.is_none(), "layer b's write is gone");
 
     // Inputs were never touched: the patch rows still hold their inserts.
@@ -431,7 +434,7 @@ fn layers_patch_rows_earlier_layers_inserted() {
         |_| {},
     );
     assert_eq!(entries.len(), 1);
-    assert!(entries[0].disabled);
+    assert!(entries[0].disabled.is_disabled());
 }
 
 // ------------------------------------------------------------------ IO ---

--- a/crates/cordis-include/tests/yaml.rs
+++ b/crates/cordis-include/tests/yaml.rs
@@ -2,8 +2,8 @@
 //! config files, patch files, and dumps — parse, round-trip, and emit.
 
 use cordis_include::{
-    Document, DumpLayer, EntryOptions, LoaderFile, Node, PatchOptions, load_overlay_patches,
-    render_config_dump,
+    Disabled, Document, DumpLayer, EntryOptions, LoaderFile, Node, PatchOptions,
+    load_overlay_patches, render_config_dump,
 };
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -60,6 +60,34 @@ fn empty_entries_tail_reads_as_an_empty_document() {
 }
 
 #[test]
+fn entry_files_round_trip_disabled_expressions() {
+    let path = temp_path("disabled-expr");
+    let _ = std::fs::remove_file(&path);
+    std::fs::write(
+        &path,
+        "entries:\n  - id: gate\n    name: adapter\n    disabled: !!js process.platform === 'win32'\n",
+    )
+    .unwrap();
+    let file = LoaderFile::open(&path).unwrap();
+    let document = file.read().unwrap();
+    assert_eq!(
+        document.entries[0].disabled,
+        Disabled::Expr("process.platform === 'win32'".to_owned())
+    );
+    file.write(&document).unwrap();
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        text.contains("disabled: !!js process.platform === 'win32'\n"),
+        "{text}"
+    );
+    // Write-back is stable and the expression survives re-reading.
+    file.write(&document).unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), text);
+    assert_eq!(file.read().unwrap(), document);
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn patch_files_keep_expressions_and_reject_them_for_disabled() {
     let path = temp_path("patch-expr");
     let _ = std::fs::remove_file(&path);
@@ -88,8 +116,8 @@ fn patch_files_keep_expressions_and_reject_them_for_disabled() {
     );
     let _ = std::fs::remove_file(&path);
 
-    // Until the typed slot lands, `disabled: !!js` fails loud with a clear
-    // message instead of silently mis-evaluating.
+    // Patch overrides need an evaluated boolean; entry rows carry the
+    // expression slot instead.
     std::fs::write(
         &path,
         "- id: x\n  disabled: !!js process.platform === 'win32'\n",
@@ -97,7 +125,7 @@ fn patch_files_keep_expressions_and_reject_them_for_disabled() {
     .unwrap();
     let error = load_overlay_patches(&path).unwrap_err().to_string();
     assert!(
-        error.contains("disabled: !!js expressions are not supported yet"),
+        error.contains("disabled: !!js expressions are not supported in patches"),
         "{error}"
     );
     let _ = std::fs::remove_file(&path);
@@ -133,5 +161,28 @@ fn dumps_print_expressions_unevaluated() {
     assert_eq!(
         config.as_object().unwrap()["model"],
         Node::Expr("process.env.DSH_MODEL".to_owned())
+    );
+}
+
+/// A `disabled: !!js` slot dumps unevaluated, like the config
+/// expressions — upstream's `--dump-config` never evaluates `!!js`.
+#[test]
+fn dumps_print_disabled_expressions_unevaluated() {
+    let base = [EntryOptions {
+        id: Some("gate".into()),
+        name: "adapter".into(),
+        disabled: Disabled::Expr("process.env.DSH_GATE === 'off'".to_owned()),
+        ..EntryOptions::default()
+    }];
+    let dump = render_config_dump(&base, "base.yml", &[], |_| {}).unwrap();
+    assert!(
+        dump.contains("disabled: !!js process.env.DSH_GATE === 'off'\n"),
+        "{dump}"
+    );
+    // The dump is loadable and the slot round-trips to the expression.
+    let entries = cordis_include::parse_entry_list(&dump).unwrap();
+    assert_eq!(
+        entries[0].disabled,
+        Disabled::Expr("process.env.DSH_GATE === 'off'".to_owned())
     );
 }

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -673,9 +673,15 @@ fn reconcile(
     Ok(diff)
 }
 
-/// Start one entry's fiber beneath its parent group's context.
+/// Start one entry's fiber beneath its parent group's context. The
+/// enabled check resolves `!!js` disabled expressions (own slot and every
+/// ancestor's); an expression that fails to evaluate is a start failure,
+/// recorded by the caller like a resolve failure.
 fn start_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
-    if !entry.enabled() || entry.fiber().is_some() {
+    if entry.fiber().is_some() {
+        return Ok(());
+    }
+    if !entry.resolved_enabled()? {
         return Ok(());
     }
     let name = entry.name();
@@ -735,8 +741,11 @@ fn stop_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
 /// Structural changes (name, inject, enabled) arrive through
 /// `diff.redefined` and never here, so no identity comparison is needed.
 /// Entries without a live fiber are left to the reload's restart phase.
+/// A `!!js` disabled expression that fails to evaluate propagates the
+/// error and leaves the fiber on its current config, retried by the next
+/// reload.
 fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
-    if !entry.enabled() {
+    if !entry.resolved_enabled()? {
         return stop_entry(inner, entry);
     }
     let Some(fiber) = entry.fiber() else {
@@ -1065,7 +1074,11 @@ fn persist_self_dispose(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     }
     entry.set_fiber(None);
     let mut options = entry_options_with_children(entry);
-    options.disabled = true;
+    // The static flag overwrites any `!!js` expression the slot held.
+    // Upstream keeps the raw expression in the options; this port trades
+    // that for the dead entry's final state — the draft is regenerated
+    // (and the expression restored) on every recomposition anyway.
+    options.disabled = cordis_include::Disabled::Flag(true);
     inner
         .tree
         .update_entry(&entry.path(), options, None, None)?;

--- a/crates/cordis-loader/tests/document.rs
+++ b/crates/cordis-loader/tests/document.rs
@@ -166,7 +166,7 @@ fn document_backed_reload_ignores_the_draft_file() {
     );
     let w1 = loader.tree().resolve("w1").unwrap();
     assert!(w1.fiber().is_some(), "draft disable leaked into the tree");
-    assert!(!w1.options().disabled);
+    assert!(!w1.options().disabled.is_disabled());
     assert_eq!(
         std::fs::read_to_string(&path).unwrap(),
         draft,
@@ -412,7 +412,7 @@ fn recomposition_drops_a_self_kill_disable_written_to_the_draft() {
         .unwrap();
     let revived = loader.tree().resolve("v1").unwrap();
     revived.fiber().unwrap().try_wait().unwrap();
-    assert!(!revived.options().disabled);
+    assert!(!revived.options().disabled.is_disabled());
 
     loader.dispose().unwrap();
     cleanup(&path);

--- a/crates/cordis-loader/tests/loader.rs
+++ b/crates/cordis-loader/tests/loader.rs
@@ -324,3 +324,177 @@ fn loader_is_exposed_as_a_weak_service() {
     assert!(handle.upgrade().is_none());
     cleanup(&path);
 }
+
+/// A registry with the counting worker, plus its counter.
+fn worker_registry() -> (PluginRegistry, Arc<AtomicUsize>) {
+    let starts = Arc::new(AtomicUsize::new(0));
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", {
+        let starts = starts.clone();
+        move || counting_plugin("worker", starts.clone())
+    });
+    (registry, starts)
+}
+
+/// `!!js` disabled expressions gate entries by their evaluated result:
+/// the same file starts the entry with the variable unset and skips it
+/// once the expression turns true, and config expressions resolve at the
+/// same hand-off point.
+#[test]
+fn disabled_expressions_gate_entries_by_environment() {
+    // `set_var`/`remove_var` are `unsafe` in edition 2024; the variable is
+    // unique to this test and cleared before it returns.
+    let var = "CORDIS_LOADER_TEST_EXPR_GATE";
+    unsafe { std::env::remove_var(var) };
+    let path = temp_path("expr-gate");
+    std::fs::write(
+        &path,
+        format!(
+            "entries:\n  - id: on\n    name: worker\n    disabled: !!js process.env.{var} === 'off'\n  - id: cfg\n    name: worker\n    config:\n      mode: !!js process.env.{var} ?? 'fallback'\n"
+        ),
+    )
+    .unwrap();
+
+    // Unset: the expression is false, the entry starts, and the config
+    // expression resolved through the hand-off.
+    let (registry, starts) = worker_registry();
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    assert!(loader.tree().resolve("on").unwrap().fiber().is_some());
+    let cfg = loader.tree().resolve("cfg").unwrap();
+    cfg.fiber().unwrap().try_wait().unwrap();
+    let config = cfg.fiber().unwrap().config().downcast::<Node>().unwrap();
+    assert_eq!(config["mode"], Node::String("fallback".to_owned()));
+    assert_eq!(starts.load(Ordering::SeqCst), 2);
+    assert!(loader.last_error().is_none());
+    loader.dispose().unwrap();
+
+    // The expression true: the entry never starts, the sibling still does.
+    unsafe { std::env::set_var(var, "off") };
+    let (registry, starts) = worker_registry();
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    assert!(loader.tree().resolve("on").unwrap().fiber().is_none());
+    assert!(loader.tree().resolve("cfg").unwrap().fiber().is_some());
+    assert_eq!(starts.load(Ordering::SeqCst), 1);
+    assert!(loader.last_error().is_none());
+    unsafe { std::env::remove_var(var) };
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// A disabled expression outside the sync subset (`ctx.*`) is a start
+/// failure: the entry is skipped and the error recorded.
+#[test]
+fn out_of_subset_disabled_expressions_fail_the_start() {
+    let path = temp_path("expr-subset");
+    std::fs::write(
+        &path,
+        "entries:\n  - id: gated\n    name: worker\n    disabled: !!js ctx.webStartup.port ?? 3080\n",
+    )
+    .unwrap();
+    let (registry, _) = worker_registry();
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    let gated = loader.tree().resolve("gated").unwrap();
+    assert!(gated.fiber().is_none());
+    let error = loader.last_error().expect("evaluation failure recorded");
+    assert!(error.contains("subset"), "{error}");
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// A disabled expression evaluating to a non-boolean is a start failure
+/// too: the slot demands a boolean decision.
+#[test]
+fn non_boolean_disabled_expressions_fail_the_start() {
+    let path = temp_path("expr-non-bool");
+    std::fs::write(
+        &path,
+        "entries:\n  - id: gated\n    name: worker\n    disabled: !!js process.platform\n",
+    )
+    .unwrap();
+    let (registry, _) = worker_registry();
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    assert!(loader.tree().resolve("gated").unwrap().fiber().is_none());
+    let error = loader.last_error().expect("evaluation failure recorded");
+    assert!(error.contains("boolean"), "{error}");
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// A config expression outside the subset fails the entry's start the
+/// same way a disabled expression does.
+#[test]
+fn out_of_subset_config_expressions_fail_the_start() {
+    let path = temp_path("expr-config-subset");
+    std::fs::write(
+        &path,
+        "entries:\n  - id: cfg\n    name: worker\n    config:\n      port: !!js dshHomePath('storages')\n",
+    )
+    .unwrap();
+    let (registry, _) = worker_registry();
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    assert!(loader.tree().resolve("cfg").unwrap().fiber().is_none());
+    let error = loader.last_error().expect("evaluation failure recorded");
+    assert!(error.contains("subset"), "{error}");
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// Self-dispose persistence overwrites a `!!js` disabled slot with the
+/// static flag — the entry is dead, and recomposition regenerates the
+/// expression from its source anyway.
+#[test]
+fn self_dispose_overwrites_a_disabled_expression_with_the_flag() {
+    let path = temp_path("expr-selfkill");
+    std::fs::write(
+        &path,
+        "entries:\n  - id: v1\n    name: victim\n    disabled: !!js process.platform === 'never'\n",
+    )
+    .unwrap();
+    let victim_fiber: Arc<Mutex<Option<Fiber>>> = Arc::new(Mutex::new(None));
+    let mut registry = PluginRegistry::new();
+    registry.register("victim", {
+        let victim_fiber = victim_fiber.clone();
+        move || {
+            let victim_fiber = victim_fiber.clone();
+            plugin_sync::<Node, _>("victim", Inject::default(), move |ctx, _config| {
+                *victim_fiber.lock().unwrap() = Some(ctx.fiber()?);
+                Ok(PluginOutput::none())
+            })
+        }
+    });
+    let root = Context::new();
+    let loader = Loader::open(&root, LoaderConfig::new(&path).with_registry(registry)).unwrap();
+    let entry = loader.tree().resolve("v1").unwrap();
+    entry.fiber().unwrap().try_wait().unwrap();
+
+    victim_fiber
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap()
+        .dispose()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let text = std::fs::read_to_string(&path).unwrap();
+        if entry.fiber().is_none() && text.contains("disabled: true") {
+            assert!(
+                !text.contains("!!js"),
+                "expression must be overwritten: {text}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "self-kill persistence never landed: {text}"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    loader.dispose().unwrap();
+    cleanup(&path);
+}


### PR DESCRIPTION
## Summary

W3-2 of the bundle/profile plan (HANDOFF-bundle-profile §4.3, second half): the `!!js` expression evaluator and the `EntryOptions.disabled` expression slot. **This is the planned breaking-change node of the W3 line.**

- **`Disabled` slot (breaking)** — `EntryOptions.disabled` is now an enum: `Flag(bool)` / `Expr(String)`. `disabled: !!js <expr>` parses through the crate's YAML dialect and round-trips verbatim (write-back preserves the raw text, `Flag(false)` stays omitted). The serde/JSON path maps `Flag` ↔ boolean and `Expr` ↔ raw string. Patch overrides still demand an evaluated boolean (`PatchOptions.disabled: Option<bool>` unchanged) and `apply_entry_patches` writes `Disabled::Flag`, per the design.
- **`expr` module** — hand-written lexer + parser for the subset the shipped bundles actually use: `process.env.NAME` (unset → null), `process.platform`, `process.cwd()`, ternary, `??`/`||`/`&&` with JS truthiness (empty string/zero falsy) and JS's no-mixing rule for `??`, `===`/`!==` (loose `==`/`!=` rejected), `!`, string/number/`true`/`false`/`null`/`undefined` literals. Results are `Node`s directly. Out-of-subset references (`ctx.*`, `dshHomePath(…)`, arithmetic, …) fail with a clear "outside the supported expression subset" error — the acceptance criterion.
- **Hand-off wiring** — `Entry::resolved_config` now evaluates every `Node::Expr` at the same point as the `${{ env.* }}` interpolation; `Entry::resolved_disabled` / `resolved_enabled` evaluate the slot and the whole ancestor chain. The loader's `start_entry`/`patch_entry` use the resolved state: evaluation failure is a start failure (recorded in `last_error`, entry skipped / fiber untouched). Self-dispose persistence overwrites the slot with `Flag(true)` — deviation from upstream (which keeps the raw expression in options) noted in a comment; the draft is regenerated on every recomposition anyway. `--dump-config`-style dumps keep printing `disabled: !!js` unevaluated.

## Tests

- `expr` unit tests: every shipped environment-conditioned sample (env fetch, platform compare, cwd, both `??` and `||` fallbacks, the permission-mode ternary), truthiness/value semantics, Int/Float `===` bridging, no-mixing errors, out-of-subset errors (subset in message), syntax errors.
- YAML: entry-level round trip of `disabled: !!js` / `disabled: true` / omitted `false`; patch-level rejection message; bundle-shaped fixture; `LoaderFile` write-back stability.
- Loader integration: env-controlled gating both directions (config expressions resolve at hand-off in the same test), out-of-subset disabled/config expressions → `last_error` + entry skipped, non-boolean disabled → error, self-dispose overwrites the expression with the flag.
- Dump: `disabled: !!js` printed verbatim and re-loadable.

## Verification

Full AGENTS gate: fmt → clippy 1.85 (`-D warnings`) → clippy 1.96 double-pass → `cargo test --workspace` (33 binaries green) → `cargo doc --workspace --no-deps` → all 8 README doctest runs (CI-identical flags).

BREAKING CHANGE: `EntryOptions.disabled` changed from `bool` to the new `Disabled` enum.