### PR TITLE
refactor!: rename public APIs per the 2026-08-19 naming review

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Dispatch modes:
 - `parallel`: poll every listener concurrently and aggregate errors.
 - `serial`: await in order and stop on the first bail value.
 - `bail`: synchronous ordered bail.
-- `waterfall` / `waterfall_async`: each listener receives `event.next()` and may wrap or veto the rest of the chain.
+- `waterfall` / `waterfall_async`: each listener receives `event.call_next()` and may wrap or veto the rest of the chain.
 
 ## Reflection
 
@@ -266,7 +266,7 @@ let root = Context::new();
 let mut config = ExporterConfig::default();
 config.levels.insert("default".into(), LoggerLevel::Debug);
 let render = config.clone();
-let _exporter = root.logger_service().exporter_fn(config, move |message| {
+let _exporter = root.logger_service().exporter_with(config, move |message| {
     println!("{}", default_format(&render, message));
 })?;
 
@@ -305,7 +305,7 @@ Override `validate_config()` to normalize config or return `CordisError::validat
 
 ## Runtime notes
 
-The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. `Fiber::await_ready`, async event modes, async plugins, and async disposers remain available; `await_ready` and `dispose_async` are synchronous pass-throughs that never yield — awaiting them blocks the calling thread for the duration.
+The original TypeScript implementation schedules lifecycle work through promises. This crate deliberately reconciles lifecycle transitions eagerly: `provide`, effect disposal, `restart`, and `update` return after affected fibers settle. This makes behavior deterministic without requiring Tokio or another executor. async event modes, async plugins, and async disposers remain available; `dispose_async` is a synchronous pass-through that never yields — awaiting them blocks the calling thread for the duration.
 
 Executor-independent futures work everywhere. If a future creates runtime-specific resources (for example `tokio::time::sleep`), call Cordis while that runtime is entered.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,7 +227,7 @@ block_on(root.events().parallel("tick", []))?;
 - `parallel`：并发轮询所有监听器并聚合错误。
 - `serial`：按顺序等待，在遇到第一个 bail 值时停止。
 - `bail`：同步、按顺序执行的 bail 分发。
-- `waterfall` / `waterfall_async`：每个监听器都会收到 `event.next()`，并可以包装或阻止后续调用链。
+- `waterfall` / `waterfall_async`：每个监听器都会收到 `event.call_next()`，并可以包装或阻止后续调用链。
 
 ## 反射
 
@@ -266,7 +266,7 @@ let root = Context::new();
 let mut config = ExporterConfig::default();
 config.levels.insert("default".into(), LoggerLevel::Debug);
 let render = config.clone();
-let _exporter = root.logger_service().exporter_fn(config, move |message| {
+let _exporter = root.logger_service().exporter_with(config, move |message| {
     println!("{}", default_format(&render, message));
 })?;
 
@@ -305,7 +305,7 @@ impl Plugin for Worker {
 
 ## 运行时说明
 
-TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供 `Fiber::await_ready`、异步事件模式、异步插件和异步 disposer；其中 `await_ready` 与 `dispose_async` 是同步直通实现，从不让出执行器——await 期间会阻塞调用线程直至完成。
+TypeScript 原版通过 Promise 调度生命周期任务。本 crate 特意采用即时生命周期协调：`provide`、effect 回收、`restart` 和 `update` 会在受影响的 fiber 稳定后才返回。因此，无需 Tokio 或其他执行器也能获得确定性行为。同时仍然提供异步事件模式、异步插件和异步 disposer；其中 `dispose_async` 是同步直通实现，从不让出执行器——await 期间会阻塞调用线程直至完成。
 
 与执行器无关的 future 可以在任何环境中运行。如果 future 会创建特定运行时资源（例如 `tokio::time::sleep`），请在对应运行时已经进入的情况下调用 Cordis。
 

--- a/crates/cordis-include/README.md
+++ b/crates/cordis-include/README.md
@@ -28,7 +28,7 @@ use cordis_include::{Entry, EntryOptions, EntryTree, Node};
 let tree = EntryTree::new();
 
 // Load a set of entries (from a file, or built by hand).
-let diff = tree.update(vec![
+let diff = tree.reconcile(vec![
     EntryOptions::new("group").with_id("srv").with_group(vec![
         EntryOptions::new("adapter-http").with_config(
             [("port".to_string(), Node::Int(8080))].into_iter().collect(),
@@ -37,10 +37,10 @@ let diff = tree.update(vec![
 ])?;
 assert_eq!(diff.created.len(), 2);
 
-// A full reload matches entries by id across groups: existing entry
+// A full reconcile matches entries by id across groups: existing entry
 // objects are reused (same pointer), so callers can keep their handles.
 let kept = tree.resolve("srv").unwrap();
-tree.update(vec![EntryOptions::new("group").with_id("srv")])?;
+tree.reconcile(vec![EntryOptions::new("group").with_id("srv")])?;
 assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
 # Ok(())
 # }

--- a/crates/cordis-include/README.zh-CN.md
+++ b/crates/cordis-include/README.zh-CN.md
@@ -26,7 +26,7 @@ use cordis_include::{Entry, EntryOptions, EntryTree, Node};
 let tree = EntryTree::new();
 
 // 载入一组条目（来自文件，或手工构建）。
-let diff = tree.update(vec![
+let diff = tree.reconcile(vec![
     EntryOptions::new("group").with_id("srv").with_group(vec![
         EntryOptions::new("adapter-http").with_config(
             [("port".to_string(), Node::Int(8080))].into_iter().collect(),
@@ -35,10 +35,10 @@ let diff = tree.update(vec![
 ])?;
 assert_eq!(diff.created.len(), 2);
 
-// 整树重载按 id 跨 group 匹配：既有条目对象会被复用（同一指针），
+// 整树 reconcile 按 id 跨 group 匹配：既有条目对象会被复用（同一指针），
 // 调用方可以保留自己的句柄。
 let kept = tree.resolve("srv").unwrap();
-tree.update(vec![EntryOptions::new("group").with_id("srv")])?;
+tree.reconcile(vec![EntryOptions::new("group").with_id("srv")])?;
 assert!(Entry::ptr_eq(&kept, &tree.resolve("srv").unwrap()));
 # Ok(())
 # }

--- a/crates/cordis-include/src/entry.rs
+++ b/crates/cordis-include/src/entry.rs
@@ -176,7 +176,11 @@ impl Entry {
     /// yields the flag, an unevaluated expression does not disable. The
     /// options snapshot ([`Entry::options`]) carries the raw slot for
     /// write-back.
-    pub fn disabled(&self) -> bool {
+    ///
+    /// Scope: this looks at the entry's **own** slot only, so it is not the
+    /// negation of [`is_enabled`](Self::is_enabled), which also cascades
+    /// through every ancestor.
+    pub fn is_disabled(&self) -> bool {
         self.state().options.disabled.is_disabled()
     }
 
@@ -203,12 +207,13 @@ impl Entry {
     /// disabled group cascades to its whole subtree. `!!js` expressions
     /// are *not* evaluated here — an unevaluated expression does not
     /// disable; use [`Entry::resolved_enabled`] for the evaluated
-    /// decision.
-    pub fn enabled(&self) -> bool {
+    /// decision. Unlike [`is_disabled`](Self::is_disabled), this walks the
+    /// whole ancestor chain, so the two predicates are not complements.
+    pub fn is_enabled(&self) -> bool {
         if self.is_root() {
             return true;
         }
-        !self.disabled() && self.parent().is_none_or(|parent| parent.enabled())
+        !self.is_disabled() && self.parent().is_none_or(|parent| parent.is_enabled())
     }
 
     /// Whether this entry and every ancestor are enabled once their

--- a/crates/cordis-include/src/lib.rs
+++ b/crates/cordis-include/src/lib.rs
@@ -18,7 +18,7 @@
 //! let mut document = file.read()?;
 //!
 //! let tree = EntryTree::new();
-//! let diff = tree.update(document.entries)?;
+//! let diff = tree.reconcile(document.entries)?;
 //! for entry in &diff.created {
 //!     println!("new entry {} ({})", entry.path(), entry.name());
 //! }

--- a/crates/cordis-include/src/tree.rs
+++ b/crates/cordis-include/src/tree.rs
@@ -17,7 +17,7 @@ pub struct RemovedEntry {
     pub path: String,
 }
 
-/// What changed in one [`EntryTree::update`] pass.
+/// What changed in one [`EntryTree::reconcile`] pass.
 ///
 /// The loader consumes this to start/stop/patch fibers without touching
 /// entries whose id, options, and position are unchanged.
@@ -136,7 +136,7 @@ impl EntryTree {
     ) -> Result<Entry> {
         let _guard = crate::lock(&self.mutation);
         let parent = parent.unwrap_or(&self.root);
-        self.assert_owned(parent)?;
+        self.ensure_owned(parent)?;
         if options.name.is_empty() {
             return Err(IncludeError::InvalidName);
         }
@@ -181,12 +181,12 @@ impl EntryTree {
         Ok(entry)
     }
 
-    /// Update one entry's options and optionally move it below
+    /// Reconcile one entry's options and optionally move it below
     /// `new_parent` (appended unless `position` is given). The entry id is
-    /// identity and survives the update; `options.id` is ignored.
+    /// identity and survives the reconcile; `options.id` is ignored.
     /// `options.group` re-syncs the entry's children, reusing existing
     /// subtree entries whose ids match.
-    pub fn update_entry(
+    pub fn reconcile_entry(
         &self,
         id: &str,
         options: EntryOptions,
@@ -202,7 +202,7 @@ impl EntryTree {
             .ok_or_else(|| IncludeError::EntryNotFound { id: id.to_owned() })?;
         let parent = match new_parent {
             Some(parent) => {
-                self.assert_owned(parent)?;
+                self.ensure_owned(parent)?;
                 if entry.contains(parent) {
                     return Err(IncludeError::Cycle);
                 }
@@ -254,14 +254,14 @@ impl EntryTree {
         Ok(entry)
     }
 
-    /// Reload the whole tree from new options, reusing existing entries
+    /// Reconcile the whole tree with new options, reusing existing entries
     /// wherever ids match — including entries that moved between groups —
     /// and returning what changed.
     ///
     /// Entries in the new data without an id cannot be matched and are
     /// always created fresh; persist generated ids by writing
     /// [`EntryTree::serialize`] back to the file.
-    pub fn update(&self, entries: Vec<EntryOptions>) -> Result<TreeDiff> {
+    pub fn reconcile(&self, entries: Vec<EntryOptions>) -> Result<TreeDiff> {
         let _guard = crate::lock(&self.mutation);
         // Existing ids are reusable here, so nothing is reserved; only
         // duplicates within the incoming data are rejected.
@@ -300,7 +300,7 @@ impl EntryTree {
     }
 
     /// Fail unless `candidate` is the root of, or lives inside, this tree.
-    fn assert_owned(&self, candidate: &Entry) -> Result<()> {
+    fn ensure_owned(&self, candidate: &Entry) -> Result<()> {
         let mut current = candidate.clone();
         loop {
             if Entry::ptr_eq(&current, &self.root) {

--- a/crates/cordis-include/tests/file.rs
+++ b/crates/cordis-include/tests/file.rs
@@ -120,7 +120,7 @@ fn unknown_top_level_keys_are_preserved() {
 
     // A tree reload keeps the extras while entries churn.
     let tree = EntryTree::new();
-    tree.update(document.entries.clone()).unwrap();
+    tree.reconcile(document.entries.clone()).unwrap();
     document.entries = tree.serialize();
     file.write(&document).unwrap();
     let reread = file.read().unwrap();
@@ -214,7 +214,7 @@ fn interpolation_expands_on_read_but_preserves_the_file() {
 
     let file = LoaderFile::open(&path).unwrap();
     let tree = EntryTree::new();
-    tree.update(file.read().unwrap().entries).unwrap();
+    tree.reconcile(file.read().unwrap().entries).unwrap();
     let entry = tree.resolve("k").unwrap();
 
     // Raw config keeps the template; resolved config substitutes it.

--- a/crates/cordis-include/tests/tree.rs
+++ b/crates/cordis-include/tests/tree.rs
@@ -58,7 +58,7 @@ fn update_reuses_entries_and_reports_the_diff() {
         EntryOptions::new("keep").with_id("k"),
         EntryOptions::new("mover").with_id("d"),
     ];
-    let diff = tree.update(initial).unwrap();
+    let diff = tree.reconcile(initial).unwrap();
     assert_eq!(diff.created.len(), 2);
     assert!(!diff.is_empty());
 
@@ -76,7 +76,7 @@ fn update_reuses_entries_and_reports_the_diff() {
             .with_id("g")
             .with_group(vec![EntryOptions::new("mover").with_id("d")]),
     ];
-    let diff = tree.update(reload).unwrap();
+    let diff = tree.reconcile(reload).unwrap();
     assert!(diff.created.iter().any(|e| e.id() == "g"));
     assert!(diff.updated.iter().any(|e| e.id() == "k"));
     assert!(diff.moved.iter().any(|e| e.id() == "d"));
@@ -107,7 +107,7 @@ fn update_reuses_entries_and_reports_the_diff() {
 #[test]
 fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
     let tree = EntryTree::new();
-    tree.update(vec![
+    tree.reconcile(vec![
         EntryOptions::new("keep").with_id("k"),
         EntryOptions::new("mover").with_id("d"),
         EntryOptions::new("worker").with_id("w"),
@@ -124,7 +124,7 @@ fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
                 .with_group(vec![EntryOptions::new("worker").with_id("w")]),
         ]),
     ];
-    let diff = tree.update(reload).unwrap();
+    let diff = tree.reconcile(reload).unwrap();
     assert!(diff.moved.iter().any(|e| e.id() == "d"));
     assert!(diff.moved.iter().any(|e| e.id() == "w"));
     assert!(diff.removed.is_empty());
@@ -136,10 +136,10 @@ fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
     assert_eq!(nested.path(), "g:d:w");
     assert!(moved.parent().is_some_and(|p| Entry::ptr_eq(&p, &group)));
     assert!(nested.parent().is_some_and(|p| Entry::ptr_eq(&p, &moved)));
-    assert!(moved.enabled() && nested.enabled());
+    assert!(moved.is_enabled() && nested.is_enabled());
 
     // Disabling the group must cascade through the preserved links.
-    tree.update(vec![
+    tree.reconcile(vec![
         EntryOptions::new("group")
             .with_id("g")
             .with_disabled(true)
@@ -150,12 +150,15 @@ fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
             ]),
     ])
     .unwrap();
-    assert!(!moved.enabled(), "ancestor cascade reaches moved entry");
-    assert!(!nested.enabled(), "ancestor cascade reaches nested entry");
+    assert!(!moved.is_enabled(), "ancestor cascade reaches moved entry");
+    assert!(
+        !nested.is_enabled(),
+        "ancestor cascade reaches nested entry"
+    );
 
     // Genuine removal still detaches: the parent link of a dropped child
     // is cleared, not kept by mistake.
-    tree.update(vec![EntryOptions::new("group").with_id("g")])
+    tree.reconcile(vec![EntryOptions::new("group").with_id("g")])
         .unwrap();
     assert_eq!(moved.parent().map(|p| p.id().to_string()), None);
     assert_eq!(moved.path(), "d");
@@ -164,14 +167,14 @@ fn update_keeps_the_parent_link_of_entries_moved_into_groups() {
 #[test]
 fn update_rejects_duplicate_ids_atomically() {
     let tree = EntryTree::new();
-    tree.update(vec![EntryOptions::new("a").with_id("one")])
+    tree.reconcile(vec![EntryOptions::new("a").with_id("one")])
         .unwrap();
     let bad = vec![
         EntryOptions::new("a").with_id("same"),
         EntryOptions::new("b").with_id("same"),
     ];
     assert!(matches!(
-        tree.update(bad),
+        tree.reconcile(bad),
         Err(IncludeError::DuplicateId { .. })
     ));
     // The failed reload left the existing tree untouched.
@@ -199,7 +202,7 @@ fn remove_detaches_but_keeps_the_subtree() {
 }
 
 #[test]
-fn update_entry_moves_and_rejects_cycles() {
+fn reconcile_entry_moves_and_rejects_cycles() {
     let tree = EntryTree::new();
     let outer = tree
         .create(EntryOptions::new("group").with_id("outer"), None, None)
@@ -214,13 +217,13 @@ fn update_entry_moves_and_rejects_cycles() {
 
     // Move `outer` beneath its own child: must fail.
     assert!(matches!(
-        tree.update_entry("outer", EntryOptions::new("group"), Some(&inner), None),
+        tree.reconcile_entry("outer", EntryOptions::new("group"), Some(&inner), None),
         Err(IncludeError::Cycle)
     ));
 
     // Move `inner` (nested under `outer`) to the top level and rename it.
     let moved = tree
-        .update_entry(
+        .reconcile_entry(
             "outer:inner",
             EntryOptions::new("renamed"),
             Some(tree.root()),
@@ -235,7 +238,7 @@ fn update_entry_moves_and_rejects_cycles() {
 #[test]
 fn disabled_cascades_through_ancestors() {
     let tree = EntryTree::new();
-    tree.update(vec![
+    tree.reconcile(vec![
         EntryOptions::new("group")
             .with_id("g")
             .with_group(vec![EntryOptions::new("child").with_id("c")]),
@@ -244,24 +247,24 @@ fn disabled_cascades_through_ancestors() {
     let group = tree.resolve("g").unwrap();
     let child = tree.resolve("g:c").unwrap();
 
-    assert!(child.enabled());
-    tree.update(vec![
+    assert!(child.is_enabled());
+    tree.reconcile(vec![
         EntryOptions::new("group")
             .with_id("g")
             .with_disabled(true)
             .with_group(vec![EntryOptions::new("child").with_id("c")]),
     ])
     .unwrap();
-    assert!(!group.enabled());
-    assert!(group.disabled());
-    assert!(!child.disabled(), "own flag untouched");
-    assert!(!child.enabled(), "ancestor cascade applies");
+    assert!(!group.is_enabled());
+    assert!(group.is_disabled());
+    assert!(!child.is_disabled(), "own flag untouched");
+    assert!(!child.is_enabled(), "ancestor cascade applies");
 }
 
 #[test]
 fn serialize_round_trips_nested_groups() {
     let tree = EntryTree::new();
-    tree.update(vec![EntryOptions::new("group").with_id("g").with_group(
+    tree.reconcile(vec![EntryOptions::new("group").with_id("g").with_group(
         vec![
         EntryOptions::new("child").with_id("c").with_config(node(&[("n", 1.into())])),
     ],
@@ -278,7 +281,7 @@ fn serialize_round_trips_nested_groups() {
 
     // Reload from the serialized form: identity is preserved by id.
     let before = tree.resolve("g:c").unwrap();
-    tree.update(options).unwrap();
+    tree.reconcile(options).unwrap();
     let after = tree.resolve("g:c").unwrap();
     assert!(Entry::ptr_eq(&before, &after));
 }

--- a/crates/cordis-loader/README.md
+++ b/crates/cordis-loader/README.md
@@ -124,7 +124,7 @@ let loader = Loader::open(
 assert!(!path.exists(), "boot touched the draft");
 
 // Recomposition: full diff → stop → patch → start, no write-back.
-let diff = loader.update(Document::with_entries(vec![
+let diff = loader.recompose(Document::with_entries(vec![
     EntryOptions::new("worker").with_id("w1").with_config(
         [("port".to_string(), Node::Int(8080))].into_iter().collect(),
     ),

--- a/crates/cordis-loader/README.zh-CN.md
+++ b/crates/cordis-loader/README.zh-CN.md
@@ -120,7 +120,7 @@ let loader = Loader::open(
 assert!(!path.exists(), "boot touched the draft");
 
 // 重组合：完整 diff → stop → patch → start，不写回。
-let diff = loader.update(Document::with_entries(vec![
+let diff = loader.recompose(Document::with_entries(vec![
     EntryOptions::new("worker").with_id("w1").with_config(
         [("port".to_string(), Node::Int(8080))].into_iter().collect(),
     ),

--- a/crates/cordis-loader/src/lib.rs
+++ b/crates/cordis-loader/src/lib.rs
@@ -29,7 +29,7 @@
 //!   unreadable main file fails the operation instead of silently booting
 //!   an empty tree (import files keep a tolerant record-and-skip path).
 //! - **Document sources** ([`LoaderConfig::with_document`],
-//!   [`Loader::update`]): compose from an in-memory document instead of the
+//!   [`Loader::recompose`]): compose from an in-memory document instead of the
 //!   entry file. Boot then never reads or writes the file — concurrent
 //!   boots on one shared draft cannot race, and the directory may stay
 //!   read-only — while reloads recompose from the stored document (import

--- a/crates/cordis-loader/src/loader.rs
+++ b/crates/cordis-loader/src/loader.rs
@@ -62,7 +62,7 @@ impl LoaderConfig {
     /// open" races between concurrent boots on one profile (another
     /// process's draft could land between this one's write and read) and
     /// requires a writable directory. Replace the source at runtime with
-    /// [`Loader::update`].
+    /// [`Loader::recompose`].
     pub fn with_document(mut self, document: cordis_include::Document) -> Self {
         self.document = Some(document);
         self
@@ -119,7 +119,7 @@ pub(crate) struct LoaderInner {
     operation: OperationLock,
     /// Composition source override; `None` for file-backed loaders. Set by
     /// [`LoaderConfig::with_document`] and replaced by every
-    /// [`Loader::update`]: reloads recompose from it instead of re-reading
+    /// [`Loader::recompose`]: reloads recompose from it instead of re-reading
     /// the root file (import files are still read), so rows a write-back
     /// baked into the draft can never re-enter the composition.
     document: Mutex<Option<cordis_include::Document>>,
@@ -212,7 +212,7 @@ impl Loader {
             watchers: Mutex::new(Vec::new()),
             write_debounce: Mutex::new(config.write_debounce),
         });
-        inner.tree.update(composed)?;
+        inner.tree.reconcile(composed)?;
         // Generated ids from the initial load are persisted lazily, on the
         // first explicit write-back.
 
@@ -330,8 +330,8 @@ impl Loader {
     pub fn reload(&self) -> Result<TreeDiff> {
         let inner = &self.inner;
         // Whole-reload exclusion: compose, diff, fiber transitions, and the
-        // id write-back must not interleave with update() or update_config()
-        // or dispose().
+        // id write-back must not interleave with recompose() or
+        // update_config() or dispose().
         let _operation = inner.operation.guard();
         let mut imports = HashMap::new();
         let mut errors = Vec::new();
@@ -366,7 +366,7 @@ impl Loader {
             },
         };
         // Id-less rows at any depth — including entries nested inside
-        // groups — get a generated id during the tree update below; the
+        // groups — get a generated id during the tree reconcile below; the
         // write-back must fire for them, or every reload would regenerate
         // a different id and churn the entry's fiber.
         let dirty = missing_id(&composed);
@@ -399,8 +399,8 @@ impl Loader {
     /// The document also becomes the loader's composition source: later
     /// reloads recompose from it instead of re-reading the root file
     /// (import files are still read). This is the core HMR primitive — a
-    /// watcher recomposes fresh layers and hands the result to `update`.
-    pub fn update(&self, document: cordis_include::Document) -> Result<TreeDiff> {
+    /// watcher recomposes fresh layers and hands the result to `recompose`.
+    pub fn recompose(&self, document: cordis_include::Document) -> Result<TreeDiff> {
         let inner = &self.inner;
         // Same exclusion as reload(): the source swap, tree diff, and fiber
         // transitions must land as one unit.
@@ -431,7 +431,7 @@ impl Loader {
     /// restarted when active) and the new config is persisted to the file.
     pub fn update_config(&self, id: &str, config: Node) -> Result<()> {
         let inner = &self.inner;
-        // Same exclusion as reload(): the fiber update, tree commit, and
+        // Same exclusion as reload(): the fiber transitions, tree commit, and
         // file write-back must land as one unit, or a concurrent reload
         // could patch the fiber back to the file's previous content.
         let _operation = inner.operation.guard();
@@ -445,7 +445,7 @@ impl Loader {
         options.config = Some(config.clone());
         inner
             .tree
-            .update_entry(&entry.path(), options, None, None)?;
+            .reconcile_entry(&entry.path(), options, None, None)?;
         write_back(inner)?;
         emit(
             inner,
@@ -632,7 +632,7 @@ fn reconcile(
     composed: Vec<EntryOptions>,
     imports: HashMap<PathBuf, LoaderFile>,
 ) -> Result<TreeDiff> {
-    let diff = inner.tree.update(composed)?;
+    let diff = inner.tree.reconcile(composed)?;
     *lock(&inner.imports) = imports;
 
     for removed in &diff.removed {
@@ -771,7 +771,7 @@ fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
             vec![Value::new(entry.clone())],
         );
         if let Err(error) = fiber.update_value(Config::new(new_config)) {
-            // tree.update() already committed the new options before this
+            // tree.reconcile() already committed the new options before this
             // patch ran. Rolling the entry's stored config back to what the
             // fiber actually runs keeps the tree honest and — crucially —
             // makes the next reload's diff see a change again, so a config
@@ -780,7 +780,10 @@ fn patch_entry(inner: &LoaderInner, entry: &Entry) -> Result<()> {
             if let Some(old_config) = current {
                 let mut options = entry_options_with_children(entry);
                 options.config = Some(old_config);
-                if let Err(revert) = inner.tree.update_entry(&entry.path(), options, None, None) {
+                if let Err(revert) = inner
+                    .tree
+                    .reconcile_entry(&entry.path(), options, None, None)
+                {
                     lock(&inner.state).last_error = Some(format!(
                         "failed to roll back config of {}: {revert}",
                         entry.path()
@@ -820,7 +823,7 @@ fn entry_depth(entry: &Entry) -> usize {
     depth
 }
 
-/// Serialize an entry together with its live subtree (used by update paths
+/// Serialize an entry together with its live subtree (used by reconcile paths
 /// that must not disturb children).
 fn entry_options_with_children(entry: &Entry) -> EntryOptions {
     let mut options = entry.options();
@@ -906,7 +909,7 @@ fn import_canonical(inner: &LoaderInner, entry: &Entry) -> PathBuf {
 }
 
 /// Whether any entry in the list — at any nesting depth — lacks an
-/// explicit id. `EntryTree::update` generates one for each, and the file
+/// explicit id. `EntryTree::reconcile` generates one for each, and the file
 /// must be written back afterwards or the next reload matches nothing and
 /// churns those entries' fibers.
 fn missing_id(entries: &[EntryOptions]) -> bool {
@@ -917,7 +920,7 @@ fn missing_id(entries: &[EntryOptions]) -> bool {
 
 /// Read `file` and recursively mount import subtrees: every `import`
 /// entry's `group` becomes the entries of the file its `url` names, so one
-/// `EntryTree::update` diffs across all files uniformly. Returns the
+/// `EntryTree::reconcile` diffs across all files uniformly. Returns the
 /// composed top-level entries (import children included, so id-less
 /// detection sees the whole tree).
 ///
@@ -945,7 +948,7 @@ fn compose(
 
 /// Mount import subtrees under base rows supplied in memory — the entries
 /// half of [`compose`], used by document-backed composition sources
-/// ([`LoaderConfig::with_document`], [`Loader::update`]). `base` resolves
+/// ([`LoaderConfig::with_document`], [`Loader::recompose`]). `base` resolves
 /// relative import urls. Infallible: import failures follow the tolerant
 /// record-and-skip path.
 ///
@@ -1096,7 +1099,7 @@ fn persist_self_dispose(inner: &LoaderInner, entry: &Entry) -> Result<()> {
     options.disabled = cordis_include::Disabled::Flag(true);
     inner
         .tree
-        .update_entry(&entry.path(), options, None, None)?;
+        .reconcile_entry(&entry.path(), options, None, None)?;
     write_back(inner)?;
     emit(
         inner,

--- a/crates/cordis-loader/tests/document.rs
+++ b/crates/cordis-loader/tests/document.rs
@@ -1,5 +1,5 @@
 //! Document-backed composition sources: `LoaderConfig::with_document` and
-//! `Loader::update` — boot from an in-memory document whose entry file is
+//! `Loader::recompose` — boot from an in-memory document whose entry file is
 //! only ever a write-back draft, and the in-memory recomposition primitive.
 
 use cordis::{Context, Fiber, Inject, PluginHandle, PluginOutput, plugin_sync};
@@ -202,7 +202,7 @@ fn update_reconciles_without_write_back() {
     // created, the g/w1 subtree removed. The id-less row makes the pass
     // dirty, but a recomposition is not a file edit — nothing is written.
     let diff = loader
-        .update(Document::with_entries(vec![
+        .recompose(Document::with_entries(vec![
             EntryOptions::new("worker")
                 .with_id("w2")
                 .with_config(Node::from_iter([("port".to_string(), Node::Int(2))])),
@@ -260,7 +260,7 @@ fn update_replaces_the_composition_source_for_later_reloads() {
     // update() makes the document the composition source: a later reload
     // recomposes from it instead of re-reading the file (which still says w1).
     loader
-        .update(Document::with_entries(vec![
+        .recompose(Document::with_entries(vec![
             EntryOptions::new("worker").with_id("w2"),
         ]))
         .unwrap();
@@ -292,7 +292,7 @@ fn update_mounts_import_rows() {
 
     // A composition can insert an import row; its file mounts as a subtree.
     loader
-        .update(Document::with_entries(vec![
+        .recompose(Document::with_entries(vec![
             EntryOptions::new("worker").with_id("m1"),
             EntryOptions::new("import")
                 .with_id("imp")
@@ -406,7 +406,7 @@ fn recomposition_drops_a_self_kill_disable_written_to_the_draft() {
     // A fresh recomposition deliberately drops the disable: the patch
     // composition tree is short-lived, and the draft is never an input.
     loader
-        .update(Document::with_entries(vec![
+        .recompose(Document::with_entries(vec![
             EntryOptions::new("victim").with_id("v1"),
         ]))
         .unwrap();

--- a/crates/cordis/src/context.rs
+++ b/crates/cordis/src/context.rs
@@ -430,6 +430,24 @@ impl Context {
             .on_async(name, listener, EventOptions::default())
     }
 
+    /// Register an asynchronous listener with placement and filtering
+    /// options.
+    ///
+    /// See [`EventsService::on_async`](crate::EventsService::on_async) for the
+    /// blocking-executor caveats before awaiting thread-local work here.
+    pub fn on_async_with<F, Fut>(
+        &self,
+        name: impl Into<String>,
+        listener: F,
+        options: EventOptions,
+    ) -> Result<EffectHandle>
+    where
+        F: Fn(Event) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = EventResult> + Send + 'static,
+    {
+        self.events().on_async(name, listener, options)
+    }
+
     /// Register a one-shot event listener.
     pub fn once<F>(&self, name: impl Into<String>, listener: F) -> Result<EffectHandle>
     where
@@ -485,6 +503,20 @@ impl Context {
         F: Fn() -> EventResult + Send + Sync + 'static,
     {
         self.events().waterfall(name, args, inner)
+    }
+
+    /// Compose listeners around an innermost asynchronous callback.
+    pub async fn waterfall_async<F, Fut>(
+        &self,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = EventValue>,
+        inner: F,
+    ) -> EventResult
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = EventResult> + Send + 'static,
+    {
+        self.events().waterfall_async(name, args, inner).await
     }
 
     /// Start a plugin and return its lifecycle fiber.

--- a/crates/cordis/src/context.rs
+++ b/crates/cordis/src/context.rs
@@ -351,15 +351,15 @@ impl Context {
     where
         T: Send + Sync + 'static,
     {
-        self.reflect().get(name, true)
+        self.reflect().get(name)
     }
 
     /// Read a service even while its provider is loading or unloading.
-    pub fn get_unchecked<T>(&self, name: &str) -> Result<Option<Arc<T>>>
+    pub fn get_relaxed<T>(&self, name: &str) -> Result<Option<Arc<T>>>
     where
         T: Send + Sync + 'static,
     {
-        self.reflect().get(name, false)
+        self.reflect().get_relaxed(name)
     }
 
     /// Require a currently active service.
@@ -504,25 +504,6 @@ impl Context {
     {
         self.registry()
             .plugin_value(plugin.into_plugin(), Config::default())
-    }
-
-    /// Wrap and start a concrete [`Plugin`](crate::Plugin) implementation.
-    pub fn plugin_object<P, C>(&self, plugin: P, config: C) -> Fiber
-    where
-        P: crate::Plugin,
-        C: Send + Sync + 'static,
-    {
-        self.registry()
-            .plugin_value(crate::PluginHandle::new(plugin), Config::new(config))
-    }
-
-    /// Start a concrete plugin implementation with unit configuration.
-    pub fn plugin_object_default<P>(&self, plugin: P) -> Fiber
-    where
-        P: crate::Plugin,
-    {
-        self.registry()
-            .plugin_value(crate::PluginHandle::new(plugin), Config::default())
     }
 
     /// Start an inline callback after all listed services become available.

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -100,7 +100,11 @@ impl Event {
     }
 
     /// Invoke the next waterfall listener or innermost behavior.
-    pub fn next(&self) -> BoxFuture<EventResult> {
+    ///
+    /// Renamed from upstream's `next()` to avoid colliding with
+    /// [`Iterator::next`]; the [`Next`] type
+    /// alias keeps the upstream vocabulary.
+    pub fn call_next(&self) -> BoxFuture<EventResult> {
         match self.next.clone() {
             Some(next) => next(),
             None => Box::pin(async { Ok(None) }),
@@ -218,7 +222,7 @@ impl EventsService {
         once: bool,
     ) -> Result<EffectHandle> {
         let fiber = self.ctx.fiber()?;
-        fiber.assert_active()?;
+        fiber.ensure_active()?;
         let id = self.ctx.root.events.next_id();
 
         // Register the owning effect first: failure leaves no hook behind,

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -272,8 +272,8 @@ impl Fiber {
         lock(&self.inner.data).error.clone()
     }
 
-    /// Throw when the fiber has already been disposed.
-    pub fn assert_active(&self) -> Result<()> {
+    /// Return an error when the fiber has already been disposed.
+    pub fn ensure_active(&self) -> Result<()> {
         if self.uid().is_none() || self.state() == FiberState::Disposed {
             Err(CordisError::new(ErrorCode::InactiveEffect))
         } else {
@@ -294,7 +294,7 @@ impl Fiber {
         label: impl Into<String>,
         disposer: AsyncDisposer,
     ) -> Result<EffectHandle> {
-        self.assert_active()?;
+        self.ensure_active()?;
         if self.state() == FiberState::Unloading {
             return Err(CordisError::new(ErrorCode::InactiveEffect));
         }
@@ -704,15 +704,15 @@ impl Fiber {
     /// The wait honors the same ceiling as `restart`/`dispose` (currently
     /// ten seconds): a transition held longer — a hung `apply` or disposer
     /// on another thread — surfaces as a logged error naming the fiber
-    /// instead of blocking the caller forever. `await_idle` has no result
+    /// instead of blocking the caller forever. `wait_idle` has no result
     /// channel, so the log is where the timeout lands.
     ///
     /// Never call this from a lifecycle callback (status listener, disposer,
     /// plugin apply) on the same fiber: the transition mutex is held while
     /// those run, so the call stalls the callback for the full bound before
-    /// logging the timeout. Probe [`idle`](Self::idle) from callbacks
+    /// logging the timeout. Probe [`is_idle`](Self::is_idle) from callbacks
     /// instead.
-    pub fn await_idle(&self) {
+    pub fn wait_idle(&self) {
         {
             let Some(_guard) = self.acquire_transition() else {
                 let error = self.transition_timeout_error();
@@ -733,26 +733,16 @@ impl Fiber {
 
     /// Whether no lifecycle transition is in progress on this fiber.
     ///
-    /// The non-blocking counterpart of [`await_idle`](Self::await_idle):
+    /// The non-blocking counterpart of [`wait_idle`](Self::wait_idle):
     /// lifecycle callbacks and plugin `apply` run on the fiber's own thread
-    /// with the transition mutex held, so they can probe `idle()` safely but
-    /// must never block on `await_idle`. This is a pure probe — it does not
-    /// drain the dirty flag or trigger a reconcile.
-    pub fn idle(&self) -> bool {
+    /// with the transition mutex held, so they can probe `is_idle()` safely
+    /// but must never block on `wait_idle`. This is a pure probe — it does
+    /// not drain the dirty flag or trigger a reconcile.
+    pub fn is_idle(&self) -> bool {
         matches!(
             self.inner.transition.try_lock(),
             Ok(_) | Err(std::sync::TryLockError::Poisoned(_))
         )
-    }
-
-    /// Async equivalent of [`try_wait`](Self::try_wait).
-    ///
-    /// **This never suspends.** It is a synchronous poll despite the
-    /// `async` signature — the eager lifecycle model means there is nothing
-    /// to wait for — so awaiting it runs to completion without ever
-    /// yielding to the executor.
-    pub async fn await_ready(&self) -> Result<Fiber> {
-        self.try_wait()
     }
 
     /// Dispose and immediately reload this plugin with its current config.
@@ -771,7 +761,7 @@ impl Fiber {
     /// other concurrently both time out rather than complete. Trigger
     /// cross-fiber lifecycle operations from a plain thread instead.
     pub fn restart(&self) -> Result<()> {
-        self.assert_active()?;
+        self.ensure_active()?;
         if self.inner.plugin.is_none() {
             return Err(CordisError::with_message(
                 ErrorCode::Other,
@@ -812,7 +802,7 @@ impl Fiber {
 
     /// Type-erased variant of [`update`](Self::update).
     pub fn update_value(&self, config: Config) -> Result<()> {
-        self.assert_active()?;
+        self.ensure_active()?;
         let Some(plugin) = self.inner.plugin.as_ref() else {
             return Err(CordisError::with_message(
                 ErrorCode::Other,
@@ -972,14 +962,14 @@ mod tests {
             let observed = observed.clone();
             move |ctx, _| {
                 // apply() runs inside the fiber's own transition: the probe
-                // must report busy where await_idle would deadlock.
-                lock(&observed).push(ctx.fiber()?.idle());
+                // must report busy where wait_idle would deadlock.
+                lock(&observed).push(ctx.fiber()?.is_idle());
                 Ok(PluginOutput::none())
             }
         }));
         fiber.try_wait().unwrap();
         assert_eq!(*lock(&observed), vec![false]);
-        assert!(fiber.idle());
+        assert!(fiber.is_idle());
     }
 
     /// Regression: a notification landing between refresh()'s final
@@ -1084,13 +1074,13 @@ mod tests {
         provider.join().unwrap().unwrap();
     }
 
-    /// Regression (review 2026-08-19, REV-03): `await_idle` used an
+    /// Regression (review 2026-08-19, REV-03): `wait_idle` used an
     /// unbounded blocking lock on the transition mutex; with a hung apply
     /// holding it, the caller parked forever. It must honor the same wait
     /// ceiling as `restart`/`dispose` and return (logging the timeout)
     /// instead.
     #[test]
-    fn await_idle_times_out_when_apply_hangs() {
+    fn wait_idle_times_out_when_apply_hangs() {
         let root = Context::new();
         let (tx, rx) = std::sync::mpsc::channel::<()>();
         // mpsc receivers are not Sync; the mutex makes the callback shareable
@@ -1120,13 +1110,13 @@ mod tests {
 
         TRANSITION_WAIT_MILLIS.store(150, Ordering::Relaxed);
         let started = Instant::now();
-        fiber.await_idle();
+        fiber.wait_idle();
         let elapsed = started.elapsed();
         TRANSITION_WAIT_MILLIS.store(0, Ordering::Relaxed);
 
         assert!(
             elapsed >= Duration::from_millis(150) && elapsed < Duration::from_secs(5),
-            "await_idle returned in {elapsed:?} instead of timing out at the bound"
+            "wait_idle returned in {elapsed:?} instead of timing out at the bound"
         );
 
         // Let the parked apply finish so the helper thread can join.

--- a/crates/cordis/src/lib.rs
+++ b/crates/cordis/src/lib.rs
@@ -30,6 +30,29 @@
 //! assert_eq!(counter.load(Ordering::SeqCst), 1);
 //! fiber.dispose().unwrap();
 //! ```
+//!
+//! # Naming vocabulary
+//!
+//! The API keeps upstream Cordis verbs (`emit`, `bail`, `waterfall`,
+//! `serial`, `parallel`, `on`, `once`, `provide`, `get`, `set`, `inject`,
+//! `isolate`, `intercept`, `effect`, `plugin`, `accessor`, `require`,
+//! `notify`) and renames them only when a Rust convention conflicts
+//! strongly (e.g. `Event::call_next` instead of upstream's `next()`, which
+//! collides with [`Iterator::next`]). The
+//! suffix/prefix conventions:
+//!
+//! - `*_value` — type-erased (`Value`/`Config`) variant; `resolved_*` —
+//!   evaluated (as opposed to static) result; `with_*` — builder or
+//!   "with extra parameter" variant; `*Service` — context-bound service
+//!   facade.
+//! - `is_`/`has_` — predicates; `assert_` — panics (fallible checks are
+//!   `ensure_`, e.g. [`Fiber::ensure_active`]); `*_unchecked` is reserved
+//!   for genuinely `unsafe` APIs (this crate has none).
+//! - `as_` — cheap borrow; `to_` — expensive copy; `into_` — ownership
+//!   transfer.
+//! - `_async` suffixes mark genuinely suspending functions. The one
+//!   exception is [`Fiber::dispose_async`], kept for upstream parity with
+//!   `disposeAsync`: it is a synchronous pass-through that never yields.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -61,8 +84,8 @@ pub use events::{
 };
 pub use fiber::{Fiber, FiberState};
 pub use logger::{
-    C16, C256, Exporter, ExporterConfig, FormatterFn, LogArg, Logger, LoggerIntercept, LoggerLevel,
-    LoggerService, LoggerType, Message, color_code, default_format,
+    ANSI16_PALETTE, ANSI256_PALETTE, Exporter, ExporterConfig, FormatterFn, LogArg, LogKind,
+    Logger, LoggerIntercept, LoggerLevel, LoggerService, Message, color_code, default_format,
 };
 pub use reflect::{Accessor, Property, ReflectService, ServiceInfo};
 pub use registry::{

--- a/crates/cordis/src/logger.rs
+++ b/crates/cordis/src/logger.rs
@@ -9,9 +9,12 @@ use std::fmt::{self, Debug, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Logger severity/method name.
+/// Logger severity/method name (`error`/`info`/`warn`/`debug`).
+///
+/// Upstream Cordis types this as `LoggerType` with a `type` message field;
+/// the Rust port names the field `kind`, and the type follows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum LoggerType {
+pub enum LogKind {
     /// Error message.
     Error,
     /// Informational message.
@@ -36,7 +39,7 @@ pub enum LoggerLevel {
     Debug = 3,
 }
 
-impl LoggerType {
+impl LogKind {
     fn level(self) -> LoggerLevel {
         match self {
             Self::Error => LoggerLevel::Error,
@@ -164,7 +167,7 @@ pub struct Message {
     /// Logger name.
     pub name: String,
     /// Severity category.
-    pub kind: LoggerType,
+    pub kind: LogKind,
     /// Numeric severity.
     pub level: LoggerLevel,
     /// Printf-style format plus values.
@@ -182,8 +185,9 @@ pub type FormatterFn =
 /// Exporter formatting and level configuration.
 #[derive(Clone)]
 pub struct ExporterConfig {
-    /// ANSI color capability (`0` disables, `2+` enables decorations).
-    pub colors: u8,
+    /// ANSI color depth: `0` disables color, `1` selects the 16-color
+    /// palette, `2+` the 256-color palette.
+    pub color_depth: u8,
     /// Maximum Unicode scalar count for each rendered line.
     pub max_length: usize,
     /// Logger-specific thresholds. The `default` key is the fallback.
@@ -195,7 +199,7 @@ pub struct ExporterConfig {
 impl Default for ExporterConfig {
     fn default() -> Self {
         Self {
-            colors: 0,
+            color_depth: 0,
             max_length: 10_240,
             levels: HashMap::new(),
             formatters: HashMap::new(),
@@ -206,7 +210,7 @@ impl Default for ExporterConfig {
 impl Debug for ExporterConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExporterConfig")
-            .field("colors", &self.colors)
+            .field("color_depth", &self.color_depth)
             .field("max_length", &self.max_length)
             .field("levels", &self.levels)
             .field("formatters", &self.formatters.keys().collect::<Vec<_>>())
@@ -301,7 +305,7 @@ impl LoggerRoot {
     /// bail out before assembling arguments. Per-exporter thresholds may
     /// still drop the record later; this only rules out records nobody
     /// could ever see.
-    fn enabled(&self, default_level: Option<LoggerLevel>, kind: LoggerType) -> bool {
+    fn enabled(&self, default_level: Option<LoggerLevel>, kind: LogKind) -> bool {
         let state = lock(&self.state);
         let buffered =
             state.buffer_size > 0 && default_level.unwrap_or(LoggerLevel::Info) >= kind.level();
@@ -312,7 +316,7 @@ impl LoggerRoot {
         &self,
         name: String,
         default_level: Option<LoggerLevel>,
-        kind: LoggerType,
+        kind: LogKind,
         args: Vec<LogArg>,
         fiber_uid: Option<u64>,
         fiber_name: String,
@@ -370,9 +374,9 @@ impl LoggerRoot {
 }
 
 /// ANSI 16-color palette indexes used for logger name coloring.
-pub const C16: &[u8] = &[6, 2, 3, 4, 5, 1];
+pub const ANSI16_PALETTE: &[u8] = &[6, 2, 3, 4, 5, 1];
 /// ANSI 256-color palette indexes used for logger name coloring.
-pub const C256: &[u8] = &[
+pub const ANSI256_PALETTE: &[u8] = &[
     20, 21, 26, 27, 32, 33, 38, 39, 40, 41, 42, 43, 44, 45, 56, 57, 62, 63, 68, 69, 74, 75, 76, 77,
     78, 79, 80, 81, 92, 93, 98, 99, 112, 113, 129, 134, 135, 148, 149, 160, 161, 162, 163, 164,
     165, 166, 167, 168, 169, 170, 171, 172, 173, 178, 179, 184, 185, 196, 197, 198, 199, 200, 201,
@@ -380,7 +384,10 @@ pub const C256: &[u8] = &[
 ];
 
 /// Stable logger-name color hash.
-pub fn color_code(name: &str, colors: u8) -> u8 {
+///
+/// `color_depth` is the ANSI capability level: `0` disables color, `1`
+/// selects the 16-color palette, `2+` the 256-color palette.
+pub fn color_code(name: &str, color_depth: u8) -> u8 {
     let mut hash: i32 = 0;
     for byte in name.bytes() {
         hash = hash
@@ -389,18 +396,18 @@ pub fn color_code(name: &str, colors: u8) -> u8 {
             .wrapping_add(i32::from(byte))
             .wrapping_add(13);
     }
-    let palette = if colors == 0 {
+    let palette = if color_depth == 0 {
         return 0;
-    } else if colors >= 2 {
-        C256
+    } else if color_depth >= 2 {
+        ANSI256_PALETTE
     } else {
-        C16
+        ANSI16_PALETTE
     };
     palette[(hash.unsigned_abs() as usize) % palette.len()]
 }
 
 fn color(config: &ExporterConfig, code: u8, value: String) -> String {
-    if config.colors == 0 {
+    if config.color_depth == 0 {
         value
     } else if code < 8 {
         format!("\u{001b}[3{code}m{value}\u{001b}[0m")
@@ -459,7 +466,7 @@ pub fn default_format(config: &ExporterConfig, message: &Message) -> String {
             'c' => Some(String::new()),
             'C' => Some(color(
                 config,
-                color_code(&message.name, config.colors),
+                color_code(&message.name, config.color_depth),
                 value.string(),
             )),
             _ => None,
@@ -506,7 +513,7 @@ pub struct Logger {
 }
 
 impl Logger {
-    fn write(&self, kind: LoggerType, format: impl Into<String>, args: Vec<LogArg>) {
+    fn write(&self, kind: LogKind, format: impl Into<String>, args: Vec<LogArg>) {
         // Fast path: when neither the bounded buffer nor any exporter would
         // consume this record, skip the argument assembly and fiber-name
         // resolution entirely — the level check inside send() would only
@@ -532,22 +539,22 @@ impl Logger {
 
     /// Log an error.
     pub fn error(&self, format: impl Into<String>, args: impl IntoIterator<Item = LogArg>) {
-        self.write(LoggerType::Error, format, args.into_iter().collect());
+        self.write(LogKind::Error, format, args.into_iter().collect());
     }
 
     /// Log an informational message.
     pub fn info(&self, format: impl Into<String>, args: impl IntoIterator<Item = LogArg>) {
-        self.write(LoggerType::Info, format, args.into_iter().collect());
+        self.write(LogKind::Info, format, args.into_iter().collect());
     }
 
     /// Log a warning.
     pub fn warn(&self, format: impl Into<String>, args: impl IntoIterator<Item = LogArg>) {
-        self.write(LoggerType::Warn, format, args.into_iter().collect());
+        self.write(LogKind::Warn, format, args.into_iter().collect());
     }
 
     /// Log a debug message.
     pub fn debug(&self, format: impl Into<String>, args: impl IntoIterator<Item = LogArg>) {
-        self.write(LoggerType::Debug, format, args.into_iter().collect());
+        self.write(LogKind::Debug, format, args.into_iter().collect());
     }
 }
 
@@ -606,8 +613,8 @@ impl LoggerService {
         self.exporter_arc(Arc::new(exporter))
     }
 
-    /// Register an exporter callback with explicit config.
-    pub fn exporter_fn<F>(&self, config: ExporterConfig, callback: F) -> Result<EffectHandle>
+    /// Register an exporter callback with an explicit config.
+    pub fn exporter_with<F>(&self, config: ExporterConfig, callback: F) -> Result<EffectHandle>
     where
         F: Fn(&Message) + Send + Sync + 'static,
     {
@@ -737,7 +744,7 @@ mod tests {
         logger.error("kept %d", [LogArg::Integer(2)]);
         let buffer = service.buffer();
         assert_eq!(buffer.len(), 1);
-        assert_eq!(buffer[0].kind, LoggerType::Error);
+        assert_eq!(buffer[0].kind, LogKind::Error);
         assert!(matches!(
             &buffer[0].args[0],
             LogArg::String(text) if text == "kept %d"

--- a/crates/cordis/src/reflect.rs
+++ b/crates/cordis/src/reflect.rs
@@ -244,17 +244,42 @@ impl ReflectService {
     }
 
     /// Read and downcast a service.
-    pub fn get<T>(&self, name: &str, strict: bool) -> Result<Option<Arc<T>>>
+    ///
+    /// The strict path: the read fails while the service's provider is
+    /// loading or unloading. See [`get_relaxed`](Self::get_relaxed) for the
+    /// tolerant variant.
+    pub fn get<T>(&self, name: &str) -> Result<Option<Arc<T>>>
     where
         T: Send + Sync + 'static,
     {
-        self.get_value(name, strict)?
+        self.get_value(name)?
             .map(|value| value.downcast())
             .transpose()
     }
 
-    /// Read a type-erased service or accessor result.
-    pub fn get_value(&self, name: &str, strict: bool) -> Result<Option<Value>> {
+    /// Read and downcast a service even while its provider is loading or
+    /// unloading.
+    pub fn get_relaxed<T>(&self, name: &str) -> Result<Option<Arc<T>>>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.get_value_relaxed(name)?
+            .map(|value| value.downcast())
+            .transpose()
+    }
+
+    /// Read a type-erased service or accessor result, strict variant.
+    pub fn get_value(&self, name: &str) -> Result<Option<Value>> {
+        self.read(name, true)
+    }
+
+    /// Read a type-erased service or accessor result even while its provider
+    /// is loading or unloading.
+    pub fn get_value_relaxed(&self, name: &str) -> Result<Option<Value>> {
+        self.read(name, false)
+    }
+
+    fn read(&self, name: &str, strict: bool) -> Result<Option<Value>> {
         self.ctx.root.reflect.value(&self.ctx, name, strict)
     }
 
@@ -263,7 +288,7 @@ impl ReflectService {
     where
         T: Send + Sync + 'static,
     {
-        let value = self.get_value(name, true)?.ok_or_else(|| {
+        let value = self.get_value(name)?.ok_or_else(|| {
             CordisError::with_message(
                 ErrorCode::MissingService,
                 format!("required service \"{name}\" is unavailable"),
@@ -280,7 +305,7 @@ impl ReflectService {
         check: Option<AvailabilityCheck>,
     ) -> Result<EffectHandle> {
         let fiber = self.ctx.fiber()?;
-        fiber.assert_active()?;
+        fiber.ensure_active()?;
         let uid = fiber
             .uid()
             .ok_or_else(|| CordisError::new(ErrorCode::InactiveEffect))?;
@@ -509,7 +534,7 @@ impl ReflectService {
         self.accessor(
             alias,
             Accessor::read_write(
-                move |ctx| ctx.reflect().get_value(&getter_target, true),
+                move |ctx| ctx.reflect().get_value(&getter_target),
                 move |ctx, value| ctx.reflect().set_value(&setter_target, value),
             ),
         )

--- a/crates/cordis/src/registry.rs
+++ b/crates/cordis/src/registry.rs
@@ -251,6 +251,9 @@ impl Debug for PluginHandle {
 }
 
 /// Conversion accepted by [`Context::plugin`](crate::Context::plugin).
+///
+/// Implemented for every [`Plugin`] (wrapping it in a fresh
+/// [`PluginHandle`]) and for [`PluginHandle`] itself (identity).
 pub trait IntoPlugin {
     /// Produce a stable plugin handle.
     fn into_plugin(self) -> PluginHandle;
@@ -259,6 +262,12 @@ pub trait IntoPlugin {
 impl IntoPlugin for PluginHandle {
     fn into_plugin(self) -> PluginHandle {
         self
+    }
+}
+
+impl<T: Plugin> IntoPlugin for T {
+    fn into_plugin(self) -> PluginHandle {
+        PluginHandle::new(self)
     }
 }
 
@@ -508,7 +517,7 @@ impl RegistryService {
     /// Like [`contains`](Self::contains), dead weak references are pruned
     /// and a runtime whose fibers were all dropped without `dispose()` is
     /// removed, so it disappears from later [`len`](Self::len) counts too.
-    pub fn values(&self) -> Vec<RuntimeInfo> {
+    pub fn runtimes(&self) -> Vec<RuntimeInfo> {
         let mut state = lock(&self.ctx.root.registry.state);
         prune_runtimes(&mut state);
         state
@@ -625,7 +634,7 @@ mod tests {
             );
         }
         assert_eq!(root.registry().len(), 0, "len prunes empty runtimes");
-        assert!(root.registry().values().is_empty());
+        assert!(root.registry().runtimes().is_empty());
         assert!(!root.registry().contains(&handle));
     }
 }

--- a/crates/cordis/tests/dispose.rs
+++ b/crates/cordis/tests/dispose.rs
@@ -1,6 +1,5 @@
 use cordis::{
-    Context, CordisError, EffectMeta, ErrorCode, Inject, LoggerType, PluginOutput, Result,
-    plugin_sync,
+    Context, CordisError, EffectMeta, ErrorCode, Inject, LogKind, PluginOutput, Result, plugin_sync,
 };
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -38,11 +37,7 @@ fn failing_disposer_is_isolated_and_teardown_completes() -> Result<()> {
 
     // The failure reached the logger rather than being silently swallowed.
     let buffer = root.logger_service().buffer();
-    assert!(
-        buffer
-            .iter()
-            .any(|message| message.kind == LoggerType::Error)
-    );
+    assert!(buffer.iter().any(|message| message.kind == LogKind::Error));
     Ok(())
 }
 

--- a/crates/cordis/tests/events.rs
+++ b/crates/cordis/tests/events.rs
@@ -290,3 +290,48 @@ fn sync_waterfall_composes_listeners_around_sync_inner() -> Result<()> {
     assert_eq!(calls.load(Ordering::SeqCst), 2);
     Ok(())
 }
+
+#[test]
+fn on_async_with_prepends_and_context_waterfall_async() -> Result<()> {
+    let root = Context::new();
+    let order = Arc::new(Mutex::new(Vec::new()));
+
+    let regular = order.clone();
+    root.on_async("hook", move |_| {
+        let regular = regular.clone();
+        async move {
+            regular.lock().unwrap().push(1);
+            Ok(None)
+        }
+    })?;
+    let prepended = order.clone();
+    root.on_async_with(
+        "hook",
+        move |_| {
+            let prepended = prepended.clone();
+            async move {
+                prepended.lock().unwrap().push(0);
+                Ok(None)
+            }
+        },
+        EventOptions {
+            prepend: true,
+            global: false,
+        },
+    )?;
+    root.emit("hook", [])?;
+    assert_eq!(*order.lock().unwrap(), vec![0, 1]);
+
+    root.on_async("sum", |event| async move {
+        let value = *event.arg::<u32>(0)?.unwrap();
+        let next = event.call_next().await?.unwrap().downcast::<u32>()?;
+        Ok(Some(Value::new(value + *next)))
+    })?;
+    let result = block_on(root.waterfall_async("sum", [Value::new(1_u32)], || async {
+        Ok(Some(Value::new(2_u32)))
+    }))?
+    .unwrap()
+    .downcast::<u32>()?;
+    assert_eq!(*result, 3);
+    Ok(())
+}

--- a/crates/cordis/tests/events.rs
+++ b/crates/cordis/tests/events.rs
@@ -68,12 +68,12 @@ fn bail_serial_parallel_and_waterfall() -> Result<()> {
 
     root.on_async("sum", |event| async move {
         let value = *event.arg::<u32>(0)?.unwrap();
-        let next = event.next().await?.unwrap().downcast::<u32>()?;
+        let next = event.call_next().await?.unwrap().downcast::<u32>()?;
         Ok(Some(Value::new(value + *next)))
     })?;
     root.on_async("sum", |event| async move {
         let value = *event.arg::<u32>(0)?.unwrap();
-        let next = event.next().await?.unwrap().downcast::<u32>()?;
+        let next = event.call_next().await?.unwrap().downcast::<u32>()?;
         Ok(Some(Value::new(value + *next)))
     })?;
     let result = block_on(
@@ -274,7 +274,7 @@ fn sync_waterfall_composes_listeners_around_sync_inner() -> Result<()> {
             async move {
                 calls.fetch_add(1, Ordering::SeqCst);
                 let value = *event.arg::<u32>(0)?.unwrap();
-                let next = event.next().await?.unwrap().downcast::<u32>()?;
+                let next = event.call_next().await?.unwrap().downcast::<u32>()?;
                 Ok(Some(Value::new(value + *next)))
             }
         })?;

--- a/crates/cordis/tests/lifecycle.rs
+++ b/crates/cordis/tests/lifecycle.rs
@@ -430,7 +430,7 @@ fn panicking_plugin_state_is_recoverable() -> Result<()> {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| root.plugin_default(plugin)));
     assert!(panicked.is_err());
 
-    let fiber = root.registry().values()[0].fibers[0].clone();
+    let fiber = root.registry().runtimes()[0].fibers[0].clone();
     assert_eq!(fiber.state(), FiberState::Loading);
 
     should_panic.store(false, Ordering::SeqCst);
@@ -493,10 +493,10 @@ fn partial_dependencies_keep_fiber_pending() -> Result<()> {
     let effect_a = root.provide_arc("a", Arc::new(1_u32))?;
     assert_eq!(fiber.state(), FiberState::Pending);
     let _effect_b = root.provide_arc("b", Arc::new(2_u32))?;
-    fiber.await_idle();
+    fiber.wait_idle();
     assert_eq!(fiber.state(), FiberState::Active);
     effect_a.dispose()?;
-    fiber.await_idle();
+    fiber.wait_idle();
     assert_eq!(fiber.state(), FiberState::Pending);
     Ok(())
 }

--- a/crates/cordis/tests/reflect_logger.rs
+++ b/crates/cordis/tests/reflect_logger.rs
@@ -42,7 +42,7 @@ fn logger_buffers_exports_formats_and_intercepts() -> Result<()> {
         .insert("default".to_owned(), LoggerLevel::Debug);
     let exporter = root
         .logger_service()
-        .exporter_fn(config.clone(), move |message| {
+        .exporter_with(config.clone(), move |message| {
             sink.lock().unwrap().push(message.clone());
         })?;
 


### PR DESCRIPTION
## Summary

Executes the naming review decided on 2026-08-19 (the reviewed list lives locally as `NAMING-REVIEW.md`). Two commits:

- `refactor!:` the rename wave — align the public surface with Rust naming conventions while keeping upstream Cordis verbs; deviations are recorded in doc comments.
- `feat:` close two facade gaps — `Context::on_async_with` and `Context::waterfall_async`.

## Renames

| Old | New | Why |
| --- | --- | --- |
| `Fiber::assert_active` | `ensure_active` | `assert_` is reserved for panicking checks |
| `Context::get_unchecked` | `get_relaxed` | safe API; `unchecked` implies `unsafe` |
| `ReflectService::get`/`get_value` (`strict: bool`) | `get`/`get_relaxed`, `get_value`/`get_value_relaxed` | drop the boolean parameter |
| `Event::next` | `call_next` | avoids the `Iterator::next` collision; the `Next` alias keeps the upstream vocabulary |
| `EntryTree::update` / `update_entry` | `reconcile` / `reconcile_entry` | reuse-by-id + `TreeDiff` semantics; matches the loader's own vocabulary |
| `Loader::update` | `recompose` | dual of `reload` (memory document vs file) |
| `Entry::disabled` / `enabled` | `is_disabled` / `is_enabled` | predicate convention; docs now spell out the scope asymmetry between the two |
| `Fiber::await_idle` / `idle` | `wait_idle` / `is_idle` | non-async function; predicate convention |
| `LoggerType` | `LogKind` | the upstream message field `type` is already ported as `kind` |
| `C16` / `C256` | `ANSI16_PALETTE` / `ANSI256_PALETTE` | readable const names |
| `color_code(colors)` param + `ExporterConfig.colors` | `color_depth` | it is a 0/1/2 capability level, not a count |
| `RegistryService::values` | `runtimes` | returns `Vec<RuntimeInfo>` snapshots |
| `LoggerService::exporter_fn` | `exporter_with` | matches the `*_with` convention of `on_with`/`require_with` |
| `EntryTree::assert_owned` (private) | `ensure_owned` | same rule as `ensure_active`, internal consistency |

## Removals

- `Fiber::await_ready` — was identical to `try_wait`.
- `Context::plugin_object` / `plugin_object_default` — replaced by a blanket `impl<T: Plugin> IntoPlugin for T`, so `Context::plugin` accepts plugin implementations directly (`PluginHandle` still works).

## Additions (second commit)

- `Context::on_async_with` — async listeners can now set `EventOptions` (`prepend`/`global`); the service layer already accepted options, only the facade lacked the entry point.
- `Context::waterfall_async` — mirrors `EventsService::waterfall_async` on the facade, next to the sync `waterfall`.

Also adds a naming-vocabulary section to the crate docs (including the `dispose_async` upstream-parity exception: it keeps its name but never yields) and updates both README languages.

## Verification

Full gate run twice (pinned 1.85 toolchain): `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (33 suites, including a new test for the facade additions), `cargo doc --workspace --no-deps` with `-D warnings`, and all eight README doctests (EN + zh-CN) with the CI-exact `--extern` flags.

Release-plz should derive a minor bump (`refactor!` → 0.6.0).