### PR TITLE
feat: port the five intercept meta-events (internal/get, internal/set, internal/config, internal/update, internal/listener)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 *.profraw
 .DS_Store
+/.cargo-home/

--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ The crate currently ports the complete **core runtime**:
 | Logger buffer/exporters/levels/formatters | corresponding logger APIs | ✅ |
 | Standard Schema validation | `Plugin::validate_config` + validation issues | ✅³ |
 | `internal/plugin`, `internal/status`, `internal/service`, `internal/dispatch` | same meta-events | ✅⁴ |
-| Intercept meta-events (`internal/get`/`set`/`config`/`update`/`listener`) | not ported | Not included |
+| Intercept meta-events (`internal/get`/`set`/`config`/`update`/`listener`) | same five interception points | ✅⁵ |
 | Decorators and callable services | explicit Rust traits/builders | Rust-native |
 | Loader / include packages | [`cordis-include`](../crates/cordis-include), [`cordis-group`](../crates/cordis-group), [`cordis-loader`](../crates/cordis-loader), [`cordis-cli`](../crates/cordis-cli) | ✅ separate crates |
 
 1. Rust cannot dynamically project arbitrary struct fields like a JavaScript Proxy, so `alias()` is the explicit counterpart to common `mixin()` usage.
 2. Rust plugin code registers multiple effects explicitly; `EffectHandle::adopt()` provides the original nested diagnostic/disposal tree.
 3. Validation is trait-based because Standard Schema is a JavaScript protocol.
-4. `internal/dispatch` carries `(mode, name, args)`; the upstream fourth `thisArg` argument is omitted. The waterfall/bail interception points used by upstream HMR and config injection (`internal/get`, `internal/set`, `internal/config`, `internal/update`, `internal/listener`) are not part of this port, so downstream code relying on them needs a different extension point.
+4. `internal/dispatch` carries `(mode, name, args)`; the upstream fourth `thisArg` argument is omitted.
+5. The five interception points used by upstream HMR and config injection are ported with Rust-native semantics: `internal/get` (waterfall around strict service reads), `internal/set` (waterfall around service writes), `internal/config` (waterfall around config resolution; the effective config is the waterfall's result), `internal/update` (waterfall around the restart an update schedules), and `internal/listener` (bail whose value cancels a registration, returning an inert handle). Arguments are immutable `Value`s — listeners wrap through `Event::call_next()` or veto by skipping it.
 
 ## Design goals
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,14 +32,15 @@ Cordis 是一个基于上下文的插件框架，适用于需要显式依赖注�
 | Logger 缓冲区/exporter/级别/格式化器 | 对应的 logger API | ✅ |
 | Standard Schema 校验 | `Plugin::validate_config` + 校验问题列表 | ✅³ |
 | `internal/plugin`、`internal/status`、`internal/service`、`internal/dispatch` | 同名元事件 | ✅⁴ |
-| 拦截元事件（`internal/get`/`set`/`config`/`update`/`listener`） | 未移植 | 未包含 |
+| 拦截元事件（`internal/get`/`set`/`config`/`update`/`listener`） | 相同的五个拦截点 | ✅⁵ |
 | 装饰器和可调用服务 | 显式 Rust trait/builder | Rust 原生实现 |
 | Loader / include 包 | [`cordis-include`](../crates/cordis-include)、[`cordis-group`](../crates/cordis-group)、[`cordis-loader`](../crates/cordis-loader)、[`cordis-cli`](../crates/cordis-cli) | ✅ 独立 crate |
 
 1. Rust 无法像 JavaScript Proxy 一样动态投影任意 struct 字段，因此 `alias()` 是常见 `mixin()` 用法的显式对应方案。
 2. Rust 插件代码会显式注册多个 effect；`EffectHandle::adopt()` 提供与原版对应的嵌套诊断和回收树。
 3. Standard Schema 是 JavaScript 协议，因此 Rust 版本采用 trait 方式进行校验。
-4. `internal/dispatch` 携带 `(mode, name, args)` 三个参数，省略了上游的第四个 `thisArg` 参数。上游 HMR 和配置注入依赖的 waterfall/bail 拦截点（`internal/get`、`internal/set`、`internal/config`、`internal/update`、`internal/listener`）不在本移植范围内，依赖这些事件的下游代码需要另找扩展点。
+4. `internal/dispatch` 携带 `(mode, name, args)` 三个参数，省略了上游的第四个 `thisArg` 参数。
+5. 上游 HMR 和配置注入依赖的五个拦截点已按 Rust 原生语义移植：`internal/get`（围绕严格服务读取的 waterfall）、`internal/set`（围绕服务写入的 waterfall）、`internal/config`（围绕配置解析的 waterfall，生效配置即 waterfall 的结果）、`internal/update`（围绕 update 触发的重启的 waterfall）、`internal/listener`（bail，其值会取消注册并返回一个惰性 handle）。参数是不可变的 `Value`——监听器通过 `Event::call_next()` 包裹原操作，或跳过它来否决。
 
 ## 设计目标
 

--- a/crates/cordis/src/effect.rs
+++ b/crates/cordis/src/effect.rs
@@ -213,6 +213,20 @@ impl EffectHandle {
         Self { cell }
     }
 
+    /// A handle that owns nothing: returned when an `internal/listener`
+    /// interceptor cancels a registration and takes ownership of the
+    /// listener. Disposing it is a no-op.
+    pub(crate) fn inert() -> Self {
+        Self {
+            cell: EffectCell::new(
+                0,
+                Weak::new(),
+                "intercepted listener",
+                AsyncDisposer::from_sync(|| Ok(())),
+            ),
+        }
+    }
+
     /// Dispose this effect synchronously, waiting for asynchronous cleanup.
     pub fn dispose(&self) -> Result<()> {
         block_on(self.dispose_async())

--- a/crates/cordis/src/events.rs
+++ b/crates/cordis/src/events.rs
@@ -223,6 +223,22 @@ impl EventsService {
     ) -> Result<EffectHandle> {
         let fiber = self.ctx.fiber()?;
         fiber.ensure_active()?;
+
+        // Upstream parity: a bail `internal/listener` fires before any
+        // listener is registered. A bailing listener cancels the standard
+        // registration and takes ownership of the listener, so the caller
+        // receives an inert handle instead of a live one.
+        if self.listener_count("internal/listener") > 0 {
+            let intercepted = self.bail_from(
+                self.ctx.clone(),
+                "internal/listener",
+                [Value::new(name.clone()), Value::new(options)],
+            )?;
+            if intercepted.is_some() {
+                return Ok(EffectHandle::inert());
+            }
+        }
+
         let id = self.ctx.root.events.next_id();
 
         // Register the owning effect first: failure leaves no hook behind,
@@ -536,7 +552,24 @@ impl EventsService {
         name: impl Into<String>,
         args: impl IntoIterator<Item = EventValue>,
     ) -> EventResult {
-        let event = Event::new(name, args);
+        self.bail_event(Event::new(name, args))
+    }
+
+    /// Synchronous ordered bail dispatch with an explicit target context for
+    /// listener filtering.
+    ///
+    /// The targeted counterpart of [`bail`](Self::bail), mirroring
+    /// [`emit_from`](Self::emit_from).
+    pub fn bail_from(
+        &self,
+        target: Context,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = EventValue>,
+    ) -> EventResult {
+        self.bail_event(Event::new(name, args).with_target(target))
+    }
+
+    fn bail_event(&self, event: Event) -> EventResult {
         for callback in self.dispatch(DispatchMode::Bail, &event) {
             let result = block_on(callback(event.clone()))?;
             if is_bailed(&result) {
@@ -560,7 +593,35 @@ impl EventsService {
         F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = EventResult> + Send + 'static,
     {
-        let event = Event::new(name, args);
+        self.waterfall_async_event(Event::new(name, args), inner)
+            .await
+    }
+
+    /// Compose listeners around an innermost asynchronous callback, with an
+    /// explicit target context for listener filtering.
+    ///
+    /// The targeted counterpart of [`waterfall_async`](Self::waterfall_async),
+    /// mirroring [`emit_from`](Self::emit_from).
+    pub async fn waterfall_async_from<F, Fut>(
+        &self,
+        target: Context,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = EventValue>,
+        inner: F,
+    ) -> EventResult
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = EventResult> + Send + 'static,
+    {
+        self.waterfall_async_event(Event::new(name, args).with_target(target), inner)
+            .await
+    }
+
+    async fn waterfall_async_event<F, Fut>(&self, event: Event, inner: F) -> EventResult
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = EventResult> + Send + 'static,
+    {
         let callbacks = self.dispatch(DispatchMode::Waterfall, &event);
         let inner = Arc::new(inner);
         let mut next: Next = Arc::new(move || Box::pin(inner()));
@@ -587,6 +648,27 @@ impl EventsService {
         F: Fn() -> EventResult + Send + Sync + 'static,
     {
         block_on(self.waterfall_async(name, args, move || {
+            let result = inner();
+            async move { result }
+        }))
+    }
+
+    /// Synchronous waterfall convenience wrapper with an explicit target
+    /// context for listener filtering.
+    ///
+    /// The targeted counterpart of [`waterfall`](Self::waterfall), mirroring
+    /// [`emit_from`](Self::emit_from).
+    pub fn waterfall_from<F>(
+        &self,
+        target: Context,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = EventValue>,
+        inner: F,
+    ) -> EventResult
+    where
+        F: Fn() -> EventResult + Send + Sync + 'static,
+    {
+        block_on(self.waterfall_async_from(target, name, args, move || {
             let result = inner();
             async move { result }
         }))

--- a/crates/cordis/src/fiber.rs
+++ b/crates/cordis/src/fiber.rs
@@ -438,7 +438,9 @@ impl Fiber {
         };
         let result = match validated {
             Some(config) => Ok(config),
-            None => plugin.plugin().validate_config(raw_config),
+            None => self
+                .resolve_config(raw_config)
+                .and_then(|config| plugin.plugin().validate_config(config)),
         }
         .and_then(|config| {
             let output = block_on(plugin.plugin().apply(ctx, config.clone()))?;
@@ -788,9 +790,12 @@ impl Fiber {
     /// Validate and apply new config, then restart when dependencies are
     /// active.
     ///
-    /// An `Active` fiber is validated first — a validation failure keeps the
-    /// running plugin untouched — then restarted, so the returned result
-    /// reflects the new startup.
+    /// An `Active` fiber is resolved through the `internal/config` waterfall
+    /// and validated first — a validation failure keeps the running plugin
+    /// untouched — then restarted, so the returned result reflects the new
+    /// startup. The restart itself runs through the `internal/update`
+    /// waterfall: listeners may wrap it or veto it by skipping `next` (the
+    /// config is stored either way).
     ///
     /// A `Pending` or `Failed` fiber instead stores the new config, clears
     /// any previous startup error, and reconciles: it activates with the new
@@ -818,31 +823,82 @@ impl Fiber {
                 "cannot update config on the root fiber",
             ));
         };
-        // Match Cordis: validation happens before an active plugin is torn
-        // down. The validated result is stashed so activate() does not run
-        // the validator twice for the same raw config.
-        let validated = if self.state() == FiberState::Active {
-            Some(plugin.plugin().validate_config(config.clone())?)
-        } else {
-            None
-        };
+        if self.state() == FiberState::Active {
+            // Match Cordis: resolution (the `internal/config` waterfall) and
+            // validation happen before an active plugin is torn down. The
+            // validated result is stashed so activate() does not run the
+            // waterfall or the validator twice for the same raw config.
+            let config = self.resolve_config(config)?;
+            let validated = plugin.plugin().validate_config(config.clone())?;
+            {
+                let mut data = lock(&self.inner.data);
+                data.validated = Some((config.clone(), validated.clone()));
+                data.raw_config = config;
+                data.failed_epoch = None;
+                data.error = None;
+            }
+            return self.waterfall_update(validated);
+        }
+        // Match Cordis: a config update on an inactive fiber is stored and
+        // reconciled, not resolved or awaited. The refresh below may already
+        // have re-run a failed startup; the outcome is observable through
+        // state()/error() rather than this return value.
         {
             let mut data = lock(&self.inner.data);
-            data.validated = validated.map(|valid| (config.clone(), valid));
+            data.validated = None;
             data.raw_config = config;
             data.failed_epoch = None;
             data.error = None;
         }
-        if self.state() == FiberState::Active {
-            self.restart()
-        } else {
-            // Match Cordis: a config update on an inactive fiber is stored
-            // and reconciled, not awaited. The refresh above may already
-            // have re-run a failed startup; the outcome is observable
-            // through state()/error() rather than this return value.
-            self.refresh();
-            Ok(())
+        self.refresh();
+        Ok(())
+    }
+
+    /// Run the `internal/config` waterfall over a raw config and return the
+    /// effective config: the waterfall's result when a listener rewrites it,
+    /// the original otherwise.
+    ///
+    /// When no `internal/config` listener is registered (the common case)
+    /// the config passes through untouched. A listener error fails the
+    /// caller, which on the activation path leaves the fiber `Failed`.
+    fn resolve_config(&self, config: Config) -> Result<Config> {
+        let Some(ctx) = self.context() else {
+            return Ok(config);
+        };
+        if ctx.events().listener_count("internal/config") == 0 {
+            return Ok(config);
         }
+        let value = config.clone();
+        let result = ctx.events().waterfall_from(
+            ctx.clone(),
+            "internal/config",
+            [config.clone()],
+            move || Ok(Some(value.clone())),
+        )?;
+        Ok(result.unwrap_or(config))
+    }
+
+    /// Run the `internal/update` waterfall around the restart scheduled by a
+    /// config update on an active fiber.
+    ///
+    /// Listeners may wrap the restart by calling `event.call_next()` or veto
+    /// it by skipping `next` (the config is stored either way, so a later
+    /// restart applies it). The innermost behavior restarts the fiber, so a
+    /// vetoed update reports `Ok(())` without restarting — matching upstream
+    /// HMR's interception point.
+    fn waterfall_update(&self, config: Config) -> Result<()> {
+        let Some(ctx) = self.context() else {
+            return self.restart();
+        };
+        if ctx.events().listener_count("internal/update") == 0 {
+            return self.restart();
+        }
+        let fiber = self.clone();
+        ctx.events()
+            .waterfall_from(ctx.clone(), "internal/update", [config], move || {
+                fiber.restart().map(|_| None)
+            })?;
+        Ok(())
     }
 
     /// Permanently dispose this plugin fiber. Repeated calls are no-ops.

--- a/crates/cordis/src/lib.rs
+++ b/crates/cordis/src/lib.rs
@@ -57,6 +57,36 @@
 //! - `_async` suffixes mark genuinely suspending functions. The one
 //!   exception is [`Fiber::dispose_async`], kept for upstream parity with
 //!   `disposeAsync`: it is a synchronous pass-through that never yields.
+//!
+//! # Intercept meta-events
+//!
+//! The five upstream interception points are ported as ordinary events on
+//! the root bus, named `internal/get`, `internal/set`, `internal/config`,
+//! `internal/update`, and `internal/listener`. Each fires with the operating
+//! context as its dispatch target, so context filters apply, and arguments
+//! are immutable [`Value`]s — interception means wrapping or vetoing, never
+//! in-place mutation:
+//!
+//! - `internal/get` — waterfall around every strict service read
+//!   ([`ReflectService::get_value`] / [`Context::require`]); accessor reads
+//!   and relaxed reads bypass it. The innermost behavior resolves the
+//!   service; listeners may wrap or replace the result.
+//! - `internal/set` — waterfall around service writes
+//!   ([`ReflectService::set_value`]); listeners may veto a write by not
+//!   calling [`Event::call_next`].
+//! - `internal/config` — waterfall around config resolution ([`Fiber::update`]
+//!   and activation); the effective config is the waterfall's result, the
+//!   original when untouched.
+//! - `internal/update` — waterfall around the restart an update schedules;
+//!   skipping [`Event::call_next`] vetoes the restart (the config is stored
+//!   either way).
+//! - `internal/listener` — bail fired before a listener is registered; a
+//!   bail value cancels the registration and the caller receives an inert
+//!   [`EffectHandle`].
+//!
+//! Like upstream, the interception events themselves fire no
+//! `internal/dispatch` meta-event, so meta-listeners cannot recurse through
+//! them.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/cordis/src/reflect.rs
+++ b/crates/cordis/src/reflect.rs
@@ -113,6 +113,11 @@ impl ReflectRoot {
             .or_else(|| lock(&self.state).default_scopes.get(name).copied())
     }
 
+    /// The reflected property kind for `name`, without resolving the value.
+    fn property_kind(&self, name: &str) -> Option<Property> {
+        lock(&self.state).properties.get(name).cloned()
+    }
+
     fn ensure_scope(&self, ctx: &Context, name: &str) -> Isolation {
         if let Some(scope) = ctx.scope_override(name) {
             return scope;
@@ -280,7 +285,24 @@ impl ReflectService {
     }
 
     fn read(&self, name: &str, strict: bool) -> Result<Option<Value>> {
-        self.ctx.root.reflect.value(&self.ctx, name, strict)
+        // Upstream parity: the `internal/get` waterfall fires only on strict
+        // reads of service properties. Accessor reads bypass it (the proxy
+        // calls accessor getters directly), as do relaxed reads.
+        if !strict
+            || self.ctx.root.reflect.property_kind(name) == Some(Property::Accessor)
+            || self.ctx.events().listener_count("internal/get") == 0
+        {
+            return self.ctx.root.reflect.value(&self.ctx, name, strict);
+        }
+        let ctx = self.ctx.clone();
+        let name = name.to_owned();
+        let result = ctx.events().waterfall_from(
+            ctx.clone(),
+            "internal/get",
+            [Value::new(name.clone())],
+            move || ctx.root.reflect.value(&ctx, &name, true),
+        )?;
+        Ok(result)
     }
 
     /// Require and downcast an active service.
@@ -426,24 +448,56 @@ impl ReflectService {
     /// Availability predicates registered with
     /// [`provide_checked`](Self::provide_checked) see the new value on their
     /// next evaluation.
+    ///
+    /// Service writes run the `internal/set` waterfall when listeners are
+    /// registered: listeners may observe the write or veto it by not calling
+    /// `call_next()`. Accessor writes and writes to undeclared names bypass
+    /// the waterfall, matching upstream.
     pub fn set_value(&self, name: &str, value: Value) -> Result<()> {
+        match self.ctx.root.reflect.property_kind(name) {
+            Some(Property::Accessor) => {
+                let setter = lock(&self.ctx.root.reflect.state)
+                    .accessors
+                    .get(name)
+                    .and_then(|record| record.accessor.set.clone());
+                let setter = setter.ok_or_else(|| {
+                    CordisError::with_message(
+                        ErrorCode::AccessDenied,
+                        format!("property \"{name}\" is read-only"),
+                    )
+                })?;
+                setter(&self.ctx, value)
+            }
+            None => Err(CordisError::with_message(
+                ErrorCode::MissingService,
+                format!("cannot set property \"{name}\" without provide"),
+            )),
+            Some(Property::Service) => {
+                if self.ctx.events().listener_count("internal/set") == 0 {
+                    return self.set_service_value(name, value);
+                }
+                let ctx = self.ctx.clone();
+                let name = name.to_owned();
+                ctx.events().waterfall_from(
+                    ctx.clone(),
+                    "internal/set",
+                    [Value::new(name.clone()), value.clone()],
+                    move || {
+                        ctx.reflect()
+                            .set_service_value(&name, value.clone())
+                            .map(|_| None)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+
+    /// The service-write half of [`set_value`](Self::set_value), wrapped by
+    /// the `internal/set` waterfall when listeners are registered.
+    fn set_service_value(&self, name: &str, value: Value) -> Result<()> {
         let scope_override = self.ctx.scope_override(name);
         let mut state = lock(&self.ctx.root.reflect.state);
-        if state.properties.get(name) == Some(&Property::Accessor) {
-            let setter = state
-                .accessors
-                .get(name)
-                .and_then(|record| record.accessor.set.clone());
-            drop(state);
-            let setter = setter.ok_or_else(|| {
-                CordisError::with_message(
-                    ErrorCode::AccessDenied,
-                    format!("property \"{name}\" is read-only"),
-                )
-            })?;
-            return setter(&self.ctx, value);
-        }
-
         let scope = scope_override
             .or_else(|| state.default_scopes.get(name).copied())
             .ok_or_else(|| {

--- a/crates/cordis/tests/intercepts.rs
+++ b/crates/cordis/tests/intercepts.rs
@@ -1,0 +1,287 @@
+//! The five upstream intercept meta-events: `internal/get`, `internal/set`,
+//! `internal/config`, `internal/update`, and `internal/listener`.
+
+use cordis::utils::block_on;
+use cordis::{Accessor, Context, ErrorCode, FiberState, PluginOutput, Result, Value, plugin_sync};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn internal_get_rewrites_strict_reads_and_skips_accessors_and_relaxed() -> Result<()> {
+    let root = Context::new();
+    root.provide("svc", 42_u32)?;
+    let seen = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let seen_in_listener = seen.clone();
+    root.on("internal/get", move |event| {
+        // The interception event carries the operating context as its target
+        // and the service name as its argument.
+        assert!(event.target().is_some());
+        let name = event.arg::<String>(0)?.unwrap();
+        seen_in_listener.lock().unwrap().push(name.to_string());
+        let next = block_on(event.call_next())?;
+        if name.as_str() == "svc" {
+            Ok(Some(Value::new(7_u32)))
+        } else {
+            Ok(next)
+        }
+    })?;
+
+    // Strict reads are intercepted and rewritten.
+    assert_eq!(*root.require::<u32>("svc")?, 7);
+    assert_eq!(root.get::<u32>("svc")?.unwrap().as_ref(), &7_u32);
+
+    // Relaxed reads bypass the interception.
+    assert_eq!(*root.get_relaxed::<u32>("svc")?.unwrap(), 42);
+
+    // Accessor reads bypass the interception (upstream proxy parity).
+    let _accessor = root.accessor(
+        "computed",
+        Accessor::read_only(|_| Ok(Some(Value::new(1_u32)))),
+    )?;
+    assert_eq!(*root.require::<u32>("computed")?, 1);
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec!["svc".to_owned(), "svc".to_owned()]
+    );
+    Ok(())
+}
+
+#[test]
+fn internal_get_failure_fails_the_read() -> Result<()> {
+    let root = Context::new();
+    root.provide("svc", 1_u32)?;
+    root.on("internal/get", |event| {
+        let name = event.arg::<String>(0)?.unwrap();
+        if name.as_str() == "svc" {
+            Err(cordis::CordisError::with_message(
+                ErrorCode::Event,
+                "get intercepted",
+            ))
+        } else {
+            block_on(event.call_next())
+        }
+    })?;
+    let error = root.require::<u32>("svc").unwrap_err();
+    assert!(error.to_string().contains("get intercepted"));
+    Ok(())
+}
+
+#[test]
+fn internal_set_observes_and_can_veto_writes() -> Result<()> {
+    let root = Context::new();
+    root.provide("svc", 1_u32)?;
+    let seen = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let seen_in_listener = seen.clone();
+    root.on("internal/set", move |event| {
+        let name = event.arg::<String>(0)?.unwrap();
+        let value = *event.arg::<u32>(1)?.unwrap();
+        seen_in_listener
+            .lock()
+            .unwrap()
+            .push(format!("{}={value}", name.as_str()));
+        block_on(event.call_next())
+    })?;
+
+    root.set("svc", 2_u32)?;
+    assert_eq!(*root.require::<u32>("svc")?, 2);
+
+    // A later listener vetoes the write of 3 by not continuing the chain.
+    root.on("internal/set", |event| {
+        let value = *event.arg::<u32>(1)?.unwrap();
+        if value == 3 {
+            Ok(None)
+        } else {
+            block_on(event.call_next())
+        }
+    })?;
+    root.set("svc", 3_u32)?;
+    assert_eq!(
+        *root.require::<u32>("svc")?,
+        2,
+        "vetoed write must not land"
+    );
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec!["svc=2".to_owned(), "svc=3".to_owned()]
+    );
+    Ok(())
+}
+
+#[test]
+fn internal_set_failure_fails_the_set() -> Result<()> {
+    let root = Context::new();
+    root.provide("svc", 1_u32)?;
+    root.on("internal/set", |event| {
+        let name = event.arg::<String>(0)?.unwrap();
+        if name.as_str() == "svc" {
+            Err(cordis::CordisError::with_message(
+                ErrorCode::Event,
+                "set rejected",
+            ))
+        } else {
+            block_on(event.call_next())
+        }
+    })?;
+    let error = root.set("svc", 2_u32).unwrap_err();
+    assert!(error.to_string().contains("set rejected"));
+    assert_eq!(*root.require::<u32>("svc")?, 1, "failed set must not land");
+    Ok(())
+}
+
+#[test]
+fn internal_config_rewrites_config_on_start_and_update() -> Result<()> {
+    let root = Context::new();
+    let intercepted = Arc::new(Mutex::new(Vec::<u32>::new()));
+    let applied = Arc::new(Mutex::new(Vec::<u32>::new()));
+
+    let intercepted_in_listener = intercepted.clone();
+    root.on("internal/config", move |event| {
+        let config = *event.arg::<u32>(0)?.unwrap();
+        intercepted_in_listener.lock().unwrap().push(config);
+        Ok(Some(Value::new(config * 2)))
+    })?;
+
+    let applied_in_plugin = applied.clone();
+    let fiber = root.plugin(
+        plugin_sync::<u32, _>("cfg", Default::default(), move |_, config| {
+            applied_in_plugin.lock().unwrap().push(*config);
+            Ok(PluginOutput::none())
+        }),
+        5_u32,
+    );
+    fiber.try_wait()?;
+    assert_eq!(*applied.lock().unwrap(), vec![10], "startup config doubled");
+    assert_eq!(*fiber.config().downcast::<u32>()?, 10);
+
+    fiber.update(21_u32)?;
+    fiber.try_wait()?;
+    assert_eq!(
+        *applied.lock().unwrap(),
+        vec![10, 42],
+        "update config doubled"
+    );
+    assert_eq!(*fiber.config().downcast::<u32>()?, 42);
+    assert_eq!(*intercepted.lock().unwrap(), vec![5, 21]);
+    Ok(())
+}
+
+#[test]
+fn internal_config_failure_fails_activation() -> Result<()> {
+    let root = Context::new();
+    root.on("internal/config", |_| {
+        Err(cordis::CordisError::with_message(
+            ErrorCode::Event,
+            "config rejected",
+        ))
+    })?;
+    let fiber = root.plugin(
+        plugin_sync::<u32, _>("cfg", Default::default(), |_, _| Ok(PluginOutput::none())),
+        1_u32,
+    );
+    assert_eq!(fiber.state(), FiberState::Failed);
+    let error = fiber.error().unwrap();
+    assert!(error.to_string().contains("config rejected"));
+    Ok(())
+}
+
+#[test]
+fn internal_update_can_veto_and_then_allow_restarts() -> Result<()> {
+    let root = Context::new();
+    let applies = Arc::new(AtomicUsize::new(0));
+    let applies_in_plugin = applies.clone();
+    let fiber = root.plugin(
+        plugin_sync::<u32, _>("up", Default::default(), move |_, _| {
+            applies_in_plugin.fetch_add(1, Ordering::SeqCst);
+            Ok(PluginOutput::none())
+        }),
+        1_u32,
+    );
+    fiber.try_wait()?;
+    assert_eq!(applies.load(Ordering::SeqCst), 1);
+
+    let veto = Arc::new(AtomicBool::new(true));
+    let veto_in_listener = veto.clone();
+    root.on("internal/update", move |event| {
+        if veto_in_listener.load(Ordering::SeqCst) {
+            Ok(None) // veto: do not continue to the restart
+        } else {
+            block_on(event.call_next())
+        }
+    })?;
+
+    // Vetoed update: the config is stored but the fiber is not restarted.
+    fiber.update(2_u32)?;
+    assert_eq!(applies.load(Ordering::SeqCst), 1, "vetoed update restarted");
+    assert_eq!(*fiber.config().downcast::<u32>()?, 1);
+    assert_eq!(fiber.state(), FiberState::Active);
+
+    // Lifting the veto lets the next update restart with its config.
+    veto.store(false, Ordering::SeqCst);
+    fiber.update(3_u32)?;
+    fiber.try_wait()?;
+    assert_eq!(applies.load(Ordering::SeqCst), 2);
+    assert_eq!(*fiber.config().downcast::<u32>()?, 3);
+    Ok(())
+}
+
+#[test]
+fn internal_update_failure_fails_the_update() -> Result<()> {
+    let root = Context::new();
+    let fiber = root.plugin(
+        plugin_sync::<u32, _>("up", Default::default(), |_, _| Ok(PluginOutput::none())),
+        1_u32,
+    );
+    fiber.try_wait()?;
+    root.on("internal/update", |_| {
+        Err(cordis::CordisError::with_message(
+            ErrorCode::Event,
+            "update vetoed",
+        ))
+    })?;
+    let error = fiber.update(2_u32).unwrap_err();
+    assert!(error.to_string().contains("update vetoed"));
+    assert_eq!(fiber.state(), FiberState::Active, "failed update restarted");
+    Ok(())
+}
+
+#[test]
+fn internal_listener_bail_cancels_registration() -> Result<()> {
+    let root = Context::new();
+    root.on("internal/listener", |event| {
+        let name = event.arg::<String>(0)?.unwrap();
+        if name.as_str() == "blocked" {
+            Ok(Some(Value::new(()))) // take over: cancel the registration
+        } else {
+            Ok(None)
+        }
+    })?;
+
+    let fired = Arc::new(AtomicUsize::new(0));
+    let fired_in_listener = fired.clone();
+    let handle = root.on("blocked", move |_| {
+        fired_in_listener.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    })?;
+    root.emit("blocked", [])?;
+    assert_eq!(
+        fired.load(Ordering::SeqCst),
+        0,
+        "registration was cancelled"
+    );
+    handle.dispose()?; // the inert handle disposes cleanly and is idempotent
+
+    // Unintercepted names register and fire normally.
+    let allowed = Arc::new(AtomicUsize::new(0));
+    let allowed_in_listener = allowed.clone();
+    root.on("allowed", move |_| {
+        allowed_in_listener.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    })?;
+    root.emit("allowed", [])?;
+    assert_eq!(allowed.load(Ordering::SeqCst), 1);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Ports the five upstream Cordis 4.x interception points — the extension hooks used by HMR and config injection — into the core crate, with Rust-native semantics. Verified against the vendored cordis 4.x source in `deepseek-ai/deepseek-harness` (`vendor/cordis`).

| Event | Mode | Hook point | Semantics |
| --- | --- | --- | --- |
| `internal/get` | waterfall | `ReflectService::read` (strict reads) | innermost resolves the service; listeners wrap or replace the result. Accessor and relaxed reads bypass it (upstream proxy parity) |
| `internal/set` | waterfall | `ReflectService::set_value` (service writes) | innermost performs the write; listeners observe or veto by skipping `call_next()` |
| `internal/config` | waterfall | `Fiber::resolve_config` (activation + active-path update) | the effective config is the waterfall's result; a listener error fails activation → `Failed` |
| `internal/update` | waterfall | `Fiber::waterfall_update` (active-path update) | wraps the restart; skipping `call_next()` vetoes it (the config is stored either way) |
| `internal/listener` | bail | `EventsService::register_callback` | a bail value cancels the registration; the caller receives an inert `EffectHandle` |

## Supporting changes

- **`events.rs`** — new target-aware `bail_from`, `waterfall_from`, `waterfall_async_from` (mirroring the existing `emit_from`) so intercepts dispatch with the operating context as their target and context filters apply.
- **`fiber.rs`** — config resolution on activation and on active-path updates runs through `internal/config` exactly once (the validated-config stash is keyed on the resolved config, avoiding the upstream double-resolution quirk); `internal/update` wraps the scheduled restart.
- **`effect.rs`** — `EffectHandle::inert()` (crate-private) for intercepted registrations.
- **Docs** — crate-level intercept section in `lib.rs`; README + README.zh-CN status tables updated (previously marked "not ported").

## Testing

New `crates/cordis/tests/intercepts.rs` (9 tests) covering rewrite/observe/veto/error-propagation/target/accessor-bypass for all five events. All CI-equivalent gates pass on the commit:

- `cargo +1.85 check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (33 suites, 0 failures)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- README doctests (EN + zh-CN), 9/9 each
- `cargo fmt --all -- --check`

## Notes

- Arguments are immutable `Value`s — interception means wrapping or vetoing, never in-place mutation.
- `internal/get` approximates upstream's "no runtime → bypass" gate with the strict/relaxed read split; documented in the code.
- The gating race (a listener registering between the `listener_count` check and dispatch) matches the pre-existing `internal/dispatch` pattern.