### PR TITLE
docs: align READMEs with the W1-W3 assembly-layer features

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,16 +322,22 @@ crates that build on it:
 
 | Crate | Purpose |
 | --- | --- |
-| [`cordis-include`](../crates/cordis-include) | Config entry trees, YAML/JSON loader files, `${{ env.NAME }}` interpolation, atomic and debounced writes |
+| [`cordis-include`](../crates/cordis-include) | Config entry trees, YAML/JSON loader files, patch lists with provenance dumps (bundle/profile composition), the tag-preserving `!!js` dialect with expression evaluation, `${{ env.NAME }}` interpolation, atomic and debounced writes |
 | [`cordis-group`](../crates/cordis-group) | Group plugin: nested entries with cascading disable |
-| [`cordis-loader`](../crates/cordis-loader) | Plugin registry + entry↔fiber state machine, cross-file `import` entries, hot reload, lifecycle events, debounced write-backs, dynamic-library plugins (`dynamic` feature) |
+| [`cordis-loader`](../crates/cordis-loader) | Plugin registry + entry↔fiber state machine, cross-file `import` entries, document-backed composition sources (`with_document` / `update`), hot reload, lifecycle events, debounced write-backs, dynamic-library plugins (`dynamic` feature) |
 | [`cordis-cli`](../crates/cordis-cli) | `cordis run` executable: daemon/worker exit-code protocol, signals, dotenv, plugin-library hot restarts |
 
 Ported so far: static plugin registry, groups, `import` sub-files, self-kill
 detection, entry-level inject, config hot reload, the `loader/*` event
-family, debounced writes, the daemon/worker runner, and dynamic-library
-plugins with worker-restart HMR (`cordis-loader`'s `dynamic` feature plus
-`cordis run --plugin-dir`). Not yet ported: isolate / service migration.
+family, debounced writes, bundle/profile patch composition with
+provenance-aware dumps (`apply_entry_patches` / `compose_layers` /
+`render_config_dump`), a tag-preserving `!!js` YAML dialect with the
+expression subset evaluated at config hand-off (including the
+`disabled: !!js` slot), document-backed composition with in-memory
+recomposition, the daemon/worker runner, and dynamic-library plugins with
+worker-restart HMR (`cordis-loader`'s `dynamic` feature plus
+`cordis run --plugin-dir`). Not yet ported: isolate / service migration,
+arbitrary-JavaScript expressions beyond the shipped subset.
 
 ## Project layout
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -321,15 +321,19 @@ TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采�
 
 | Crate | 用途 |
 | --- | --- |
-| [`cordis-include`](../crates/cordis-include) | 配置条目树、YAML/JSON 配置文件、`${{ env.NAME }}` 插值、原子写与防抖合并写 |
+| [`cordis-include`](../crates/cordis-include) | 配置条目树、YAML/JSON 配置文件、补丁列表与溯源导出（bundle/profile 组合）、保真 `!!js` 方言与表达式求值、`${{ env.NAME }}` 插值、原子写与防抖合并写 |
 | [`cordis-group`](../crates/cordis-group) | 分组插件：嵌套条目与级联禁用 |
-| [`cordis-loader`](../crates/cordis-loader) | 插件注册表 + 条目↔fiber 状态机、跨文件 `import` 条目、配置热重载、生命周期事件、防抖写回、动态库插件（`dynamic` feature） |
+| [`cordis-loader`](../crates/cordis-loader) | 插件注册表 + 条目↔fiber 状态机、跨文件 `import` 条目、文档组合源（`with_document` / `update`）、配置热重载、生命周期事件、防抖写回、动态库插件（`dynamic` feature） |
 | [`cordis-cli`](../crates/cordis-cli) | `cordis run` 可执行入口：daemon/worker 退出码协议、信号、dotenv、插件库热重启 |
 
 已移植：静态插件注册表、分组、`import` 子文件、自杀判别、entry 级
-inject、配置热重载、`loader/*` 事件族、防抖写、daemon/worker 运行器，
-以及动态库插件 + worker 重启式 HMR（`cordis-loader` 的 `dynamic`
-feature 与 `cordis run --plugin-dir`）。尚未移植：isolate / 服务迁移.
+inject、配置热重载、`loader/*` 事件族、防抖写、bundle/profile 补丁组合
+与溯源导出（`apply_entry_patches` / `compose_layers` /
+`render_config_dump`）、保真 `!!js` YAML 方言（表达式子集在配置交接时
+求值，含 `disabled: !!js` 槽位）、文档组合源与内存重组合、
+daemon/worker 运行器，以及动态库插件 + worker 重启式 HMR
+（`cordis-loader` 的 `dynamic` feature 与 `cordis run --plugin-dir`）。
+尚未移植：isolate / 服务迁移、超出出厂子集的任意 JavaScript 表达式。
 
 ## 项目结构
 

--- a/crates/cordis-group/README.md
+++ b/crates/cordis-group/README.md
@@ -8,8 +8,8 @@ Nested plugin groups with cascading disable for the
 A group is an entry with a `group` array in the config file. At runtime the
 loader starts each group as a [`Group`] fiber and starts the child entries
 *beneath that fiber's context*: disposing the group cascades to the whole
-subtree, and a `disabled` flag anywhere on the ancestor chain keeps the
-subtree from starting at all.
+subtree, and a `disabled` slot anywhere on the ancestor chain — a plain
+flag or a `!!js` expression — keeps the subtree from starting at all.
 
 ```yaml
 entries:

--- a/crates/cordis-group/README.zh-CN.md
+++ b/crates/cordis-group/README.zh-CN.md
@@ -8,7 +8,7 @@
 group 是配置文件中携带 `group` 数组的条目。运行时 loader 会把每个 group
 作为一个 [`Group`] fiber 启动，并把子条目启动在**该 fiber 的 context
 之下**：销毁 group 会级联到整棵子树，而祖先链上任意位置的 `disabled`
-标志都会让整棵子树从一开始就不启动。
+槽位（纯标志或 `!!js` 表达式）都会让整棵子树从一开始就不启动。
 
 ```yaml
 entries:

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -8,8 +8,10 @@ Config entry trees and YAML/JSON loader files for the
 This crate is the data half of porting upstream Cordis' loader: it maps
 between config files on disk and an in-memory tree of entries, preserving
 object key order for diff-friendly files, expanding `${{ env.NAME }}`
-templates, and providing the suspend guards that break the
-write → watch → write feedback loop.
+templates, evaluating the `!!js` expression subset at hand-off, carrying
+the patch algebra behind bundle/profile composition (apply, layer
+composition, provenance dumps), and providing the suspend guards that
+break the write → watch → write feedback loop.
 
 ```text
 ┌─ cordis-loader   assembly: plugin registry + fiber state machine

--- a/crates/cordis-include/README.zh-CN.md
+++ b/crates/cordis-include/README.zh-CN.md
@@ -6,8 +6,10 @@
 与 YAML/JSON 配置文件。
 
 本 crate 是 Cordis loader 移植的数据层：它在磁盘配置文件与内存条目树之间
-做映射，为 diff 友好的文件保留对象键序，展开 `${{ env.NAME }}` 模板，并提供
-用于打断 write → watch → write 反馈回路的 suspend guard。
+做映射，为 diff 友好的文件保留对象键序，展开 `${{ env.NAME }}` 模板，在
+交接时求值 `!!js` 表达式子集，承载 bundle/profile 组合背后的补丁代数
+（应用、分层组合、溯源导出），并提供用于打断 write → watch → write
+反馈回路的 suspend guard。
 
 ```text
 ┌─ cordis-loader   组装层：插件注册表 + fiber 状态机

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -213,6 +213,13 @@ changes. See the `dynamic` module docs for the full safety model.
   through the same machinery without write-back — the HMR primitive for
   layer-based composition. Reloads of a document-backed loader recompose
   from the stored document; only import files are re-read.
+- **expressions** — `!!js` scalars (config values and the `disabled` slot)
+  evaluate at activation through cordis-include's `process.*` subset; a
+  disabled expression decides whether the entry (and its subtree) starts,
+  and an out-of-subset or failing expression fails that entry's start and
+  is recorded in `last_error()` (on the patch path the fiber keeps its
+  current config and the next reload retries). Files and dumps keep the
+  raw expression text.
 - **dispose** — stop every entry, stop watching files, and release the
   loader's root-level effects (the status listener and the `loader`
   service); a fresh `Loader::open` on the same root works afterwards.

--- a/crates/cordis-loader/README.zh-CN.md
+++ b/crates/cordis-loader/README.zh-CN.md
@@ -198,6 +198,11 @@ let registry = PluginRegistry::new().with_dynamic_dirs(["/usr/lib/cordis-plugins
   （文件变成纯写回草稿，绝不再作为组合输入），`Loader::update` 用同一
   套机制协调一次全新组合且不写回 —— 分层组合的 HMR 原语。文档组合源
   loader 的 reload 从存储的文档重新组合；只有 import 文件会被重读。
+- **表达式** —— `!!js` 标量（配置值与 `disabled` 槽位）在激活时经
+  cordis-include 的 `process.*` 子集求值；disabled 表达式决定该条目
+  （及其子树）是否启动，子集外或求失败的表达式使该条目启动失败并记
+  录进 `last_error()`（patch 路径上 fiber 保留当前配置，下一次 reload
+  重试）。文件与 dump 始终保留表达式原文。
 - **dispose** —— 停止每个条目，停止文件监视，并释放 loader 的根级
   effect（状态监听器和 `loader` 服务）；之后在同一 root 上重新
   `Loader::open` 依然可用。


### PR DESCRIPTION
## Summary

README audit against the merged W1–W3 work (patch algebra, YAML dialect + expression evaluation, document-backed composition). The code-level docs (crate docs, API docs) were already updated with each PR; these were the stale spots:

- **Root READMEs (en/zh)** — the ecosystem table and the "ported so far" paragraph predated W1/W2/W3: `cordis-include` didn't mention patch lists/provenance dumps or the `!!js` dialect, `cordis-loader` didn't mention document-backed composition. Now they list `apply_entry_patches`/`compose_layers`/`render_config_dump`, the tag-preserving `!!js` dialect with hand-off evaluation (including the `disabled: !!js` slot), and `with_document`/`update`. "Not yet ported" now also names arbitrary-JS expressions beyond the shipped subset.
- **cordis-include READMEs (en/zh)** — intro now names the patch algebra and expression evaluation alongside interpolation and suspend guards.
- **cordis-loader READMEs (en/zh)** — the state-machine list gains an **expressions** bullet: activation-time evaluation through the `process.*` subset, `last_error()` on failed/out-of-subset evaluation, fiber keeps its config on the patch path, raw text preserved in files and dumps.
- **cordis-group READMEs (en/zh)** — the cascade sentence now says the `disabled` slot accepts a plain flag or a `!!js` expression.

cordis-cli READMEs describe the process model only and needed no change.

## Verification

Full AGENTS gate: fmt (no-op), clippy `-D warnings`, `cargo test --workspace` (33 binaries green), `cargo doc --workspace --no-deps`, all 8 README doctest runs.