### PR TITLE
fix: stop the lib/bin rustdoc output collision between cordis-rs and cordis-cli

### DIFF
--- a/crates/cordis-cli/Cargo.toml
+++ b/crates/cordis-cli/Cargo.toml
@@ -13,6 +13,11 @@ readme = "README.md"
 [[bin]]
 name = "cordis"
 path = "src/main.rs"
+# The bin shares its rustdoc output path (`doc/cordis/`) with the
+# `cordis` lib of cordis-rs; cargo documents both in parallel and they
+# clobber each other (rust-lang/cargo#6313). The CLI has no rustdoc
+# content of its own, so keep it out of `cargo doc` entirely.
+doc = false
 
 [dependencies]
 cordis-loader = { workspace = true, features = ["watch", "dynamic"] }


### PR DESCRIPTION
## Summary

The release PR #58's CI failed at `cargo doc --locked --workspace --no-deps --all-features` with I/O errors like `doc/cordis/reflect/struct.Accessor.html: No such file or directory`, preceded by:

```
warning: output filename collision at target/doc/cordis/index.html
note: the lib target `cordis` in package `cordis-rs` has the same output filename
as the bin target `cordis` in package `cordis-cli`
```

Root cause: the known cargo bug [rust-lang/cargo#6313](https://github.com/rust-lang/cargo/issues/6313) — the cordis-rs lib and the cordis-cli bin are both named `cordis`, so the two parallel rustdoc jobs document into the same `doc/cordis/` directory and race; the loser's files get deleted mid-write. It's nondeterministic: PR #57's runs and the main merge were green, only this run lost the race.

Fix: `doc = false` on the `[[bin]]` target — the CLI binary has no rustdoc content of its own, and this removes the collision deterministically instead of rerolling the dice on every release PR.

## Verification

CI-identical `cargo doc --locked --workspace --no-deps --all-features` passes locally with zero collision warnings, plus the full AGENTS gate (fmt, clippy `-D warnings`, `cargo test --workspace` — 33 binaries green, all 8 README doctest runs).