### PR TITLE
fix: address all seven findings from the 2026-08-19 code review (REV-01 .. REV-07)

### DIFF
--- a/crates/cordis-include/src/entry.rs
+++ b/crates/cordis-include/src/entry.rs
@@ -136,6 +136,11 @@ impl Entry {
     /// Replace the child list, re-pointing moved-in children and clearing
     /// the parent link of children that were dropped. Detached children
     /// keep their own subtrees intact for teardown.
+    ///
+    /// A dropped child that is no longer *ours* is left alone: during a
+    /// whole-tree update a nested `set_children` pass may have re-parented
+    /// it already (a top-level entry moved into a group), and clearing
+    /// that fresh link would orphan the entry from ancestor cascades.
     pub(crate) fn set_children(&self, new_children: Vec<Entry>) {
         let old_children = {
             let mut state = self.state();
@@ -146,7 +151,7 @@ impl Entry {
         }
         for child in &old_children {
             let still_present = new_children.iter().any(|kept| Entry::ptr_eq(kept, child));
-            if !still_present {
+            if !still_present && child.parent().is_some_and(|p| Entry::ptr_eq(&p, self)) {
                 child.state().parent = None;
             }
         }

--- a/crates/cordis-include/src/expr.rs
+++ b/crates/cordis-include/src/expr.rs
@@ -17,8 +17,9 @@
 //!   without parentheses
 //! - strict equality `===` / `!==` (loose `==`/`!=` is outside the subset)
 //! - unary `!`
-//! - string literals in single or double quotes, decimal integers and
-//!   floats, `true`/`false`/`null`/`undefined`
+//! - string literals in single or double quotes with JavaScript escapes
+//!   (`\n`-style plus `\xNN`, `\uNNNN`, and `\u{…}`), decimal integers
+//!   and floats, `true`/`false`/`null`/`undefined`
 //! - member access limited to `process.platform`, `process.env.NAME`
 //!   (unset variables are `undefined`), and `process.cwd()`
 //!
@@ -163,37 +164,105 @@ fn lex(source: &str) -> Vec<Token> {
 
 /// One quoted string literal with JS-style escapes; `None` when the
 /// string is unterminated. Returns the unescaped text and the consumed
-/// width.
+/// width. `\xNN`, `\uNNNN`, and `\u{…}` decode like JavaScript string
+/// literals; a malformed one collapses to the escaped character, matching
+/// the unknown-escape fallback.
 fn lex_string(rest: &str) -> Option<(String, usize)> {
     let quote = rest.chars().next()?;
+    let tail = &rest[quote.len_utf8()..];
     let mut text = String::new();
-    let mut width = quote.len_utf8();
-    let mut chars = rest[width..].chars();
-    while let Some(character) = chars.next() {
-        width += character.len_utf8();
+    let mut cursor = 0;
+    while let Some(character) = tail[cursor..].chars().next() {
+        cursor += character.len_utf8();
         if character == quote {
-            return Some((text, width));
+            return Some((text, quote.len_utf8() + cursor));
         }
         if character == '\n' {
             return None;
         }
-        if character == '\\' {
-            let escaped = chars.next()?;
-            width += escaped.len_utf8();
-            text.push(match escaped {
-                'n' => '\n',
-                't' => '\t',
-                'r' => '\r',
-                '0' => '\0',
-                // Unknown escapes collapse to the escaped character, like
-                // JavaScript string literals.
-                other => other,
-            });
-        } else {
+        if character != '\\' {
             text.push(character);
+            continue;
+        }
+        let escaped = tail[cursor..].chars().next()?;
+        cursor += escaped.len_utf8();
+        match escaped {
+            'n' => text.push('\n'),
+            't' => text.push('\t'),
+            'r' => text.push('\r'),
+            '0' => text.push('\0'),
+            'x' => match take_hex(&tail[cursor..], 2) {
+                // Two hex digits cap the value at 0xFF, so the narrowing
+                // is lossless.
+                Some((code, width)) => {
+                    cursor += width;
+                    text.push(code as u8 as char);
+                }
+                None => text.push('x'),
+            },
+            'u' => match take_unicode(&tail[cursor..]) {
+                Some((character, width)) => {
+                    cursor += width;
+                    text.push(character);
+                }
+                None => text.push('u'),
+            },
+            // Unknown escapes collapse to the escaped character, like
+            // JavaScript string literals.
+            other => text.push(other),
         }
     }
     None
+}
+
+/// Take exactly `count` leading ASCII hex digits, returning their value
+/// and byte width; `None` when the run is shorter or overflows.
+fn take_hex(slice: &str, count: usize) -> Option<(u32, usize)> {
+    let mut value = 0_u32;
+    let mut width = 0;
+    for character in slice.chars().take(count) {
+        let digit = character.to_digit(16)?;
+        value = value.checked_mul(16)?.checked_add(digit)?;
+        width += character.len_utf8();
+    }
+    (width == count).then_some((value, width))
+}
+
+/// Decode the body of a `\u` escape — four hex digits or a braced
+/// `{…}` run — into the character and its byte width; `None` when
+/// malformed (then the escape collapses to a literal `u`).
+///
+/// A high surrogate pairs with an immediately following `\uNNNN` low
+/// surrogate like JavaScript; a lone surrogate, which a Rust string cannot
+/// hold, decodes to U+FFFD.
+fn take_unicode(tail: &str) -> Option<(char, usize)> {
+    if let Some(braced) = tail.strip_prefix('{') {
+        let digits: String = braced
+            .chars()
+            .take_while(|character| character.is_ascii_hexdigit())
+            .collect();
+        if digits.is_empty() || braced.as_bytes().get(digits.len()) != Some(&b'}') {
+            return None;
+        }
+        let value = u32::from_str_radix(&digits, 16).ok()?;
+        // '{', the digits, and '}' — one byte each, all ASCII.
+        return char::from_u32(value).map(|character| (character, digits.len() + 2));
+    }
+    let (code, width) = take_hex(tail, 4)?;
+    if (0xD800..0xDC00).contains(&code) {
+        // High surrogate: a following "\u" + low surrogate completes the
+        // pair; anything else leaves it unpaired (U+FFFD below).
+        if let Some((low, low_width)) = tail[width..]
+            .strip_prefix("\\u")
+            .and_then(|rest| take_hex(rest, 4))
+            .filter(|(low, _)| (0xDC00..0xE000).contains(low))
+        {
+            let combined = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+            let character = char::from_u32(combined)?;
+            return Some((character, width + 2 + low_width));
+        }
+    }
+    char::from_u32(code).map(|character| (character, width))
 }
 
 /// One decimal number: integer when it fits `i64` and has no fraction or
@@ -757,6 +826,33 @@ mod tests {
     }
 
     // --- operator semantics ---
+
+    #[test]
+    fn string_escapes_decode_like_javascript() {
+        assert_eq!(eval(r"'a\tb\nc'", &[]), Node::String("a\tb\nc".to_owned()));
+        assert_eq!(eval(r"'\x41'", &[]), Node::String("A".to_owned()));
+        assert_eq!(eval(r"'\x4a'", &[]), Node::String("J".to_owned()));
+        assert_eq!(eval(r"'\u0041'", &[]), Node::String("A".to_owned()));
+        assert_eq!(eval(r"'\u{41}'", &[]), Node::String("A".to_owned()));
+        assert_eq!(eval(r"'\u{1F600}'", &[]), Node::String("😀".to_owned()));
+        // A surrogate pair combines, as in JavaScript string literals.
+        assert_eq!(eval(r"'\uD83D\uDE00'", &[]), Node::String("😀".to_owned()));
+        // Malformed hex escapes collapse to the escaped character, like
+        // unknown escapes.
+        assert_eq!(eval(r"'\xZ1'", &[]), Node::String("xZ1".to_owned()));
+        assert_eq!(eval(r"'\u12'", &[]), Node::String("u12".to_owned()));
+        assert_eq!(eval(r"'\u{}'", &[]), Node::String("u{}".to_owned()));
+        assert_eq!(
+            eval(r"'\u{110000}'", &[]),
+            Node::String("u{110000}".to_owned())
+        );
+        // Escapes feed operators like any other literal.
+        assert_eq!(eval(r"'\x41' === 'A'", &[]), Node::Bool(true));
+        // A malformed escape collapses without swallowing the closing quote.
+        assert_eq!(eval(r"'\x4'", &[]), Node::String("x4".to_owned()));
+        // An escape running into the end of the source stays an error.
+        assert!(error(r"'\x41").contains("outside the supported expression subset"));
+    }
 
     #[test]
     fn numbers_evaluate_across_the_int_float_split() {

--- a/crates/cordis-include/src/file.rs
+++ b/crates/cordis-include/src/file.rs
@@ -255,10 +255,11 @@ impl LoaderFile {
 /// Serialize `document` and atomically replace the file behind `inner`.
 /// A no-op while the file is suspended.
 ///
-/// The whole sequence — serialize, write the sibling `.tmp`, fsync, rename —
-/// runs under `write_lock`: concurrent writers (a synchronous `write`, the
-/// deferred flusher, the loader's write-back) would otherwise interleave on
-/// the same `.tmp` path and the rename could publish torn content.
+/// The whole sequence — serialize, write the sibling `.tmp`, fsync, rename,
+/// fsync the parent directory (Unix) — runs under `write_lock`: concurrent
+/// writers (a synchronous `write`, the deferred flusher, the loader's
+/// write-back) would otherwise interleave on the same `.tmp` path and the
+/// rename could publish torn content.
 fn write_document(inner: &FileInner, document: &Document) -> Result<()> {
     let _write = crate::lock(&inner.write_lock);
     if *crate::lock(&inner.suspend) > 0 {
@@ -300,6 +301,18 @@ fn write_document(inner: &FileInner, document: &Document) -> Result<()> {
         file.sync_all()?;
     }
     fs::rename(&tmp, &inner.path)?;
+    // Persist the directory entry too: on some filesystems a crash shortly
+    // after the rename can otherwise lose the new name, defeating the
+    // atomic-write guarantee. POSIX fsyncs a directory through a read-only
+    // fd; failures are best-effort since the rename itself succeeded.
+    #[cfg(unix)]
+    {
+        if let Some(parent) = inner.path.parent() {
+            if let Ok(dir) = fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/cordis-include/tests/tree.rs
+++ b/crates/cordis-include/tests/tree.rs
@@ -99,6 +99,68 @@ fn update_reuses_entries_and_reports_the_diff() {
     assert_eq!(fresh.id.as_deref().map(str::len), Some(6));
 }
 
+/// Regression (review 2026-08-19, REV-01): a whole-tree update re-parents a
+/// top-level entry into a nested group during `sync_children`, and the
+/// root's final `set_children` pass used to clear that fresh parent link —
+/// the moved entry lost `path()`, ancestor cascades, and (at the loader
+/// layer) its group fiber context.
+#[test]
+fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
+    let tree = EntryTree::new();
+    tree.update(vec![
+        EntryOptions::new("keep").with_id("k"),
+        EntryOptions::new("mover").with_id("d"),
+        EntryOptions::new("worker").with_id("w"),
+    ])
+    .unwrap();
+
+    let reload = vec![
+        EntryOptions::new("keep").with_id("k"),
+        // "d" moves from the top level directly into g; "w" moves into
+        // g's child, so its re-parenting happens two levels below the root.
+        EntryOptions::new("group").with_id("g").with_group(vec![
+            EntryOptions::new("mover")
+                .with_id("d")
+                .with_group(vec![EntryOptions::new("worker").with_id("w")]),
+        ]),
+    ];
+    let diff = tree.update(reload).unwrap();
+    assert!(diff.moved.iter().any(|e| e.id() == "d"));
+    assert!(diff.moved.iter().any(|e| e.id() == "w"));
+    assert!(diff.removed.is_empty());
+
+    let group = tree.resolve("g").unwrap();
+    let moved = tree.resolve("g:d").unwrap();
+    let nested = tree.resolve("g:d:w").unwrap();
+    assert_eq!(moved.path(), "g:d");
+    assert_eq!(nested.path(), "g:d:w");
+    assert!(moved.parent().is_some_and(|p| Entry::ptr_eq(&p, &group)));
+    assert!(nested.parent().is_some_and(|p| Entry::ptr_eq(&p, &moved)));
+    assert!(moved.enabled() && nested.enabled());
+
+    // Disabling the group must cascade through the preserved links.
+    tree.update(vec![
+        EntryOptions::new("group")
+            .with_id("g")
+            .with_disabled(true)
+            .with_group(vec![
+                EntryOptions::new("mover")
+                    .with_id("d")
+                    .with_group(vec![EntryOptions::new("worker").with_id("w")]),
+            ]),
+    ])
+    .unwrap();
+    assert!(!moved.enabled(), "ancestor cascade reaches moved entry");
+    assert!(!nested.enabled(), "ancestor cascade reaches nested entry");
+
+    // Genuine removal still detaches: the parent link of a dropped child
+    // is cleared, not kept by mistake.
+    tree.update(vec![EntryOptions::new("group").with_id("g")])
+        .unwrap();
+    assert_eq!(moved.parent().map(|p| p.id().to_string()), None);
+    assert_eq!(moved.path(), "d");
+}
+
 #[test]
 fn update_rejects_duplicate_ids_atomically() {
     let tree = EntryTree::new();

--- a/crates/cordis-loader/src/dynamic.rs
+++ b/crates/cordis-loader/src/dynamic.rs
@@ -1,10 +1,19 @@
 //! Dynamic-library plugins (behind the `dynamic` feature).
 //!
 //! Rust has no stable ABI, so a `.so`/`.dylib`/`.dll` and the process
-//! loading it are only compatible when they were produced by the *same*
-//! toolchain, target, panic strategy, and `cordis-rs` core version. This
-//! module enforces exactly that through a build fingerprint, then lets the
-//! two sides exchange a [`Plugin`] trait object directly.
+//! loading it are only compatible when their ABI-determining build
+//! ingredients match. This module gates on a build [`fingerprint`] that
+//! pins exactly those: the export protocol version, the `cordis-rs` core
+//! version, the exact rustc release *and* commit hash, the target triple,
+//! and the panic strategy. With the gate passed, the two sides exchange a
+//! [`Plugin`] trait object directly.
+//!
+//! Codegen knobs — opt-level, LTO, codegen units, `-C target-feature`/
+//! `target-cpu`, debug-assertions, or the debug/release profile — are
+//! intentionally **not** fingerprinted: they do not take part in Rust's
+//! type and vtable layout, which is what the pinned ingredients determine
+//! for a given rustc. Should that ever change, the ingredient list (and
+//! [`DYNAMIC_ABI`]) is where the fix belongs.
 //!
 //! A plugin library is a `cdylib` crate that implements [`Plugin`] and ends
 //! with [`export_plugin!`]:
@@ -93,6 +102,10 @@ type CreateFn = unsafe extern "C" fn() -> *mut c_void;
 /// [`cordis`] core version (trait/vtable source of truth), the exact rustc
 /// release *and* commit hash, the target triple, and the panic strategy —
 /// `panic=abort` versus `unwind` changes both unwinding and codegen.
+/// Codegen options (opt-level, LTO, target-feature, debug/release
+/// profile) are deliberately excluded: they do not influence Rust type or
+/// vtable layout, which the pinned ingredients fully determine for a
+/// given rustc.
 ///
 /// The ingredients come from this crate's build script and are baked into
 /// the dependent's compilation: evaluating them inside a plugin build and

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -173,7 +173,7 @@ impl Loader {
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
         let document = config.document;
-        let (composed, _dirty) = match document.clone() {
+        let composed = match document.clone() {
             Some(document) => compose_entries(
                 document.entries,
                 &file,
@@ -198,7 +198,9 @@ impl Loader {
             state: Mutex::new(LoaderState {
                 entries: HashMap::new(),
                 operating: 0,
-                last_error: errors.pop(),
+                // Every import failure is joined into one message: keeping
+                // only the last one hid the rest behind fix-and-retry loops.
+                last_error: (!errors.is_empty()).then(|| errors.join("; ")),
                 _keep_alive: Vec::new(),
             }),
             operation: OperationLock::default(),
@@ -333,7 +335,7 @@ impl Loader {
         let _operation = inner.operation.guard();
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
-        let (composed, dirty) = match lock(&inner.document).clone() {
+        let composed = match lock(&inner.document).clone() {
             // A document-backed loader never re-reads its root file: the
             // file is a write-back draft, and rows a write-back baked into
             // it would re-enter the composition and duplicate every insert.
@@ -363,6 +365,11 @@ impl Loader {
                 }
             },
         };
+        // Id-less rows at any depth — including entries nested inside
+        // groups — get a generated id during the tree update below; the
+        // write-back must fire for them, or every reload would regenerate
+        // a different id and churn the entry's fiber.
+        let dirty = missing_id(&composed);
         for error in errors {
             self.record_error(LoaderError::Include(
                 cordis_include::IncludeError::Message { message: error },
@@ -400,7 +407,7 @@ impl Loader {
         let _operation = inner.operation.guard();
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
-        let (composed, _dirty) = compose_entries(
+        let composed = compose_entries(
             document.entries.clone(),
             &inner.file,
             &mut imports,
@@ -898,11 +905,21 @@ fn import_canonical(inner: &LoaderInner, entry: &Entry) -> PathBuf {
     std::fs::canonicalize(&path).unwrap_or(path)
 }
 
+/// Whether any entry in the list — at any nesting depth — lacks an
+/// explicit id. `EntryTree::update` generates one for each, and the file
+/// must be written back afterwards or the next reload matches nothing and
+/// churns those entries' fibers.
+fn missing_id(entries: &[EntryOptions]) -> bool {
+    entries
+        .iter()
+        .any(|options| options.id.is_none() || missing_id(&options.group))
+}
+
 /// Read `file` and recursively mount import subtrees: every `import`
 /// entry's `group` becomes the entries of the file its `url` names, so one
 /// `EntryTree::update` diffs across all files uniformly. Returns the
-/// composed top-level entries and whether any file carried entries without
-/// ids (whose generated ids need persisting).
+/// composed top-level entries (import children included, so id-less
+/// detection sees the whole tree).
 ///
 /// Reading the file passed directly to this call is not recoverable here:
 /// callers loading the main file propagate the error, while callers
@@ -914,7 +931,7 @@ fn compose(
     active: &mut HashSet<PathBuf>,
     mounted: &mut HashSet<PathBuf>,
     errors: &mut Vec<String>,
-) -> cordis_include::Result<(Vec<EntryOptions>, bool)> {
+) -> cordis_include::Result<Vec<EntryOptions>> {
     let document = file.read()?;
     Ok(compose_entries(
         document.entries,
@@ -944,9 +961,8 @@ fn compose_entries(
     active: &mut HashSet<PathBuf>,
     mounted: &mut HashSet<PathBuf>,
     errors: &mut Vec<String>,
-) -> (Vec<EntryOptions>, bool) {
+) -> Vec<EntryOptions> {
     let mut composed = Vec::with_capacity(entries.len());
-    let mut dirty = entries.iter().any(|options| options.id.is_none());
     for mut options in entries {
         if let Some(url) = options.import_url().map(str::to_owned) {
             let path = import_path(base, &url);
@@ -969,8 +985,7 @@ fn compose_entries(
             match LoaderFile::open(&path) {
                 Ok(sub_file) => {
                     match compose(&sub_file, imports, active, mounted, errors) {
-                        Ok((sub_entries, sub_dirty)) => {
-                            dirty |= sub_dirty;
+                        Ok(sub_entries) => {
                             options.group = sub_entries;
                         }
                         Err(error) => {
@@ -997,7 +1012,7 @@ fn compose_entries(
         }
         composed.push(options);
     }
-    (composed, dirty)
+    composed
 }
 
 /// Route `internal/status` disposals: a fiber that reached `Disposed`

--- a/crates/cordis-loader/tests/review_fixes.rs
+++ b/crates/cordis-loader/tests/review_fixes.rs
@@ -1,12 +1,13 @@
-//! Regression tests for the review findings on loader races and
-//! self-kill persistence (issues #30, #33, #39).
+//! Regression tests for review findings: loader races and self-kill
+//! persistence (issues #30, #33, #39) and the 2026-08-19 review
+//! (REV-20260819-01/-02/-05).
 
 use cordis::utils::BoxFuture;
 use cordis::{
-    Config, Context, CordisError, ErrorCode, Inject, Plugin, PluginHandle, PluginOutput, Result,
-    plugin_sync,
+    Config, Context, CordisError, ErrorCode, FiberState, Inject, Plugin, PluginHandle,
+    PluginOutput, Result, plugin_sync,
 };
-use cordis_include::{Document, EntryOptions, Node};
+use cordis_include::{Document, Entry, EntryOptions, Node};
 use cordis_loader::{Loader, LoaderConfig, PluginRegistry};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -269,6 +270,172 @@ fn self_kill_persistence_leaves_the_transition_snappy() {
         );
         std::thread::sleep(Duration::from_millis(20));
     }
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// A registry with one no-op `worker` plugin, shared by the tests below.
+fn worker_registry() -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+    registry.register("worker", || {
+        plugin_sync::<Node, _>("worker", Inject::default(), |_, _| Ok(PluginOutput::none()))
+    });
+    registry
+}
+
+/// Regression (review 2026-08-19, REV-01): a reload moving a top-level
+/// entry into a group used to clear the entry's parent link, so its fiber
+/// restarted under the ROOT context — disposing the group no longer
+/// cascaded to the moved child, and group isolation/intercept were lost.
+#[test]
+fn reload_moving_entry_into_group_keeps_cascade_dispose() {
+    let path = temp_path("move-cascade");
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(worker_registry())
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("worker").with_id("w1"),
+            ])),
+    )
+    .unwrap();
+    let worker = loader.tree().resolve("w1").unwrap();
+    worker.fiber().unwrap().try_wait().unwrap();
+
+    // External edit: the top-level worker moves into a new group.
+    std::fs::write(
+        &path,
+        "entries:\n  - id: g\n    name: group\n    group:\n      - id: w1\n        name: worker\n",
+    )
+    .unwrap();
+    let diff = loader.reload().unwrap();
+    assert!(diff.moved.iter().any(|entry| entry.id() == "w1"));
+
+    let group = loader.tree().resolve("g").unwrap();
+    let moved = loader.tree().resolve("g:w1").unwrap();
+    assert_eq!(moved.path(), "g:w1");
+    assert!(
+        moved
+            .parent()
+            .is_some_and(|parent| Entry::ptr_eq(&parent, &group)),
+        "the moved entry stays linked to its group"
+    );
+    moved.fiber().unwrap().try_wait().unwrap();
+
+    // The moved fiber runs under the group's context: disposing the group
+    // cascades. Before the fix it restarted under the root and stayed
+    // Active here.
+    let group_fiber = group.fiber().unwrap();
+    let moved_fiber = moved.fiber().unwrap();
+    group_fiber.dispose().unwrap();
+    assert_eq!(
+        moved_fiber.state(),
+        FiberState::Disposed,
+        "group disposal must cascade to the moved child"
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// Regression (review 2026-08-19, REV-02): the reload dirty check only
+/// looked at top-level rows, so ids generated for id-less entries nested
+/// inside groups were never written back — every reload destroyed and
+/// recreated those fibers under fresh random ids.
+#[test]
+fn reload_persists_generated_ids_of_nested_entries() {
+    let path = temp_path("nested-ids");
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            .with_registry(worker_registry())
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("group")
+                    .with_id("g")
+                    .with_group(vec![EntryOptions::new("worker")]),
+            ])),
+    )
+    .unwrap();
+    let worker = loader.tree().top_level()[0].children()[0].clone();
+    worker.fiber().unwrap().try_wait().unwrap();
+
+    // The first reload materializes the generated id into the file (the
+    // open-time id churns once — a no-id row can never match a pooled
+    // entry — and the write-back persists the fresh one).
+    loader.reload().unwrap();
+    let worker = loader.tree().top_level()[0].children()[0].clone();
+    let persisted = loader.file().read().unwrap().entries[0].group[0].id.clone();
+    assert_eq!(
+        persisted.as_deref(),
+        Some(worker.id()),
+        "the nested entry's generated id must land in the file"
+    );
+    worker.fiber().unwrap().try_wait().unwrap();
+    let fiber_before = worker.fiber().unwrap();
+
+    // The second reload matches by that id: no churn, same fiber.
+    let diff = loader.reload().unwrap();
+    assert!(
+        diff.created.is_empty() && diff.removed.is_empty(),
+        "second reload must not churn the nested entry: {diff:?}"
+    );
+    assert!(
+        worker
+            .fiber()
+            .is_some_and(|fiber| cordis::Fiber::ptr_eq(&fiber, &fiber_before)),
+        "the nested entry keeps its fiber across reloads"
+    );
+
+    loader.dispose().unwrap();
+    cleanup(&path);
+}
+
+/// Regression (review 2026-08-19, REV-05): `Loader::open` kept only the
+/// last compose error; with several broken imports the rest vanished
+/// silently behind fix-and-retry loops. (A merely *missing* import file
+/// composes as empty by design — the rows here exist but do not parse.)
+#[test]
+fn open_records_every_broken_import() {
+    let path = temp_path("import-errors");
+    let dir = path.parent().unwrap().to_path_buf();
+    std::fs::write(
+        dir.join("broken-a.yml"),
+        "entries:\n  - id: w1\n    name: [\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("broken-b.yml"),
+        "entries:\n  - id: w2\n    name: [\n",
+    )
+    .unwrap();
+    let url = |stem: &str| {
+        Node::from_iter([(
+            "url".to_string(),
+            dir.join(stem).to_string_lossy().into_owned().into(),
+        )])
+    };
+    let root = Context::new();
+    let loader = Loader::open(
+        &root,
+        LoaderConfig::new(&path)
+            // The import builtin resolves the marker rows.
+            .with_registry(PluginRegistry::new())
+            .with_initial(Document::with_entries(vec![
+                EntryOptions::new("import")
+                    .with_id("ia")
+                    .with_config(url("broken-a.yml")),
+                EntryOptions::new("import")
+                    .with_id("ib")
+                    .with_config(url("broken-b.yml")),
+            ])),
+    )
+    .unwrap();
+    let error = loader.last_error().expect("import failures recorded");
+    assert!(error.contains("broken-a.yml"), "{error}");
+    assert!(error.contains("broken-b.yml"), "{error}");
+
     loader.dispose().unwrap();
     cleanup(&path);
 }

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -602,6 +602,23 @@ impl Fiber {
         }
     }
 
+    /// The error for a transition that never became available within
+    /// [`transition_wait`], naming the fiber so the hung `apply` or
+    /// disposer can be identified.
+    fn transition_timeout_error(&self) -> CordisError {
+        let name = self.name();
+        let uid = self
+            .uid()
+            .map_or_else(|| "?".to_owned(), |uid| uid.to_string());
+        CordisError::with_message(
+            ErrorCode::Other,
+            format!(
+                "timed out waiting for the in-flight lifecycle transition \
+                 on fiber {name} (uid {uid}); its apply or a disposer may be hung",
+            ),
+        )
+    }
+
     /// Lock the transition mutex, telling reentrancy apart from contention.
     ///
     /// When the *current thread* already holds the lock — directly or
@@ -624,17 +641,7 @@ impl Fiber {
             ));
         }
         let Some(guard) = self.acquire_transition() else {
-            let name = self.name();
-            let uid = self
-                .uid()
-                .map_or_else(|| "?".to_owned(), |uid| uid.to_string());
-            let error = CordisError::with_message(
-                ErrorCode::Other,
-                format!(
-                    "timed out waiting for the in-flight lifecycle transition \
-                     on fiber {name} (uid {uid}); its apply or a disposer may be hung",
-                ),
-            );
+            let error = self.transition_timeout_error();
             // The caller only sees the failure; the log records which fiber
             // is stuck so the hung plugin can be identified.
             if let Some(ctx) = self.context() {
@@ -694,12 +701,26 @@ impl Fiber {
 
     /// Block until no lifecycle transition is in progress on this fiber.
     ///
+    /// The wait honors the same ceiling as `restart`/`dispose` (currently
+    /// ten seconds): a transition held longer — a hung `apply` or disposer
+    /// on another thread — surfaces as a logged error naming the fiber
+    /// instead of blocking the caller forever. `await_idle` has no result
+    /// channel, so the log is where the timeout lands.
+    ///
     /// Never call this from a lifecycle callback (status listener, disposer,
-    /// plugin apply) on the same thread: the transition mutex is held while
-    /// those run, and blocking on it here would deadlock.
+    /// plugin apply) on the same fiber: the transition mutex is held while
+    /// those run, so the call stalls the callback for the full bound before
+    /// logging the timeout. Probe [`idle`](Self::idle) from callbacks
+    /// instead.
     pub fn await_idle(&self) {
         {
-            let _guard = lock(&self.inner.transition);
+            let Some(_guard) = self.acquire_transition() else {
+                let error = self.transition_timeout_error();
+                if let Some(ctx) = self.context() {
+                    ctx.log_error(&error);
+                }
+                return;
+            };
         }
         // A concurrent refresh whose try_lock lost to the guard above only
         // set the dirty flag. Unlike refresh/restart/dispose, the guard here
@@ -1056,6 +1077,56 @@ mod tests {
         assert!(
             message.contains(&fiber.uid().unwrap().to_string()),
             "{message}"
+        );
+
+        // Let the parked apply finish so the helper thread can join.
+        drop(tx);
+        provider.join().unwrap().unwrap();
+    }
+
+    /// Regression (review 2026-08-19, REV-03): `await_idle` used an
+    /// unbounded blocking lock on the transition mutex; with a hung apply
+    /// holding it, the caller parked forever. It must honor the same wait
+    /// ceiling as `restart`/`dispose` and return (logging the timeout)
+    /// instead.
+    #[test]
+    fn await_idle_times_out_when_apply_hangs() {
+        let root = Context::new();
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        // mpsc receivers are not Sync; the mutex makes the callback shareable
+        // while recv() parks the apply under it.
+        let rx = Mutex::new(rx);
+        let fiber = root.plugin_default(plugin_sync::<(), _>(
+            "hung-idle",
+            Inject::new(["svc"]),
+            move |_, _| {
+                let _ = lock(&rx).recv();
+                Ok(PluginOutput::none())
+            },
+        ));
+        assert_eq!(fiber.state(), FiberState::Pending);
+
+        // Providing the dependency parks apply() on the provider thread,
+        // which then holds the transition mutex indefinitely.
+        let provider = std::thread::spawn({
+            let root = root.clone();
+            move || root.provide("svc", 1_u32)
+        });
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while fiber.state() != FiberState::Loading {
+            assert!(Instant::now() < deadline, "apply never started");
+            std::thread::yield_now();
+        }
+
+        TRANSITION_WAIT_MILLIS.store(150, Ordering::Relaxed);
+        let started = Instant::now();
+        fiber.await_idle();
+        let elapsed = started.elapsed();
+        TRANSITION_WAIT_MILLIS.store(0, Ordering::Relaxed);
+
+        assert!(
+            elapsed >= Duration::from_millis(150) && elapsed < Duration::from_secs(5),
+            "await_idle returned in {elapsed:?} instead of timing out at the bound"
         );
 
         // Let the parked apply finish so the helper thread can join.


### PR DESCRIPTION
## Summary

Resolves all seven findings from the 2026-08-19 review (against b913272): one P1, two P2, and four P3. The full verification gate passed — `cargo fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace [--all-features]`, `cargo doc --no-deps`, and all eight README doctests.

## Fixes

| ID | Severity | Commit | Change |
| --- | --- | --- | --- |
| REV-01 | P1 | fa0f764 | `set_children` clears a dropped child's parent link only while this parent still owns it: entries moved from the top level into nested groups keep their parent chain (`path()`, disable cascades, and the loader's group-context restart all work again). Regression tests at both the include and loader layers |
| REV-02 | P2 | 671dc6c | The reload dirty check is now recursive over the fully composed tree (`missing_id`), so generated ids for id-less entries nested inside groups are persisted — no more removed+created churn on every reload; the redundant bool return of `compose`/`compose_entries` is gone |
| REV-05 | P3 | 671dc6c | `Loader::open` joins every compose error into `last_error` instead of keeping only the last one |
| REV-03 | P2 | 6a645c5 | `Fiber::await_idle` acquires the transition through `acquire_transition()` — the same 10s ceiling as `restart`/`dispose` (covered by `TRANSITION_WAIT_MILLIS`) — and logs a fiber-naming timeout error instead of hanging; the signature stays `()`, so no breaking change |
| REV-04 | P3 | 21a9ef5 | The atomic write fsyncs the parent directory after the rename (Unix, best-effort), completing the durability contract |
| REV-06 | P3 | ec260ca | Expression string literals decode `\xNN` / `\uNNNN` / `\u{...}` like JavaScript (surrogate pairs combine; a lone surrogate maps to U+FFFD); malformed sequences keep the collapse-to-literal fallback without swallowing the closing quote |
| REV-07 | P3 | 6f4a16a | Dynamic-fingerprint docs aligned: enumerate exactly what the fingerprint pins and state that codegen options are intentionally excluded |

## Tests

- `cordis-include`: `update_keeps_the_parent_link_of_entries_moved_into_groups`, `string_escapes_decode_like_javascript`
- `cordis-loader`: `reload_moving_entry_into_group_keeps_cascade_dispose`, `reload_persists_generated_ids_of_nested_entries`, `open_records_every_broken_import`
- `cordis-rs`: `await_idle_times_out_when_apply_hangs`

Each fails before its fix and passes after; the existing suites stay green.

## Notes

- The REV-05 test uses import files that exist but fail to parse: by design, a merely *missing* import file composes as an empty document without an error.